### PR TITLE
Update travis to use recent Ubuntu, CUDA and Cmake from kitware's APT…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,29 @@
 # Requires sudo for CUDA install
-dist: trusty
 sudo: required
 
 # CPP language
 language: cpp
 
-# Compiler matrix for recent GCC versions
+# Compiler, bionic should ship with recent enough GCC. 
+compiler:
+  - gcc
+
+# Compiler matrix for CUDA version(s)
+# see https://github.com/jeremad/cuda-travis/blob/master/.travis.yml
 matrix:
   include:
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
-      env: GCC_VERSION=g++-5
+    # - name: CUDA 9.2
+    #   env:
+    #   - CUDA_LONG=9.2.148-1
+    #   - CUDA_SHORT=9.2
+    #   - UBUNTU_VERSION=ubuntu1604
+    #   dist: xenial
+    - name: CUDA 10.1
+      env:
+      - CUDA_LONG=10.1.105-1
+      - CUDA_SHORT=10.1
+      - UBUNTU_VERSION=ubuntu1804
+      dist: bionic
 
 # Install CUDA
 install: 
@@ -24,7 +32,10 @@ install:
  
 # Add nvcc to path
 before_script: 
- - "export PATH=/usr/local/cmake/bin/:/usr/local/cuda/bin:$PATH"
+  - PATH=~/.local/bin:${PATH}
+  - CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
+  - LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
+  - PATH=${CUDA_HOME}/bin:${PATH}
 
 # Build steps
 script: "mkdir build && cd build && cmake .. -DBUILD_TESTS=ON && make"

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -5,39 +5,40 @@
 # Usfull for debugging
 set -ev
 
+# Get some variables
+UBUNTU_CODENAME=$(lsb_release -c | cut -f2)
+
 # Update
 apt-get -y update
 
-# Install Boost
-apt-get install libboost-dev
+# Install apt dependencies
+apt-get install apt-transport-https ca-certificates gnupg software-properties-common wget libboost-dev python3-pip
 
-# Install redent CMAKE
-CMAKE_SH=https://cmake.org/files/v3.12/cmake-3.12.2-Linux-x86_64.sh
-wget -O cmake.sh $CMAKE_SH
-sh cmake.sh --skip-license --exclude-subdir --prefix=/usr/local/cmake/
-export PATH="/usr/local/cmake/bin/:$PATH"
+# Install recent CMAKE via kitware APT repo
+wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
+sudo apt-add-repository "deb https://apt.kitware.com/ubuntu/ ${UBUNTU_CODENAME} main"
+sudo apt update -qq 
+sudo apt install -y cmake
 
-cmake --version
-which cmake
 
-# Install CUDA (see caffe example https://github.com/BVLC/caffe/blob/master/scripts/travis/install-deps.sh)
-CUDA_REPO_PKG=cuda-repo-ubuntu1404_8.0.44-1_amd64.deb
-#CUDA_REPO_PKG=cuda-repo-ubuntu1604_9.1.85-1_amd64.deb
-wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1404/x86_64/$CUDA_REPO_PKG
-#wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/$CUDA_REPO_PKG
-dpkg -i $CUDA_REPO_PKG
-rm $CUDA_REPO_PKG
+# Install CUDA (see https://github.com/jeremad/cuda-travis/blob/master/.travis.yml)
+CUDA_REPO_PKG=cuda-repo-${UBUNTU_VERSION}_${CUDA_LONG}_amd64.deb
+CUDA_PACKAGE_VERSION=${CUDA_SHORT/./-}
 
-# update package lists
-apt-get -y update
+# Download and install CUDA repo installer
+wget http://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/x86_64/${CUDA_REPO_PKG}
+dpkg -i ${CUDA_REPO_PKG}
+rm ${CUDA_REPO_PKG}
 
-# install packages
-CUDA_PKG_VERSION="8-0"
-CUDA_VERSION="8.0"
-apt-get install -y --no-install-recommends \
-  cuda-core-$CUDA_PKG_VERSION \
-  cuda-cudart-dev-$CUDA_PKG_VERSION
-#apt-get --yes --force-yes install cuda
-  
-# manually create CUDA symlink
-ln -s /usr/local/cuda-$CUDA_VERSION /usr/local/cuda
+# Add nvidia public key
+wget https://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/x86_64/7fa2af80.pub
+apt-key add 7fa2af80.pub
+
+# Update package lists
+apt-get -qq update
+
+# Install CUDA packages
+apt-get install -y --no-install-recommends cuda-core-${CUDA_PACKAGE_VERSION} cuda-cudart-dev-${CUDA_PACKAGE_VERSION}
+
+# Install cpplint (optional, not currently used at CI time)
+# pip3 install cpplint


### PR DESCRIPTION
… source

This also enables easy switching to building using multiple CUDA versions if required.

cpplint installation is disabled, but just needs uncommenting.