### PR TITLE
Valgrind suppressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ build/
 *.tlog
 *.cache
 
+# Valgrind log files (for syntax-highlight enabled editors such as vscode with plugin)
+*.valgrind
+
 # Compiled Object files
 *.slo
 *.lo

--- a/src/flamegpu/gpu/CUDAAgentModel.cu
+++ b/src/flamegpu/gpu/CUDAAgentModel.cu
@@ -282,7 +282,7 @@ bool CUDAAgentModel::step(const Simulation& simulation) {
     // stream deletion
     for (int j = 0; j < nStreams; ++j)
         gpuErrchk(cudaStreamDestroy(stream[j]));
-    free(stream);
+    delete[] stream;
 
 
     // Execute step functions

--- a/tools/valgrind-cuda-suppression.supp
+++ b/tools/valgrind-cuda-suppression.supp
@@ -1,0 +1,38 @@
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   ...
+   obj:*libcuda.so.*
+   fun:cuInit
+   fun:_ZN6cudart11globalState18loadDriverInternalEv
+   fun:_ZN6cudart24__loadDriverInternalUtilEv
+   fun:__pthread_once_slow
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Value8
+   ...
+   obj:*libcuda.so.*
+   fun:cuInit
+   fun:_ZN6cudart11globalState18loadDriverInternalEv
+   fun:_ZN6cudart24__loadDriverInternalUtilEv
+   fun:__pthread_once_slow
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   ...
+   obj:*libcuda.so*
+   ...
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   obj:*libcuda.so.*
+}
+


### PR DESCRIPTION
This PR adds a file to suppress CUDA related warnigns from suppressions. 

Usage, from `build` for a debug compiled code would be:

```
valgrind --suppressions=../tools/valgrind-cuda-suppression.supp --error-exitcode=1 --leak-check=full --gen-suppressions=no ./bin/linux-x64/Debug/tests
```

This will return a non-zero error code, so could be enabled for GPU-enabled CI to cause a build failure if memory leaks are detected.

Also replaces a `free()` with a `delete[]`, as highlighted by valgrind. 