### PR TITLE
Fix cuda memory leaks

### DIFF
--- a/include/flamegpu/runtime/utility/RandomManager.cuh
+++ b/include/flamegpu/runtime/utility/RandomManager.cuh
@@ -26,7 +26,6 @@ class RandomManager {
     /**
      * Handles seeding of random generation
      */
-    // friend class Simulation;  // bool CUDAAgentModel::step(const Simulation&)
     friend int Simulation::checkArgs(int, const char**, std::string &);
     /**
      * Calls resize() during simulation execution to resize device random array
@@ -136,6 +135,19 @@ class RandomManager {
      * Creates the singleton and calls reseed() with the return value from seedFromTime()
      */
     RandomManager();
+    /**
+     * Logs how many CUDAAgentModel objects exist, if this reaches 0, free is called
+     */
+    unsigned int simulationInstances = 0;
+    /**
+     * Increases internal counter of CUDAAgentModel instances
+     */
+    void increaseSimCounter();
+    /**
+    * Decreases internal counter of CUDAAgentModel instances
+    * If this reaches 0, free() is called
+    */
+    void decreaseSimCounter();
 
  protected:
      /**

--- a/src/flamegpu/gpu/CUDAAgentModel.cu
+++ b/src/flamegpu/gpu/CUDAAgentModel.cu
@@ -32,6 +32,7 @@ CUDAAgentModel::CUDAAgentModel(const ModelDescription& description)
     message_map(),
     host_api(*this),
     rng(RandomManager::getInstance()) {  // , function_map() {
+    rng.increaseSimCounter();
     // create a reference to curve to ensure that it is initialised. This is a singleton class so will only be done once regardless of the number of CUDAgentModels.
 
     // populate the CUDA agent map
@@ -68,6 +69,7 @@ CUDAAgentModel::CUDAAgentModel(const ModelDescription& description)
  * @brief Destroys the CUDAAgentModel object
  */
 CUDAAgentModel::~CUDAAgentModel() {
+    rng.decreaseSimCounter();
     // unique pointers cleanup by automatically
 }
 

--- a/src/flamegpu/gpu/CUDAAgentStateList.cu
+++ b/src/flamegpu/gpu/CUDAAgentStateList.cu
@@ -36,6 +36,7 @@ CUDAAgentStateList::CUDAAgentStateList(CUDAAgent& cuda_agent) : agent(cuda_agent
  * @brief Destroys the CUDAAgentStateList object
  */
 CUDAAgentStateList::~CUDAAgentStateList() {
+    cleanupAllocatedData();
 }
 
 void CUDAAgentStateList::cleanupAllocatedData() {

--- a/src/flamegpu/runtime/agent_function.cu
+++ b/src/flamegpu/runtime/agent_function.cu
@@ -39,4 +39,6 @@ __global__ void agent_function_wrapper(
         }
     }
     // do something with the return value to set a flag for deletion
+
+    delete api;
 }

--- a/src/flamegpu/runtime/utility/RandomManager.cu
+++ b/src/flamegpu/runtime/utility/RandomManager.cu
@@ -190,3 +190,12 @@ RandomManager::size_type RandomManager::size() {
 uint64_t RandomManager::seed() {
     return mSeed;
 }
+
+void RandomManager::increaseSimCounter() {
+    simulationInstances++;
+}
+void RandomManager::decreaseSimCounter() {
+    simulationInstances--;
+    if (simulationInstances == 0)
+        free();
+}


### PR DESCRIPTION
Every agent function launch was leaking ~44 bytes, via new FLAMEGPU_AGENT_API

When CUDAAgentStateList is destroyed, it's internal memory was not being freed.

RandomManager was not guarnteed to free it's device memory before exit, now uses counter of live CUDAAgentModel's