### PR TITLE
Suggested fix for segfault in simple_example.

### DIFF
--- a/examples/mas/src/main.cu
+++ b/examples/mas/src/main.cu
@@ -223,7 +223,7 @@ int main(int argc, char* argv[]) {
     cuda_model.setInitialPopulationData(population1);
     cuda_model.setInitialPopulationData(population2);
 
-    cuda_model.setMessageData(location1_message);
+    // cuda_model.setMessageData(location1_message);
 
     // cuda_model.addSimulation(simulation);
 

--- a/examples/mas/src/main.cu
+++ b/examples/mas/src/main.cu
@@ -223,8 +223,6 @@ int main(int argc, char* argv[]) {
     cuda_model.setInitialPopulationData(population1);
     cuda_model.setInitialPopulationData(population2);
 
-    // cuda_model.setMessageData(location1_message);
-
     // cuda_model.addSimulation(simulation);
 
     cuda_model.simulate(simulation);

--- a/include/flamegpu/gpu/CUDAAgentModel.h
+++ b/include/flamegpu/gpu/CUDAAgentModel.h
@@ -35,7 +35,7 @@ public:
     virtual ~CUDAAgentModel();
 
     void setInitialPopulationData(AgentPopulation& population);
-	void setMessageData(MessageDescription& message);
+	// void setMessageData(MessageDescription& message); // redundant? Messages are allocated implicity
 
     void setPopulationData(AgentPopulation& population);
 

--- a/include/flamegpu/gpu/CUDAAgentModel.h
+++ b/include/flamegpu/gpu/CUDAAgentModel.h
@@ -35,7 +35,6 @@ public:
     virtual ~CUDAAgentModel();
 
     void setInitialPopulationData(AgentPopulation& population);
-	// void setMessageData(MessageDescription& message); // redundant? Messages are allocated implicity
 
     void setPopulationData(AgentPopulation& population);
 

--- a/include/flamegpu/gpu/CUDAMessage.h
+++ b/include/flamegpu/gpu/CUDAMessage.h
@@ -30,7 +30,6 @@ public:
     virtual ~CUDAMessage(void);
 
     const MessageDescription& getMessageDescription() const;
-	void setInitialMessageList();
     unsigned int getMaximumListSize() const;
 
     /**
@@ -49,6 +48,10 @@ public:
     void unmapRuntimeVariables(const AgentFunctionDescription& func) const;
 
 protected:
+    /**
+     * @brief Allocates the messagelist memory, called by constructor
+     */
+    void setInitialMessageList();
 
 	/** @brief	Zero all message variable data. */
 	void zeroAllMessageData();

--- a/src/flamegpu/gpu/CUDAAgentModel.cu
+++ b/src/flamegpu/gpu/CUDAAgentModel.cu
@@ -88,26 +88,6 @@ void CUDAAgentModel::setInitialPopulationData(AgentPopulation& population)
 }
 
 /**
-* @brief Sets the initial message data
-* @param MessageDescription object
-* @return none
-*/
-/*void CUDAAgentModel::setMessageData(MessageDescription& message)
-{
-	CUDAMessageMap::iterator it;
-	it = message_map.find(message.getName());
-
-	if (it == message_map.end())
-	{
-		throw InvalidCudaAgent();
-	}
-
-	// create agent state lists
-	it->second->setInitialMessageList();
-
-}*/
-
-/**
 * @brief Sets the population data
 * @param AgentPopulation object
 * @return none

--- a/src/flamegpu/gpu/CUDAAgentModel.cu
+++ b/src/flamegpu/gpu/CUDAAgentModel.cu
@@ -92,7 +92,7 @@ void CUDAAgentModel::setInitialPopulationData(AgentPopulation& population)
 * @param MessageDescription object
 * @return none
 */
-void CUDAAgentModel::setMessageData(MessageDescription& message)
+/*void CUDAAgentModel::setMessageData(MessageDescription& message)
 {
 	CUDAMessageMap::iterator it;
 	it = message_map.find(message.getName());
@@ -102,10 +102,10 @@ void CUDAAgentModel::setMessageData(MessageDescription& message)
 		throw InvalidCudaAgent();
 	}
 
-	/*! create agent state lists */
+	// create agent state lists
 	it->second->setInitialMessageList();
 
-}
+}*/
 
 /**
 * @brief Sets the population data

--- a/src/flamegpu/gpu/CUDAMessage.cu
+++ b/src/flamegpu/gpu/CUDAMessage.cu
@@ -28,7 +28,7 @@
 */
 CUDAMessage::CUDAMessage(const MessageDescription& description) : message_description(description), max_list_size(0)
 {
-
+    setInitialMessageList();
 }
 
 
@@ -111,6 +111,9 @@ void CUDAMessage::zeroAllMessageData()
 */
 void CUDAMessage::mapRuntimeVariables(const AgentFunctionDescription& func) const
 {
+    //check that the message list has been allocated
+    if (!message_list)
+        throw InvalidMessageData("Error: Initial message has not been allocated");
 
     const std::string message_name = message_description.getName();
 


### PR DESCRIPTION
Closes #113 

Implicitly calls `CUDAMessage::setInitialMessageList()` at construction of `CUDAMessage`.

Messages are not filled on the host, so initialisation should be implicit. Only concern is whether the list size is allocated to match agent size, I didn't check that far.

Comments out `CUDAAgentModel::setMessageData(MessageDescription&)` as it is now redundant.

It should be removed before this is merged (hence draft PR).

Also adds a check/exception to the offending method incase pointer is empty.

Now executes to exit without segfault (on Windows).