### PR TITLE
Add tests to detect bad CUDA initialisation order.

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,3 +1,3 @@
 set noparent 
 linelength=240
-filter=-legal/copyright,-readability/todo,-runtime/references
+filter=-legal/copyright,-readability/todo,-runtime/references,-build/c++11

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -146,6 +146,13 @@ foreach(SM IN LISTS SMS)
     set(GENCODES "${GENCODES} -gencode arch=compute_${SM},code=sm_${SM}")
 endforeach()
 
+# Get the minimum device architecture to pass through to nvcc to enable graceful failure prior to cuda execution.
+list(GET SMS 0 MIN_ARCH)
+# Pass this to the compiler(s)
+SET(CMAKE_CC_FLAGS "${CMAKE_C_FLAGS} -DMIN_ARCH=${MIN_ARCH}")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMIN_ARCH=${MIN_ARCH}")
+SET(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -DMIN_ARCH=${MIN_ARCH}")
+
 # Using the last element of the list, append the additional gencode argument
 list(GET SMS -1 LAST_SM)
 set(GENCODES "${GENCODES} -gencode arch=compute_${LAST_SM},code=compute_${LAST_SM}")

--- a/include/flamegpu/exception/FGPUException.h
+++ b/include/flamegpu/exception/FGPUException.h
@@ -250,6 +250,12 @@ DERIVED_FGPUException(InvalidCUDAdevice, "Invalid CUDA Device");
 
 /**
  * Defines a type of object to be thrown as exception.
+ * It reports errors that are due to CUDA device.
+ */
+DERIVED_FGPUException(InvalidCUDAComputeCapability, "Invalid CUDA Device Compute Capability");
+
+/**
+ * Defines a type of object to be thrown as exception.
  * It reports errors that are due adding an init/step/exit function/condition to a simulation multiply
  */
 DERIVED_FGPUException(InvalidHostFunc, "Invalid Host Function");

--- a/include/flamegpu/gpu/CUDAScanCompaction.h
+++ b/include/flamegpu/gpu/CUDAScanCompaction.h
@@ -97,6 +97,14 @@ namespace CUDAScanCompaction {
         assert(type < MAX_TYPES);
         hd_configs[type][streamId].zero_scan_flag();
     }
+    /**
+     * Wipes out host mirrors of device memory
+     * Only really to be used after calls to cudaDeviceReset()
+     * @note Only currently used after some tests
+     */
+    inline void purge() {
+        memset(hd_configs, 0, sizeof(hd_configs));
+    }
 }  // namespace CUDAScanCompaction
 }  // namespace flamegpu_internal
 

