### PR TITLE
Resolve segfault with vsnprintf

### DIFF
--- a/include/flamegpu/exception/FGPUException.h
+++ b/include/flamegpu/exception/FGPUException.h
@@ -56,6 +56,7 @@ class name : public FGPUException {\
         va_list argp;\
         va_start(argp, format);\
         err_message += parseArgs(format, argp);\
+        va_end(argp);\
     }\
 }
 


### PR DESCRIPTION
vsnprintf in gcc appears to modify the va_list, so it is invalid on second use, so va_copy (and va_end) are used

Closes #149 