### PR TITLE
Defers CUDA initialisation until device selection has been made

### DIFF
--- a/examples/circles_bruteforce/src/main.cu
+++ b/examples/circles_bruteforce/src/main.cu
@@ -78,6 +78,7 @@ FLAMEGPU_STEP_FUNCTION(Validation) {
 void export_data(std::shared_ptr<AgentPopulation> pop, const char *filename);
 int main(int argc, const char ** argv) {
     NVTX_RANGE("main");
+    NVTX_PUSH("ModelDescription");
     ModelDescription model("Circles_BruteForce_example");
 
     {   // Location message
@@ -124,10 +125,14 @@ int main(int argc, const char ** argv) {
         layer.addAgentFunction(move);
     }
 
+    NVTX_POP();
+
     /**
      * Create Model Runner
      */
+    NVTX_PUSH("CUDAAgentModel creation");
     CUDAAgentModel cuda_model(model);
+    NVTX_POP();
 
     /**
      * Initialisation
@@ -175,7 +180,7 @@ int main(int argc, const char ** argv) {
     StateWriter *write__ = WriterFactory::createWriter(pops, cuda_model.getStepCounter(), "end.xml");
     write__->writeStates();
     // export_data(a, "test.bin");
-    getchar();
+    // getchar();
     return 0;
 }
 

--- a/examples/circles_spatial3D/src/main.cu
+++ b/examples/circles_spatial3D/src/main.cu
@@ -159,7 +159,7 @@ int main(int argc, const char ** argv) {
     }
 
     cuda_model.simulate();
-    getchar();
+    // getchar();
 
     /**
      * Export Pop
@@ -173,7 +173,7 @@ int main(int argc, const char ** argv) {
     StateWriter *write__ = WriterFactory::createWriter(pops, cuda_model.getStepCounter(), "end.xml");
     write__->writeStates();
     // export_data(a, "test.bin");
-    getchar();
+    // getchar();
     return 0;
 }
 

--- a/include/flamegpu/gpu/CUDAAgent.h
+++ b/include/flamegpu/gpu/CUDAAgent.h
@@ -85,8 +85,6 @@ class CUDAAgent : public AgentInterface {
     CUDAStateMap state_map;
 
     unsigned int max_list_size;  // The maximum length of the agent variable arrays based on the maximum population size passed to setPopulationData
-
-    Curve &curve;
 };
 
 #endif  // INCLUDE_FLAMEGPU_GPU_CUDAAGENT_H_

--- a/include/flamegpu/gpu/CUDAAgentModel.h
+++ b/include/flamegpu/gpu/CUDAAgentModel.h
@@ -134,11 +134,6 @@ class CUDAAgentModel : public Simulation {
      */
     CUDAAgentMap agent_map;
     /**
-     * Curve instance used for variable mapping
-     * @todo Is this necessary? CUDAAgent/CUDAMessage have their own copy
-     */
-    Curve &curve;
-    /**
      * Internal model config
      */
     Config config;
@@ -147,17 +142,42 @@ class CUDAAgentModel : public Simulation {
      */
     CUDAMessageMap message_map;
     /**
-    * Resizes device random array during step()
-    */
-    RandomManager &rng;
-    /**
-     * Held here for tracking when to release cuda memory
-     */
-    CUDAScatter &scatter;
-    /**
      * Streams created within this cuda context for executing functions within layers in parallel
      */
     std::vector<cudaStream_t> streams;
+
+    /**
+     * Struct containing references to the various singletons which may include CUDA code, and therefore can only be initialsed after the deferred arg parsing is completed.
+     */
+    struct Singletons {
+      /**
+       * Curve instance used for variable mapping
+       * @todo Is this necessary? CUDAAgent/CUDAMessage have their own copy
+       */
+      Curve &curve;
+      /**
+       * Resizes device random array during step()
+       */
+      RandomManager &rng;
+      /**
+       * Held here for tracking when to release cuda memory
+       */
+      CUDAScatter &scatter;
+      /**
+       * Held here for tracking when to release cuda memory
+       */
+      EnvironmentManager &environment;
+      Singletons(Curve &curve, RandomManager &rng, CUDAScatter &scatter, EnvironmentManager &environment) : curve(curve), rng(rng), scatter(scatter), environment(environment) {}
+    } * singletons;
+    /**
+     * Flag indicating that the model has been initialsed
+     */
+    bool singletonsInitialised;
+
+    /**
+     * Initialise the instances singletons.
+     */
+    void initialiseSingletons();
 };
 
 #endif  // INCLUDE_FLAMEGPU_GPU_CUDAAGENTMODEL_H_

--- a/include/flamegpu/gpu/CUDAMessage.h
+++ b/include/flamegpu/gpu/CUDAMessage.h
@@ -123,10 +123,6 @@ class CUDAMessage {
      */
     unsigned int max_list_size;
     /**
-     * Reference to curve instance used internally
-     */
-    Curve &curve;
-    /**
      * When this flag is set to True before message output, 
      * message output truncates the messagelist rather than appending
      * 

--- a/include/flamegpu/runtime/cuRVE/curve.h
+++ b/include/flamegpu/runtime/cuRVE/curve.h
@@ -255,6 +255,15 @@ class Curve {
     int    h_states[MAX_VARIABLES];               // Host array of the states of registered variables
     size_t h_sizes[MAX_VARIABLES];                // Host array of the sizes of registered variable types (Note: RTTI not supported in CUDA so this is the best we can do for now)
     unsigned int h_lengths[MAX_VARIABLES];        // Host array of the length of registered variables (i.e: vector length)
+    bool deviceInitialised;                       // Flag indicating that curve has/hasn't been initialised yet on a device.
+
+    /**
+     * Initialises cuRVE on the currently active device.
+     * 
+     * @note - not yet aware if the device has been reset.
+     * @todo - Need to add a device-side check for initialisation.
+     */
+    void initialiseDevice();
 
  protected:
     /** @brief    Default constructor.

--- a/include/flamegpu/runtime/messaging/BruteForce.h
+++ b/include/flamegpu/runtime/messaging/BruteForce.h
@@ -12,6 +12,7 @@
 #include "flamegpu/runtime/cuRVE/curve.h"
 #include "flamegpu/gpu/CUDAErrorChecking.h"
 #include "flamegpu/gpu/CUDAScanCompaction.h"
+#include "flamegpu/util/nvtx.h"
 
 
 struct ModelData;
@@ -239,16 +240,27 @@ class MsgBruteForce {
          */
         explicit CUDAModelHandler(CUDAMessage &a)
             : MsgSpecialisationHandler()
-            , sim_message(a) {
-             gpuErrchk(cudaMalloc(&d_metadata, sizeof(MetaData)));
-        }
-        ~CUDAModelHandler() {
-            gpuErrchk(cudaFree(d_metadata));
-        }
+            , d_metadata(nullptr)
+            , sim_message(a) { }
+
+        /** 
+         * Destructor.
+         * Should free any local host memory (device memory cannot be freed in destructors)
+         */
+        ~CUDAModelHandler() { }
         /**
          * Updates the length of the messagelist stored on device
          */
         void buildIndex() override;
+        /**
+         * Allocates memory for the constructed index.
+         * The memory allocation is checked by build index.
+         */
+        void allocateMetaDataDevicePtr() override;
+        /**
+         * Releases memory for the constructed index.
+         */
+        void freeMetaDataDevicePtr() override;
         /**
          * Returns a pointer to the metadata struct, this is required for reading the message data
          */

--- a/include/flamegpu/runtime/messaging/None.h
+++ b/include/flamegpu/runtime/messaging/None.h
@@ -11,6 +11,7 @@ class CUDAMessage;
  * Interface for message specialisation
  * A derived implementation of this is required for each combination of message type (e.g. MsgBruteForce) and simulation type (e.g. CUDAAgentModel)
  * @note It is recommended that derrived classes require an object that provides access to the model specialisation's representation of messages (e.g. CUDAMessage)
+ * @note: this is slightly CUDA aware. Future abstraction DevicePtr should be in a CUDANone message or similar.
  */
 class MsgSpecialisationHandler {
  public:
@@ -25,8 +26,18 @@ class MsgSpecialisationHandler {
      */
     virtual void buildIndex() { }
     /**
+     * Allocates memory for the constructed index.
+     * The memory allocation is checked by build index.
+     */
+    virtual void allocateMetaDataDevicePtr() { }
+    /**
+     * Releases memory for the constructed index.
+     */
+    virtual void freeMetaDataDevicePtr() { }
+    /**
      * Returns a pointer to metadata for message access during agent functions
      * (For CUDAAgentModel this is a device pointer)
+     * @note: this is slightly CUDA aware. Future abstraction this should be base CUDANone or similar.
      */
     virtual const void *getMetaDataDevicePtr() const { return nullptr; }
 };

--- a/include/flamegpu/runtime/messaging/Spatial2D.h
+++ b/include/flamegpu/runtime/messaging/Spatial2D.h
@@ -327,6 +327,15 @@ class MsgSpatial2D {
          */
         void buildIndex() override;
         /**
+         * Allocates memory for the constructed index.
+         * The memory allocation is checked by build index.
+         */
+        void allocateMetaDataDevicePtr() override;
+        /**
+         * Releases memory for the constructed index.
+         */
+        void freeMetaDataDevicePtr() override;
+        /**
          * Returns a pointer to the metadata struct, this is required for reading the message data
          */
         const void *getMetaDataDevicePtr() const override { return d_data; }

--- a/include/flamegpu/runtime/messaging/Spatial3D.h
+++ b/include/flamegpu/runtime/messaging/Spatial3D.h
@@ -9,7 +9,7 @@
 #include "flamegpu/runtime/messaging/BruteForce.h"
 #include "flamegpu/runtime/messaging/Spatial2D.h"
 #include "flamegpu/runtime/cuRVE/curve.h"
-
+#include "flamegpu/util/nvtx.h"
 
 /**
  * 3D Continuous spatial messaging functionality
@@ -331,47 +331,42 @@ class MsgSpatial3D {
         explicit CUDAModelHandler(CUDAMessage &a)
          : MsgSpecialisationHandler()
          , sim_message(a) {
-             const Data &d = (const Data &)a.getMessageDescription();
-             hd_data.radius = d.radius;
-             hd_data.min[0] = d.minX;
-             hd_data.min[1] = d.minY;
-             hd_data.min[2] = d.minZ;
-             hd_data.max[0] = d.maxX;
-             hd_data.max[1] = d.maxY;
-             hd_data.max[2] = d.maxZ;
-             binCount = 1;
-             for (unsigned int axis = 0; axis < 3; ++axis) {
-                 hd_data.environmentWidth[axis] = hd_data.max[axis] - hd_data.min[axis];
-                 hd_data.gridDim[axis] = static_cast<unsigned int>(ceil(hd_data.environmentWidth[axis] / hd_data.radius));
-                 binCount *= hd_data.gridDim[axis];
-             }
-             gpuErrchk(cudaMalloc(&d_histogram, (binCount + 1) * sizeof(unsigned int)));
-             gpuErrchk(cudaMalloc(&hd_data.PBM, (binCount + 1) * sizeof(unsigned int)));
-             gpuErrchk(cudaMalloc(&d_data, sizeof(MetaData)));
-             gpuErrchk(cudaMemcpy(d_data, &hd_data, sizeof(MetaData), cudaMemcpyHostToDevice));
-             resizeCubTemp();
+            NVTX_RANGE("Spatial3D::CUDAModelHandler");
+            const Data &d = (const Data &)a.getMessageDescription();
+            hd_data.radius = d.radius;
+            hd_data.min[0] = d.minX;
+            hd_data.min[1] = d.minY;
+            hd_data.min[2] = d.minZ;
+            hd_data.max[0] = d.maxX;
+            hd_data.max[1] = d.maxY;
+            hd_data.max[2] = d.maxZ;
+            binCount = 1;
+            for (unsigned int axis = 0; axis < 3; ++axis) {
+                hd_data.environmentWidth[axis] = hd_data.max[axis] - hd_data.min[axis];
+                hd_data.gridDim[axis] = static_cast<unsigned int>(ceil(hd_data.environmentWidth[axis] / hd_data.radius));
+                binCount *= hd_data.gridDim[axis];
+            }
+            // Device allocation occurs in allocateMetaDataDevicePtr rather than the constructor.
         }
         /**
          * Destructor
          * Frees all alocated memory
          */
-        ~CUDAModelHandler() override {
-            d_CUB_temp_storage_bytes = 0;
-            gpuErrchk(cudaFree(d_CUB_temp_storage));
-            gpuErrchk(cudaFree(d_histogram));
-            gpuErrchk(cudaFree(hd_data.PBM));
-            gpuErrchk(cudaFree(d_data));
-            if (d_keys) {
-                d_keys_vals_storage_bytes = 0;
-                gpuErrchk(cudaFree(d_keys));
-                gpuErrchk(cudaFree(d_vals));
-            }
-        }
+        ~CUDAModelHandler() override { }
         /**
          * Reconstructs the partition boundary matrix
          * This should be called before reading newly output messages
          */
         void buildIndex() override;
+        /**
+         * Allocates memory for the constructed index.
+         * The memory allocation is checked by build index.
+         */
+        void allocateMetaDataDevicePtr() override;
+        /**
+         * Releases memory for the constructed index.
+         */
+        void freeMetaDataDevicePtr() override;
         /**
          * Returns a pointer to the metadata struct, this is required for reading the message data
          */

--- a/include/flamegpu/runtime/utility/EnvironmentManager.cuh
+++ b/include/flamegpu/runtime/utility/EnvironmentManager.cuh
@@ -50,10 +50,6 @@ class EnvironmentManager {
                 (std::hash<std::string>()(k.second) << 1);
         }
     };
-    /**
-     * Create an instance of curve to ensure it's initialised
-     */
-    Curve &curve;
 
  public:
     /**
@@ -487,6 +483,15 @@ class EnvironmentManager {
      * Host copy of data related to each stored property
      */
     std::unordered_map<NamePair, EnvProp, NamePairHash> properties;
+
+    /**
+     * Flag indicating that curve has/hasn't been initialised yet on a device.
+     */
+    bool deviceInitialised;
+    /**
+     * Function to initialise device-side portions of the environment manager
+     */
+    void initialiseDevice();
     /**
      * Remainder of class is singleton pattern
      */
@@ -737,10 +742,10 @@ void EnvironmentManager::remove(const NamePair &name) {
     }
     auto i = properties.at(name);
     // Unregister in cuRVE
-    curve.setNamespaceByHash(CURVE_NAMESPACE_HASH);
+    Curve::getInstance().setNamespaceByHash(CURVE_NAMESPACE_HASH);
     Curve::VariableHash cvh = toHash(name);
-    curve.unregisterVariableByHash(cvh);
-    curve.setDefaultNamespace();
+    Curve::getInstance().unregisterVariableByHash(cvh);
+    Curve::getInstance().setDefaultNamespace();
     // Update free space
     // Cast is safe, length would need to be gigabytes, we only have 64KB constant cache
     if (i.offset + static_cast<uint32_t>(i.length) == nextFree) {

--- a/include/flamegpu/runtime/utility/RandomManager.cuh
+++ b/include/flamegpu/runtime/utility/RandomManager.cuh
@@ -123,11 +123,37 @@ class RandomManager {
      * @note - std::default_random_engine is platform (compiler) specific. GCC (7.4) defaults to a linear_congruential_engine, which returns the same sequence for seeds 0 and 1. mt19937 is the default in MSVC and generally seems more sane.
      */
     std::mt19937 host_rng;
+
+    /**
+     * Flag indicating that the device memory has been initialised, and therefore might need resetting
+     */
+    bool deviceInitialised;
     /**
      * Acts as destructor
      * @note Safe to call multiple times
      */
     void free();
+
+    /**
+     * Destroys host stuff 
+     */
+    void freeHost();
+    /**
+     * Destroys device memory / resets the curand states
+     * @note includes cuda commands so not safe from c++ destructor
+     */
+    void freeDevice();
+
+    /**
+     * Reinitialises host RNG from the current seed.
+     */
+    void reseedHost();
+
+    /**
+     * Reinitialises device RNG from the current seed.
+     * @note includes cuda commands.
+     */
+    void reseedDevice();
     /**
      * Remainder of class is singleton pattern
      */

--- a/src/flamegpu/gpu/CUDAAgent.cu
+++ b/src/flamegpu/gpu/CUDAAgent.cu
@@ -35,8 +35,7 @@
 CUDAAgent::CUDAAgent(const AgentData& description)
     : agent_description(description)
     , state_map()
-    , max_list_size(0)
-    , curve(Curve::getInstance()) { }
+    , max_list_size(0) { }
 
 /**
  * A destructor.
@@ -209,22 +208,22 @@ void CUDAAgent::mapRuntimeVariables(const AgentFunctionData& func) const {
             agent_description.name.c_str(), func.initial_state.c_str());
     }
 
-    const Curve::VariableHash agent_hash = curve.variableRuntimeHash(agent_description.name.c_str());
-    const Curve::VariableHash func_hash = curve.variableRuntimeHash(func.name.c_str());
+    const Curve::VariableHash agent_hash = Curve::getInstance().variableRuntimeHash(agent_description.name.c_str());
+    const Curve::VariableHash func_hash = Curve::getInstance().variableRuntimeHash(func.name.c_str());
     // loop through the agents variables to map each variable name using cuRVE
     for (const auto &mmp : agent_description.variables) {
         // get a device pointer for the agent variable name
         void* d_ptr = sm->second->getAgentListVariablePointer(mmp.first);
 
         // map using curve
-        const Curve::VariableHash var_hash = curve.variableRuntimeHash(mmp.first.c_str());
+        const Curve::VariableHash var_hash = Curve::getInstance().variableRuntimeHash(mmp.first.c_str());
 
         // get the agent variable size
         size_t size = mmp.second.type_size;
 
        // maximum population num
         unsigned int length = this->getMaximumListSize();
-        curve.registerVariableByHash(var_hash + agent_hash + func_hash, d_ptr, size, length);
+        Curve::getInstance().registerVariableByHash(var_hash + agent_hash + func_hash, d_ptr, size, length);
     }
 }
 
@@ -238,16 +237,16 @@ void CUDAAgent::unmapRuntimeVariables(const AgentFunctionData& func) const {
             agent_description.name.c_str(), func.initial_state.c_str());
     }
 
-    const Curve::VariableHash agent_hash = curve.variableRuntimeHash(agent_description.name.c_str());
-    const Curve::VariableHash func_hash = curve.variableRuntimeHash(func.name.c_str());
+    const Curve::VariableHash agent_hash = Curve::getInstance().variableRuntimeHash(agent_description.name.c_str());
+    const Curve::VariableHash func_hash = Curve::getInstance().variableRuntimeHash(func.name.c_str());
     // loop through the agents variables to map each variable name using cuRVE
     for (const auto &mmp : agent_description.variables) {
         // get a device pointer for the agent variable name
         // void* d_ptr = sm->second->getAgentListVariablePointer(mmp.first);
 
         // unmap using curve
-        const Curve::VariableHash var_hash = curve.variableRuntimeHash(mmp.first.c_str());
-        curve.unregisterVariableByHash(var_hash + agent_hash + func_hash);
+        const Curve::VariableHash var_hash = Curve::getInstance().variableRuntimeHash(mmp.first.c_str());
+        Curve::getInstance().unregisterVariableByHash(var_hash + agent_hash + func_hash);
     }
 }
 

--- a/src/flamegpu/runtime/flamegpu_host_api.cu
+++ b/src/flamegpu/runtime/flamegpu_host_api.cu
@@ -2,6 +2,7 @@
 #include "flamegpu/runtime/flamegpu_host_agent_api.h"
 #include "flamegpu/model/ModelDescription.h"
 #include "flamegpu/sim/Simulation.h"
+#include "flamegpu/util/nvtx.h"
 
 FLAMEGPU_HOST_API::FLAMEGPU_HOST_API(Simulation &_agentModel)
     : random()
@@ -13,6 +14,7 @@ FLAMEGPU_HOST_API::FLAMEGPU_HOST_API(Simulation &_agentModel)
     , d_output_space_size(0) { }
 
 FLAMEGPU_HOST_API::~FLAMEGPU_HOST_API() {
+    // @todo - cuda is not allowed in destructor
     if (d_cub_temp) {
         gpuErrchk(cudaFree(d_cub_temp));
         d_cub_temp_size = 0;
@@ -40,6 +42,7 @@ bool FLAMEGPU_HOST_API::tempStorageRequiresResize(const CUB_Config &cc, const un
     return true;
 }
 void FLAMEGPU_HOST_API::resizeTempStorage(const CUB_Config &cc, const unsigned int &items, const size_t &newSize) {
+    NVTX_RANGE("FLAMEGPU_HOST_API::resizeTempStorage");
     if (newSize > d_cub_temp_size) {
         if (d_cub_temp) {
             gpuErrchk(cudaFree(d_cub_temp));

--- a/src/flamegpu/runtime/messaging/BruteForce.cu
+++ b/src/flamegpu/runtime/messaging/BruteForce.cu
@@ -2,6 +2,19 @@
 #include "flamegpu/model/AgentDescription.h"  // Used by Move-Assign
 #include "flamegpu/gpu/CUDAMessage.h"
 
+void MsgBruteForce::CUDAModelHandler::allocateMetaDataDevicePtr() {
+    if (d_metadata == nullptr) {
+        gpuErrchk(cudaMalloc(&d_metadata, sizeof(MetaData)));
+    }
+}
+
+void MsgBruteForce::CUDAModelHandler::freeMetaDataDevicePtr() {
+    if (d_metadata != nullptr) {
+        gpuErrchk(cudaFree(d_metadata));
+    }
+    d_metadata = nullptr;
+}
+
 void MsgBruteForce::CUDAModelHandler::buildIndex() {
     unsigned int newLength = this->sim_message.getMessageCount();
     if (newLength != hd_metadata.length) {

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -8,14 +8,15 @@
 #include "flamegpu/runtime/utility/RandomManager.cuh"
 #include "flamegpu/runtime/flamegpu_host_api.h"
 #include "flamegpu/pop/AgentPopulation.h"
+#include "flamegpu/util/nvtx.h"
 
 
 Simulation::Simulation(const ModelDescription& _model)
     : model(_model.model->clone())
-    , host_api(std::make_unique<FLAMEGPU_HOST_API>(*this)) {
-}
+    , host_api(std::make_unique<FLAMEGPU_HOST_API>(*this)) { }
 
 void Simulation::initialise(int argc, const char** argv) {
+    NVTX_RANGE("Simulation::initialise");
     config = Config();  // Reset to defaults
     resetDerivedConfig();
     // check input args


### PR DESCRIPTION
Cuda commands were previously being issued prior to `cudaSetDevice` - breaking the ability to set the device.

This resolves this, but it is a little sub-optimal, as parts such as EnvironmentManager are still a little too cuda-aware (if we are still considering a CUDA-free implementation as a goal).

Message list data structures also had to be changed. 

This Resolves #192, but these changes may want refactoring a little later on / during sorting cuda calls in constructors / destructors (#190)