--- a/include/flamegpu/gpu/CUDAScatter.h
+++ b/include/flamegpu/gpu/CUDAScatter.h
@@ -170,6 +170,12 @@ class CUDAScatter {
      * If this reaches 0, free() is called on all instances
      */
     void decreaseSimCounter();
+    /**
+     * Wipes out host mirrors of device memory
+     * Only really to be used after calls to cudaDeviceReset()
+     * @note Only currently used after some tests
+     */
+    void purge();
 
  protected:
     /**
@@ -184,6 +190,13 @@ class CUDAScatter {
     static CUDAScatter& getInstance(unsigned int streamId) {
         // Guaranteed to be destroyed.
         static std::array<CUDAScatter, flamegpu_internal::CUDAScanCompaction::MAX_STREAMS> instance;
+        // Purge code
+        if (streamId == UINT_MAX) {
+            for (unsigned int i = 0; i < flamegpu_internal::CUDAScanCompaction::MAX_STREAMS; ++i) {
+                instance[i].purge();
+            }
+            return instance[0];
+        }
         // Basic err check
         assert(streamId < flamegpu_internal::CUDAScanCompaction::MAX_STREAMS);
         instance[streamId].streamId = streamId;

--- a/include/flamegpu/runtime/cuRVE/curve.h
+++ b/include/flamegpu/runtime/cuRVE/curve.h
@@ -303,6 +303,16 @@ class Curve {
      * @todo - Need to add a device-side check for initialisation.
      */
     void initialiseDevice();
+    /**
+     * Has access to call purge
+     */
+    friend class CUDAAgentModel;
+    /**
+     * Wipes out host mirrors of device memory
+     * Only really to be used after calls to cudaDeviceReset()
+     * @note Only currently used after some tests
+     */
+    __host__ void purge();
 
  protected:
     /** @brief    Default constructor.

--- a/include/flamegpu/runtime/utility/DeviceEnvironment.cuh
+++ b/include/flamegpu/runtime/utility/DeviceEnvironment.cuh
@@ -82,6 +82,7 @@ class DeviceEnvironment {
 template<typename T, unsigned int N>
 __device__ __forceinline__ const T &DeviceEnvironment::get(const char(&name)[N]) const {
     Curve::VariableHash cvh = CURVE_NAMESPACE_HASH() + modelname_hash + Curve::variableHash(name);
+
     // Error checking is internal to Curve::getVariablePtrByHash, returns nullptr on fail
     // get a pointer to the specific variable by offsetting by the provided index
     T *value_ptr = reinterpret_cast<T*>(Curve::getVariablePtrByHash(cvh, 0));

--- a/include/flamegpu/runtime/utility/EnvironmentManager.cuh
+++ b/include/flamegpu/runtime/utility/EnvironmentManager.cuh
@@ -496,6 +496,12 @@ class EnvironmentManager {
      * Remainder of class is singleton pattern
      */
     EnvironmentManager();
+    /**
+     * Wipes out host mirrors of device memory
+     * Only really to be used after calls to cudaDeviceReset()
+     * @note Only currently used after some tests
+     */
+    void purge();
 
  protected:
     /**

--- a/include/flamegpu/runtime/utility/RandomManager.cuh
+++ b/include/flamegpu/runtime/utility/RandomManager.cuh
@@ -143,6 +143,12 @@ class RandomManager {
      * @note includes cuda commands so not safe from c++ destructor
      */
     void freeDevice();
+    /**
+     * Wipes out host mirrors of device memory
+     * Only really to be used after calls to cudaDeviceReset()
+     * @note Only currently used after some tests
+     */
+    void purge();
 
     /**
      * Reinitialises host RNG from the current seed.

--- a/include/flamegpu/util/compute_capability.cuh
+++ b/include/flamegpu/util/compute_capability.cuh
@@ -1,0 +1,33 @@
+#ifndef INCLUDE_FLAMEGPU_UTIL_COMPUTE_CAPABILITY_CUH_
+#define INCLUDE_FLAMEGPU_UTIL_COMPUTE_CAPABILITY_CUH_
+
+#include "flamegpu/gpu/CUDAErrorChecking.h"
+
+namespace util {
+namespace compute_capability {
+
+/**
+ * get the compute capability for a device
+ * @param deviceIndex the index of the device to be queried
+ * @return integer value representing the compute capability, i.e 70 for SM_70
+ */
+int getComputeCapability(int deviceIndex);
+
+/**
+ * Get the minimum compute capability which this file was compiled for.
+ * Specified via the MIN_ARCH macro, as __CUDA_ARCH__ is only defined for device compilation.
+ */
+int minimumCompiledComputeCapability();
+
+/**
+ * Check that the current executable has been built with a low enough compute capability for the current device.
+ * This assumes JIT support is enabled for future (major) architectures.
+ * If the compile time flag MIN_ARCH was not specified, no decision can be made so it is assumed to be successful.
+ * @param deviceIndex the index of the device to be checked.
+ * @return boolean indicating if the executable can run on the specified device.
+ */
+bool checkComputeCapability(int deviceIndex);
+
+}  // namespace compute_capability
+}  // namespace util
+#endif  // INCLUDE_FLAMEGPU_UTIL_COMPUTE_CAPABILITY_CUH_

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,6 +107,7 @@ SET(SRC_INCLUDE
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/utility/HostRandom.cuh
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/utility/RandomManager.cuh    
     ${FLAMEGPU_ROOT}/include/flamegpu/util/nvtx.h    
+    ${FLAMEGPU_ROOT}/include/flamegpu/util/compute_capability.cuh    
 )
 SET(SRC_FLAMEGPU2
     ${FLAMEGPU_ROOT}/src/flamegpu/exception/FGPUException.cpp
@@ -137,6 +138,7 @@ SET(SRC_FLAMEGPU2
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/utility/HostEnvironment.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/utility/EnvironmentManager.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/utility/RandomManager.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/util/compute_capability.cu
 )
 
 SET(ALL_SRC

--- a/src/flamegpu/gpu/CUDAScatter.cu
+++ b/src/flamegpu/gpu/CUDAScatter.cu
@@ -25,6 +25,11 @@ void CUDAScatter::free() {
     data_len = 0;
 }
 
+void CUDAScatter::purge() {
+    d_data = nullptr;
+    data_len = 0;
+}
+
 void CUDAScatter::resize(const unsigned int &newLen) {
     if (newLen > data_len) {
         if (d_data) {

--- a/src/flamegpu/runtime/cuRVE/curve.cu
+++ b/src/flamegpu/runtime/cuRVE/curve.cu
@@ -22,7 +22,11 @@ __host__ Curve::Curve() :
     // Initialise some host variables.
     curve_internal::h_curve_error  = ERROR_NO_ERRORS;
 }
-
+__host__ void Curve::purge() {
+    deviceInitialised = false;
+    curve_internal::h_curve_error = ERROR_NO_ERRORS;
+    initialiseDevice();
+}
 __host__ void Curve::initialiseDevice() {
     if (!deviceInitialised) {
         unsigned int *_d_hashes;

--- a/src/flamegpu/runtime/utility/EnvironmentManager.cu
+++ b/src/flamegpu/runtime/utility/EnvironmentManager.cu
@@ -31,6 +31,12 @@ EnvironmentManager::EnvironmentManager() :
     freeFragments(),
     deviceInitialised(false) { }
 
+void EnvironmentManager::purge() {
+    deviceInitialised = false;
+    freeFragments.clear();
+    m_freeSpace = EnvironmentManager::MAX_BUFFER_SIZE;
+    nextFree = 0;
+}
 
 void EnvironmentManager::init(const std::string &model_name, const EnvironmentDescription &desc) {
     // Initialise device portions of Environment manager

--- a/src/flamegpu/util/compute_capability.cu
+++ b/src/flamegpu/util/compute_capability.cu
@@ -1,0 +1,34 @@
+#include "flamegpu/util/compute_capability.cuh"
+#include "flamegpu/gpu/CUDAErrorChecking.h"
+
+int util::compute_capability::getComputeCapability(int deviceIndex) {
+        int major = 0;
+        int minor = 0;
+        gpuErrchk(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, deviceIndex));
+        gpuErrchk(cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, deviceIndex));
+        int arch = (10 * major) + minor;
+        return arch;
+}
+
+int util::compute_capability::minimumCompiledComputeCapability() {
+    #if defined(MIN_ARCH)
+        return MIN_ARCH;
+    #else
+        // Return 0 as a default minimum?
+        return 0;
+    #endif
+}
+
+bool util::compute_capability::checkComputeCapability(int deviceIndex) {
+    // If the compile time minimum architecture is defined, fetch the device's compute capability and check that the executable (probably) supports this device.
+    #if defined(MIN_ARCH)
+        if (getComputeCapability(deviceIndex) < MIN_ARCH) {
+            return false;
+        } else {
+            return true;
+        }
+    #else
+        // If not defined, we cannot make a decision so assume it will work?
+        return true;
+    #endif
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -128,6 +128,8 @@ SET(OTHER_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/helpers/device_test_functions.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/helpers/host_reductions_common.h
     ${CMAKE_CURRENT_SOURCE_DIR}/helpers/host_reductions_common.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/helpers/device_initialisation.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/helpers/device_initialisation.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/helpers/main.cu
 )
 SET(ALL_SRC
@@ -136,7 +138,7 @@ SET(ALL_SRC
 )
 SET(DEV_ALL_SRC
     ${DEV_TEST_CASE_SRC}
-    ${CMAKE_CURRENT_SOURCE_DIR}/helpers/main.cu
+    ${OTHER_SRC}
 )
 
 # Add the executable and set required flags for the target

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -85,8 +85,8 @@ endif()
 # Prepare list of source files
 SET(TEST_CASE_SRC
     # ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_func_pointer.cu # Does not currently build
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/gpu/test_gpu_validation.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/gpu/test_cuda_agent_model.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/gpu/test_gpu_validation.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/model/test_environment_description.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/model/test_message_validation.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/model/test_model_validation.cu

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -120,6 +120,7 @@ SET(TEST_CASE_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_spatial_3d.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_brute_force.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_append_truncate.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/util/test_compute_capability.cu
 )
 SET(DEV_TEST_CASE_SRC
 )

--- a/tests/helpers/device_initialisation.cu
+++ b/tests/helpers/device_initialisation.cu
@@ -19,7 +19,6 @@ Alternative is to use the driver API, call CuCtxGetCurrent(CuContext* pctx) imme
 @note - This needs to be called first, and only once.
 */
 void timeCUDAAgentModelContextCreationTest() {
-    printf("timeCUDAAgentModelContextCreationTest\n");
     // Create a very simple model to enable creation of a CudaAgentModel
     ModelDescription m("model");
     m.newAgent("agent");

--- a/tests/helpers/device_initialisation.cu
+++ b/tests/helpers/device_initialisation.cu
@@ -1,0 +1,46 @@
+#include "helpers/device_initialisation.h"
+#include <stdio.h>
+#include <chrono>
+#include "flamegpu/flame_api.h"
+#include "flamegpu/runtime/flamegpu_api.h"
+
+namespace {
+    // Boolean to store the result of the test, in an anonymous namespace (i.e. static)
+    bool _CUDAAgentModelContextCreationTime_result = false;
+}
+// Set a threshold value, which is large enough to account for context creation
+// Experimentally cudaFree(0); takes ~2us (nsys) without context creation,
+// while cudaFree(0) including context creation takes ~> 150ms in my linux titan v system.
+// This test is a little fluffy.
+const double CONTEXT_CREATION_ATLEAST_SECONDS = 0.100;  // atleast 100ms?
+
+/* Test that CUDAAgentModel::applyConfig_derived() is invoked prior to any cuda call which will invoke the CUDA
+Alternative is to use the driver API, call CuCtxGetCurrent(CuContext* pctx) immediatebly before applyConfig, and if pctx is the nullptr then the context had not yet been initialised?
+@note - This needs to be called first, and only once.
+*/
+void timeCUDAAgentModelContextCreationTest() {
+    printf("timeCUDAAgentModelContextCreationTest\n");
+    // Create a very simple model to enable creation of a CudaAgentModel
+    ModelDescription m("model");
+    AgentDescription &a = m.newAgent("agent");
+    CUDAAgentModel c(m);
+    c.CUDAConfig().device_id = 0;
+    c.SimulationConfig().steps = 1;
+    // Time how long applyconfig takes, which should invoke cudaFree as the first cuda command, initialising the context.
+    auto t0 = std::chrono::high_resolution_clock::now();
+    c.applyConfig();
+    auto t1 = std::chrono::high_resolution_clock::now();
+    auto time_span = std::chrono::duration_cast<std::chrono::duration<double>>(t1 - t0);
+    // The test fails if applyconfig was too fast.
+    _CUDAAgentModelContextCreationTime_result = time_span.count() >= CONTEXT_CREATION_ATLEAST_SECONDS;
+    // Run the simulation.
+    c.simulate();
+}
+
+/**
+ * Return the value stored in the anonymous namespace.
+ * @note - there is no way to know if the test has not yet been ran, instead it reports false.
+ */
+bool getCUDAAgentModelContextCreationTestResult() {
+    return _CUDAAgentModelContextCreationTime_result;
+}

--- a/tests/helpers/device_initialisation.cu
+++ b/tests/helpers/device_initialisation.cu
@@ -22,7 +22,7 @@ void timeCUDAAgentModelContextCreationTest() {
     printf("timeCUDAAgentModelContextCreationTest\n");
     // Create a very simple model to enable creation of a CudaAgentModel
     ModelDescription m("model");
-    AgentDescription &a = m.newAgent("agent");
+    m.newAgent("agent");
     CUDAAgentModel c(m);
     c.CUDAConfig().device_id = 0;
     c.SimulationConfig().steps = 1;

--- a/tests/helpers/device_initialisation.h
+++ b/tests/helpers/device_initialisation.h
@@ -1,0 +1,17 @@
+#ifndef TESTS_HELPERS_DEVICE_INITIALISATION_H_
+#define TESTS_HELPERS_DEVICE_INITIALISATION_H_
+
+
+/**
+ * Function to time the creation of the cuda context within the scope of FLAME GPU initialisation.
+ * Must be run first to ensure a fresh context is being created, rather than within the google test suite which may be executed in a random order.
+ */
+void timeCUDAAgentModelContextCreationTest();
+
+/**
+ * Determine the success of the cuda context creation test.
+ * @returns bool indicator of the test passing
+ */
+bool getCUDAAgentModelContextCreationTestResult();
+
+#endif  // TESTS_HELPERS_DEVICE_INITIALISATION_H_

--- a/tests/helpers/main.cu
+++ b/tests/helpers/main.cu
@@ -1,9 +1,13 @@
 #include <cuda_runtime.h>
 #include <cstdio>
 #include "gtest/gtest.h"
+#include "helpers/device_initialisation.h"
 
 
 GTEST_API_ int main(int argc, char **argv) {
+  // Time the cuda agent model initialisation, to check it creates the context.
+  timeCUDAAgentModelContextCreationTest();
+  // Run the main google test body
   printf("Running main() from %s\n", __FILE__);
   testing::InitGoogleTest(&argc, argv);
   auto rtn = RUN_ALL_TESTS();

--- a/tests/test_cases/gpu/test_cuda_agent_model.cu
+++ b/tests/test_cases/gpu/test_cuda_agent_model.cu
@@ -1,8 +1,8 @@
-#include <chrono>
 #include "gtest/gtest.h"
 
 #include "flamegpu/flame_api.h"
 #include "flamegpu/runtime/flamegpu_api.h"
+#include "helpers/device_initialisation.h"
 
 namespace test_cuda_agent_model {
     const char *MODEL_NAME = "Model";
@@ -27,38 +27,11 @@ FLAMEGPU_AGENT_FUNCTION(DeathTestFunc, MsgNone, MsgNone) {
 FLAMEGPU_STEP_FUNCTION(IncrementCounter) {
     externalCounter++;
 }
-/* Test that CUDAAgentModel::applyConfig_derived() is invoked prior to any cuda call which will invoke the CUDA
-Alternative is to use the driver API, call CuCtxGetCurrent(CuContext* pctx) immediatebly before applyConfig, and if pctx is the nullptr then the context had not yet been initialised?
-@note - this test is somewhat unreliable, as other tests may have already ran to create the context?
-*/
+
 TEST(TestCUDAAgentModel, ApplyConfigDerivedContextCreation) {
-    // Set a threshold value, which is large enough to account for context creation
-    // Experimentally cudaFree(0); takes ~2us (nsys) without context creation,
-    // while cudaFree(0) including context creation takes ~150ms in my linux system.
-    // This test is a little fluffy.
-    const double CONTEXT_CREATION_ATLEAST_SECONDS = 0.100;  // atleast 100ms?
-    // Reset the CUDADevice, killing any exisitng contexts from other tests. If this doesn't work it's fatal.
-    // ASSERT_EQ(cudaSuccess, cudaDeviceReset());
-    // Create a very simple model to enable creation of a CudaAgentModel
-    ModelDescription m("model");
-    AgentDescription &a = m.newAgent("agent");
-    // Create a CUDAAgentModel, and set configuration properties
-    CUDAAgentModel c(m);
-    // Set the device ID
-    c.CUDAConfig().device_id = 0;
-    // c.CUDAConfig().device_id = 1;
-    c.SimulationConfig().steps = 1;
-    // Time how long applyconfig takes, which should invoke cudaFree (and a few other bits unfortunately.)
-    EXPECT_NO_THROW({
-        auto t0 = std::chrono::high_resolution_clock::now();
-        c.applyConfig();
-        auto t1 = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double> time_span = std::chrono::duration_cast<std::chrono::duration<double>>(t1 - t0);
-        // The test fails applyconfig was too fast.
-        EXPECT_GE(time_span.count(), CONTEXT_CREATION_ATLEAST_SECONDS);
-    });
-    // Run the simulation.
-    c.simulate();
+    // Simply get the result from the method provided by the helper file.
+    ASSERT_TRUE(getCUDAAgentModelContextCreationTestResult());
+    // Reset the device, just to be sure.
     ASSERT_EQ(cudaSuccess, cudaDeviceReset());
 }
 // Test that the CUDAAgentModel applyConfig_derived works for multiple GPU device_id values (if available)

--- a/tests/test_cases/gpu/test_cuda_agent_model.cu
+++ b/tests/test_cases/gpu/test_cuda_agent_model.cu
@@ -46,20 +46,23 @@ TEST(TestCUDAAgentModel, AllDeviceIdValues) {
     for (int i = 0; i < device_count; i++) {
         ModelDescription m(MODEL_NAME);
         AgentDescription &a = m.newAgent(AGENT_NAME);
-        CUDAAgentModel c(m);
-        // Set the device ID
-        c.CUDAConfig().device_id = i;
-        c.SimulationConfig().steps = 1;
-        //  Apply the config (and therefore set the device.)
-        EXPECT_NO_THROW({
-            c.applyConfig();
-        });
-        // Run the simulation.
-        c.simulate();
-
+        {  // Scope to dealloc CUDAAgentModel before cudaDeviceReset()
+            CUDAAgentModel c(m);
+            // Set the device ID
+            c.CUDAConfig().device_id = i;
+            c.SimulationConfig().steps = 1;
+            //  Apply the config (and therefore set the device.)
+            EXPECT_NO_THROW({
+                c.applyConfig();
+            });
+            // Run the simulation.
+            c.simulate();
+        }
         // Reset the device to destroy the context.
         cudaDeviceReset();
     }
+    // Return to prior state for remaining tests.
+    cudaSetDevice(0);
 }
 TEST(TestSimulation, ArgParse_inputfile_long) {
     ModelDescription m(MODEL_NAME);

--- a/tests/test_cases/util/test_compute_capability.cu
+++ b/tests/test_cases/util/test_compute_capability.cu
@@ -1,0 +1,60 @@
+#include <cuda_runtime.h>
+
+#include "gtest/gtest.h"
+#include "flamegpu/util/compute_capability.cuh"
+#include "flamegpu/gpu/CUDAErrorChecking.h"
+
+// Test the getting of a device's compute capability.
+TEST(TestUtilComputeCapability, getComputeCapability) {
+    // Get the number of cuda devices
+    int device_count = 0;
+    if (cudaSuccess != cudaGetDeviceCount(&device_count) || device_count <= 0) {
+        return;
+    }
+    // For each CUDA device, get the compute capability and check it.
+    for (int i = 0; i < device_count; i++) {
+        // Manually get the arch as the reference.
+        int major = 0;
+        int minor = 0;
+        gpuErrchk(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, i));
+        gpuErrchk(cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, i));
+        int reference = (10 * major) + minor;
+        // The function should return the reference value.
+        EXPECT_EQ(util::compute_capability::getComputeCapability(i), reference);
+    }
+
+    // If the function is given a bad index, it should throw.
+    EXPECT_ANY_THROW(util::compute_capability::getComputeCapability(-1));
+    EXPECT_ANY_THROW(util::compute_capability::getComputeCapability(device_count));
+}
+
+// Test getting the minimum compiled cuda capabillity.
+TEST(TestUtilComputeCapability, minimumCompiledComputeCapability) {
+    // If the macro is defined, the returned value should match, otherwise it should be 0.
+    #if defined(MIN_ARCH)
+        EXPECT_EQ(util::compute_capability::minimumCompiledComputeCapability(), MIN_ARCH);
+    #else
+        EXPECT_EQ(util::compute_capability::minimumCompiledComputeCapability(), 0);
+    #endif
+}
+
+// Test checking the compute capability of a specific device.
+TEST(TestUtilComputeCapability, checkComputeCapability) {
+    // Get the number of cuda devices
+    int device_count = 0;
+    if (cudaSuccess != cudaGetDeviceCount(&device_count) || device_count <= 0) {
+        return;
+    }
+    // Get the minimum cc compiled for, previously tested.
+    int min_cc = util::compute_capability::minimumCompiledComputeCapability();
+    // For each CUDA device, get the compute capability and comapre it against
+    for (int i = 0; i < device_count; i++) {
+        // This function is tested elsewhere, so use it here.
+        int cc = util::compute_capability::getComputeCapability(i);
+        EXPECT_EQ(util::compute_capability::checkComputeCapability(i), cc >= min_cc);
+    }
+
+    // If the function is given a bad index, it should throw and the result is irrelevant.
+    EXPECT_ANY_THROW(util::compute_capability::checkComputeCapability(-1));
+    EXPECT_ANY_THROW(util::compute_capability::checkComputeCapability(device_count));
+}


### PR DESCRIPTION
This is not 100% reliable as it relies on timing how long the routine which sets the cuda device and calls cudaFree takes.
If the context already exists due to a previous test, this will complete too quickly.

Also disables a lint rule banning <chrono>, as cpplint is strongly oppinionated.

~Untested on windows.~

Also adds compilation architecture detection, to throw graceful exceptions if an incompatible device is used.

I..e If compiled for `SM_70`, in a system where device `1` is `SM_61` the following occurs if device `1` is selected
```
./bin/linux-x64/Release/circles_bruteforce -s 2 -d 1
terminate called after throwing an instance of 'InvalidCUDAComputeCapability'
  what():  /home/ptheywood/code/flamegpu/flamegpu2_dev/src/flamegpu/gpu/CUDAAgentModel.cu(568): Error application compiled for CUDA Compute Capability 70 and above. Device 1 is compute capability 61. Rebuild for SM_61.
```