### PR TITLE
Fixes compilation of boost test on VS2015.

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -139,7 +139,12 @@ set(CMAKE_CUDA_FLAGS_RELEASE "${CMAKE_CUDA_FLAGS_RELEASE} -lineinfo")
 set(CMAKE_CUDA_FLAGS_PROFILE "${CMAKE_CUDA_FLAGS_PROFILE} -lineinfo -DPROFILE -D_PROFILE")
 
 # Set high level of warnings, specific to the host compiler.
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --Wreorder --Werror reorder,cross-execution-space-call -Xptxas=\"-Werror\"  -Xnvlink=\"-Werror\"")
+if(WARNINGS_AS_ERRORS)
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --Wreorder --Werror reorder,cross-execution-space-call -Xptxas=\"-Werror\"  -Xnvlink=\"-Werror\"")
+else()
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --Wreorder")
+endif()
+# Compiler version specific flags
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # Only set W4 for MSVC, WAll is more like Wall, Wextra and Wpedantic
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler /W4")

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -255,7 +255,7 @@ function(add_flamegpu_executable NAME SRC FLAMEGPU_ROOT PROJECT_ROOT IS_EXAMPLE)
     endif()
 
     # Flag the new linter target and the files to be linted.
-    new_linter_target(${NAME} ${SRC})
+    new_linter_target(${NAME} "${SRC}")
     
     # Setup Visual Studio (and eclipse) filters
     #src/.h

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -138,13 +138,13 @@ set(CMAKE_CUDA_FLAGS_RELEASE "${CMAKE_CUDA_FLAGS_RELEASE} -lineinfo")
 # profile specific CUDA flags.
 set(CMAKE_CUDA_FLAGS_PROFILE "${CMAKE_CUDA_FLAGS_PROFILE} -lineinfo -DPROFILE -D_PROFILE")
 
-# Set high level of warnings, specific to the host compiler.
+# Set high level of warnings
 if(WARNINGS_AS_ERRORS)
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --Wreorder --Werror reorder,cross-execution-space-call -Xptxas=\"-Werror\"  -Xnvlink=\"-Werror\"")
 else()
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --Wreorder")
 endif()
-# Compiler version specific flags
+# Compiler version specific high warnings
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # Only set W4 for MSVC, WAll is more like Wall, Wextra and Wpedantic
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler /W4")
@@ -196,11 +196,21 @@ if(CPPLINT)
         # Don't lint external files
         list(FILTER SRC EXCLUDE REGEX "^${FLAMEGPU_ROOT}/externals/.*")
         # Add custom target for linting this
-        add_custom_target(
-            "lint_${NAME}"
-            COMMAND ${CPPLINT}
-            ${SRC}
-        )
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+            # Output in visual studio format
+            add_custom_target(
+                "lint_${NAME}"
+                COMMAND ${CPPLINT} "--output" "vs7"
+                ${SRC}
+            )
+        else()
+            # Output in default format
+            add_custom_target(
+                "lint_${NAME}"
+                COMMAND ${CPPLINT}
+                ${SRC}
+            )
+        endif()
         set_target_properties("lint_${NAME}" PROPERTIES EXCLUDE_FROM_ALL TRUE)
         # Add the custom target as a dependency of the global lint target
         if(TARGET all_lint)


### PR DESCRIPTION
There will be a compile warning, but it won't be promoted to an error.
When I added the advanced nvcc warning options, I left them always enabled. Hence the stl reorder issue was being promoted to error, even when WARNING_AS_ERROR  was disabled.

-----

Also added a fix for visual studio cpplint to this PR