### PR TITLE
Mark CUDA includes as system includes to prioritize our thrust

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -252,6 +252,8 @@ function(add_flamegpu_executable NAME SRC FLAMEGPU_ROOT PROJECT_ROOT IS_EXAMPLE)
 
     # Add include directories
     target_include_directories(${NAME} SYSTEM PRIVATE ${FLAMEGPU_ROOT}/externals)
+    target_include_directories(${NAME} SYSTEM PRIVATE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+    
     target_include_directories(${NAME} PRIVATE ${FLAMEGPU_ROOT}/include)
 
     # Enable RDC for the target
@@ -304,6 +306,7 @@ function(add_flamegpu_library NAME SRC FLAMEGPU_ROOT)
 
     # Define include dirs
     target_include_directories(${NAME}  SYSTEM PRIVATE ${FLAMEGPU_ROOT}/externals)
+    target_include_directories(${NAME} SYSTEM PRIVATE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
     target_include_directories(${NAME}  PRIVATE ${FLAMEGPU_ROOT}/include)
     target_include_directories(${NAME}  PRIVATE ${FLAMEGPU_ROOT}/src) #private headers
 

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -43,6 +43,3 @@ wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | 
 sudo apt-add-repository "deb https://apt.kitware.com/ubuntu/ ${UBUNTU_CODENAME} main"
 sudo apt update -qq && sudo apt install -y cmake
 set -e
-
-# Horrible thrust fix. This needs addressing propperly at cmake time? See issue on github. @todo
-rm -rf /usr/local/cuda-${CUDA_SHORT}/targets/x86_64-linux/include/thrust


### PR DESCRIPTION
We don't need to ship our own thrust from (probably) the next CUDA release (> 10.2)