### PR TITLE
Improve travis build time.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ Doxyfile.docs
 docs/
 bin/
 obj/
-build/
+build*/
 
 # Editor configuration files/directories
 .vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,4 @@ before_script:
   - PATH=${CUDA_HOME}/bin:${PATH}
 
 # Build steps
-script: "mkdir build && cd build && cmake .. -DBUILD_TESTS=ON -DWARNINGS_AS_ERRORS=ON && make all docs all_lint"
+script: "mkdir build && cd build && cmake .. -DBUILD_TESTS=ON -DWARNINGS_AS_ERRORS=ON && make -j`nproc` all_lint all docs "

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -72,7 +72,7 @@ if(SMS_COUNT EQUAL 0)
     if(CMAKE_CUDA_COMPILER_VERSION GREATER_EQUAL 5.0 )
         # list(APPEND SMS "30") # CUDA >= 5.0  # Skip kepler 1
         list(APPEND SMS "35") # CUDA >= 5.0 
-        list(APPEND SMS "37") # CUDA >= 5.0 
+        # list(APPEND SMS "37") # CUDA >= 5.0 # Skip K80s
     endif()
     # If the CUDA version is >= than 5.0, build for Maxwell V1 
     if(CMAKE_CUDA_COMPILER_VERSION GREATER_EQUAL 6.0 )


### PR DESCRIPTION
+ No longer builds for SM_37 by default
+ Parallel build using the number of cores via nproc
+ Ignores any directory beginning with build in the root.
+ Lints before compiling.