### PR TITLE
Array/Array2D/Array3D Message Types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(BUILD_ALL_EXAMPLES "Enable building examples" ON)
 
 # Options to enable building individual examples, if BUILD_ALL_EXAMPLES is off.
 option(BUILD_EXAMPLE_HOST_FUNCTIONS "Enable building examples/host_functions" OFF)
+option(BUILD_EXAMPLE_GAME_OF_LIFE "Enable building examples/game_of_life" OFF)
 option(BUILD_EXAMPLE_CIRCLES_BRUTE_FORCE "Enable building examples/circles_brute_force" OFF)
 option(BUILD_EXAMPLE_CIRCLES_SPATIAL_3D "Enable building examples/circles_spatial_3d" OFF)
 
@@ -38,7 +39,7 @@ option(BUILD_EXAMPLE_CIRCLES_SPATIAL_3D "Enable building examples/circles_spatia
 option(BUILD_TESTS "Enable building tests" OFF)
 
 # Option to enable/disable NVTX markers for improved profiling
-option(NVTX "Enable NVTX markers for improved profiling (if aviailable). Implied by profile builds" OFF)
+option(NVTX "Enable NVTX markers for improved profiling (if available). Implied by profile builds" OFF)
 
 # Define a function to add a lint target.
 find_file(CPPLINT NAMES cpplint cpplint.exe)
@@ -60,6 +61,10 @@ endif()
 # Add each example
 if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_HOST_FUNCTIONS)
     add_subdirectory(examples/host_functions)
+endif()
+
+if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_GAME_OF_LIFE)
+    add_subdirectory(examples/game_of_life)
 endif()
 
 if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_CIRCLES_BRUTE_FORCE)

--- a/examples/game_of_life/CMakeLists.txt
+++ b/examples/game_of_life/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Set the minimum cmake version to that which supports cuda natively.
+# 3.10 required for cuda -std=c++14, however 3.12 fixes some device linker errors
+cmake_minimum_required(VERSION VERSION 3.12 FATAL_ERROR)
+
+# Name the project and set languages
+project(game_of_life CUDA CXX)
+
+# Set the location of the ROOT flame gpu project relative to this CMakeList.txt
+get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../.. REALPATH)
+
+# Include common rules.
+include(${FLAMEGPU_ROOT}/cmake/common.cmake)
+
+# Define output location of binary files
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    # If top level project
+    SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin/${CMAKE_SYSTEM_NAME_LOWER}-x64/${CMAKE_BUILD_TYPE}/)
+else()
+    # If called via add_subdirectory()
+    SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../../bin/${CMAKE_SYSTEM_NAME_LOWER}-x64/${CMAKE_BUILD_TYPE}/)
+endif()
+
+# Prepare list of source files
+# Can't do this automatically, as CMake wouldn't know when to regen (as CMakeLists.txt would be unchanged)
+SET(ALL_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cu
+)
+
+# Add the executable and set required flags for the target
+add_flamegpu_executable("${PROJECT_NAME}" "${ALL_SRC}" "${FLAMEGPU_ROOT}" "${PROJECT_BINARY_DIR}" TRUE)
+
+# Also set as startup project (if top level project)
+set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"  PROPERTY VS_STARTUP_PROJECT "${PROJECT_NAME}")
+
+# Set the default (visual studio) debugger configure_file
+set_target_properties("${PROJECT_NAME}" PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                                                   VS_DEBUGGER_COMMAND_ARGUMENTS "-s 10")

--- a/examples/game_of_life/src/main.cu
+++ b/examples/game_of_life/src/main.cu
@@ -1,0 +1,148 @@
+#include <iostream>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+
+
+#include "flamegpu/flame_api.h"
+#include "flamegpu/runtime/flamegpu_api.h"
+#include "flamegpu/io/factory.h"
+#include "flamegpu/util/nvtx.h"
+
+void printPopulation(AgentPopulation &pop);
+
+FLAMEGPU_AGENT_FUNCTION(output, MsgNone, MsgArray2D) {
+    FLAMEGPU->message_out.setVariable<char>("is_alive", FLAMEGPU->getVariable<char>("is_alive"));
+    FLAMEGPU->message_out.setIndex(FLAMEGPU->getVariable<unsigned int, 2>("pos", 0), FLAMEGPU->getVariable<unsigned int, 2>("pos", 1));
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(update, MsgArray2D, MsgNone) {
+    const unsigned int my_x = FLAMEGPU->getVariable<unsigned int, 2>("pos", 0);
+    const unsigned int my_y = FLAMEGPU->getVariable<unsigned int, 2>("pos", 1);
+
+    unsigned int living_neighbours = 0;
+    // Iterate 3x3 grid
+    for (auto &msg : FLAMEGPU->message_in(my_x, my_y, 2)) {
+        living_neighbours += msg.getVariable<char>("is_alive") ? 1 : 0;
+    }
+    // Using count, decide and output new value for is_alive
+    char is_alive = FLAMEGPU->getVariable<char>("is_alive");
+    if (is_alive) {
+        if (living_neighbours < 2)
+            is_alive = 0;
+        else if (living_neighbours > 3)
+            is_alive = 0;
+        else  // exactly 2 or 3 living_neighbours
+            is_alive = 1;
+    } else {
+        if (living_neighbours == 3)
+            is_alive = 1;
+    }
+    FLAMEGPU->setVariable<char>("is_alive", is_alive);
+    return ALIVE;
+}
+int main(int argc, const char ** argv) {
+    NVTX_RANGE("main");
+    NVTX_PUSH("ModelDescription");
+    ModelDescription model("Game_of_Life_example");
+
+    {   // Location message
+        MsgArray2D::Description &message = model.newMessage<MsgArray2D>("is_alive_msg");
+        message.newVariable<char>("is_alive");
+        message.setDimensions(10, 10);
+    }
+    {   // Cell agent
+        AgentDescription &agent = model.newAgent("cell");
+        agent.newVariable<unsigned int, 2>("pos");
+        agent.newVariable<char>("is_alive");
+        agent.newFunction("output", output).setMessageOutput("is_alive_msg");
+        agent.newFunction("update", update).setMessageInput("is_alive_msg");
+    }
+
+    /**
+     * GLOBALS
+     */
+    {
+        EnvironmentDescription &env = model.Environment();
+        env.add("repulse", 0.05f);
+        env.add("radius", 1.0f);
+    }
+
+    /**
+     * Control flow
+     */
+    {   // Layer #1
+        LayerDescription &layer = model.newLayer();
+        layer.addAgentFunction(output);
+    }
+    {   // Layer #2
+        LayerDescription &layer = model.newLayer();
+        layer.addAgentFunction(update);
+    }
+    NVTX_POP();
+
+    /**
+     * Create Model Runner
+     */
+    NVTX_PUSH("CUDAAgentModel creation");
+    CUDAAgentModel cuda_model(model);
+    NVTX_POP();
+
+    /**
+     * Initialisation
+     */
+    cuda_model.initialise(argc, argv);
+    if (cuda_model.getSimulationConfig().xml_input_file.empty()) {
+        // Currently population has not been init, so generate an agent population on the fly
+        const unsigned int SQRT_AGENT_COUNT = 10;
+        const unsigned int AGENT_COUNT = SQRT_AGENT_COUNT * SQRT_AGENT_COUNT;
+        std::default_random_engine rng;
+        std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+        AgentPopulation init_pop(model.Agent("cell"), AGENT_COUNT);
+        for (unsigned int x = 0; x < SQRT_AGENT_COUNT; ++x) {
+            for (unsigned int y = 0; y < SQRT_AGENT_COUNT; ++y) {
+                AgentInstance instance = init_pop.getNextInstance();
+                instance.setVariable<unsigned int, 2>("pos", { x, y });
+                char is_alive = dist(rng) < 0.4f ? 1 : 0;
+                instance.setVariable<char>("is_alive", is_alive);  // 40% Chance of being alive
+            }
+        }
+        printPopulation(init_pop);
+        cuda_model.setPopulationData(init_pop);
+    }
+
+    /**
+     * Execution
+     */
+    AgentPopulation cell_pop(model.Agent("cell"));
+     while (cuda_model.getStepCounter() < cuda_model.getSimulationConfig().steps && cuda_model.step()) {
+        cuda_model.getPopulationData(cell_pop);
+        printPopulation(cell_pop);
+        getchar();
+     }
+
+    /**
+     * Export Pop
+     */
+    // TODO
+    return 0;
+}
+/**
+ * Only works on square grids
+ * Assumes grid is always in same order as output
+ */
+void printPopulation(AgentPopulation &pop) {
+    const unsigned int dim = static_cast<unsigned int>(sqrt(pop.getCurrentListSize()));
+    unsigned int i = 0;
+    for (unsigned int x = 0; x < dim; ++x) {
+        for (unsigned int y = 0; y < dim; ++y) {
+            AgentInstance instance = pop.getInstanceAt(i++);
+            printf("%s", instance.getVariable<char>("is_alive") ? "#" : " ");
+        }
+        printf("\n");
+    }
+    for (unsigned int x = 0; x < dim; ++x) {
+        printf("-");
+    }
+    printf("\n");
+}

--- a/include/flamegpu/exception/FGPUException.h
+++ b/include/flamegpu/exception/FGPUException.h
@@ -328,4 +328,9 @@ DERIVED_FGPUException(DifferentModel, "Attempted to use member from a different 
  */
 DERIVED_FGPUException(UnsupportedFileType, "Cannot handle file type.");
 
+/**
+ * Defines an exception for errors when two agents try to output an array message to the same index
+ */
+DERIVED_FGPUException(ArrayMessageWriteConflict, "Two messages attempted to write to the same index");
+
 #endif  // INCLUDE_FLAMEGPU_EXCEPTION_FGPUEXCEPTION_H_

--- a/include/flamegpu/gpu/CUDAMessage.h
+++ b/include/flamegpu/gpu/CUDAMessage.h
@@ -54,6 +54,12 @@ class CUDAMessage {
      */
     unsigned int getMessageCount() const;
     /**
+     * Manually update the message count
+     * @note This should be used cautiously
+     * @note Required by array message types
+     */
+    void setMessageCount(const unsigned int &_message_count);
+    /**
      * Updates message_count to equal newSize, internally reallocates buffer space if more space is required
      * @param newSize The number of messages that the buffer should be capable of storing
      */

--- a/include/flamegpu/gpu/CUDAMessageList.h
+++ b/include/flamegpu/gpu/CUDAMessageList.h
@@ -71,6 +71,7 @@ class CUDAMessageList {
     /**
      * Copy all message data from d_swap_list to d_list
      * This ALWAYS performs and append to the existing message list count
+     * Used by swap() when appending messagelists
      * @param newCount Number of new messages to be scattered
      * @return Total number of messages now in list (includes old + new counts)
      */

--- a/include/flamegpu/pop/AgentPopulation.h
+++ b/include/flamegpu/pop/AgentPopulation.h
@@ -41,7 +41,7 @@ class AgentPopulation {
 
     AgentStateMemory& getStateMemory(const std::string agent_state = ModelData::DEFAULT_STATE);
 
-    unsigned int getCurrentListSize(const std::string agent_state = ModelData::DEFAULT_STATE);
+    unsigned int getCurrentListSize(const std::string agent_state = ModelData::DEFAULT_STATE) const;
 
     const AgentStateMemory& getReadOnlyStateMemory(const std::string agent_state = ModelData::DEFAULT_STATE) const;
 

--- a/include/flamegpu/runtime/AgentFunction.h
+++ b/include/flamegpu/runtime/AgentFunction.h
@@ -18,7 +18,8 @@ typedef void(AgentFunctionWrapper)(
     Curve::NamespaceHash messagename_outp_hash,
     Curve::NamespaceHash agent_output_hash,
     const int popNo,
-    const void *messagelist_metadata,
+    const void *in_messagelist_metadata,
+    const void *out_messagelist_metadata,
     const unsigned int thread_in_layer_offset,
     const unsigned int streamId);  // Can't put __global__ in a typedef
 
@@ -31,7 +32,8 @@ typedef void(AgentFunctionWrapper)(
  * @param messagename_outp_hash CURVE hash of the output message's name
  * @param agent_output_hash CURVE hash of "_agent_birth" or 0 if agent birth not present
  * @param popNo Total number of agents exeucting the function (number of threads launched)
- * @param messagelist_metadata Pointer to the MsgIn metadata struct, it is interpreted by MsgIn
+ * @param in_messagelist_metadata Pointer to the MsgIn metadata struct, it is interpreted by MsgIn
+ * @param out_messagelist_metadata Pointer to the MsgOut metadata struct, it is interpreted by MsgOut
  * @param thread_in_layer_offset Add this value to TID to calculate a thread-safe TID (TS_ID), used by ActorRandom for accessing curand array in a thread-safe manner
  * @tparam AgentFunction The modeller defined agent function (defined as FLAMEGPU_AGENT_FUNCTION in model code)
  * @tparam MsgIn Message handler for input messages (e.g. MsgNone, MsgBruteForce, MsgSpatial3D)
@@ -45,7 +47,8 @@ __global__ void agent_function_wrapper(
     Curve::NamespaceHash messagename_outp_hash,
     Curve::NamespaceHash agent_output_hash,
     const int popNo,
-    const void *messagelist_metadata,
+    const void *in_messagelist_metadata,
+    const void *out_messagelist_metadata,
     const unsigned int thread_in_layer_offset,
     const unsigned int streamId) {
     // Must be terminated here, else AgentRandom has bounds issues inside FLAMEGPU_DEVICE_API constructor
@@ -58,8 +61,8 @@ __global__ void agent_function_wrapper(
         agent_func_name_hash,
         agent_output_hash,
         streamId,
-        MsgIn::In(agent_func_name_hash, messagename_inp_hash, messagelist_metadata),
-        MsgOut::Out(agent_func_name_hash, messagename_outp_hash, streamId));
+        MsgIn::In(agent_func_name_hash, messagename_inp_hash, in_messagelist_metadata),
+        MsgOut::Out(agent_func_name_hash, messagename_outp_hash, out_messagelist_metadata, streamId));
 
     // call the user specified device function
     {

--- a/include/flamegpu/runtime/flamegpu_device_api.h
+++ b/include/flamegpu/runtime/flamegpu_device_api.h
@@ -109,7 +109,8 @@ class FLAMEGPU_DEVICE_API : public FLAMEGPU_READ_ONLY_DEVICE_API{
         Curve::NamespaceHash,
         Curve::NamespaceHash,
         const int,
-        const void *messagelist_metadata,
+        const void *,
+        const void *,
         const unsigned int,
         const unsigned int);
 

--- a/include/flamegpu/runtime/messaging.h
+++ b/include/flamegpu/runtime/messaging.h
@@ -10,6 +10,9 @@
 #include "flamegpu/runtime/messaging/BruteForce.h"
 #include "flamegpu/runtime/messaging/Spatial2D.h"
 #include "flamegpu/runtime/messaging/Spatial3D.h"
+#include "flamegpu/runtime/messaging/Array.h"
+#include "flamegpu/runtime/messaging/Array2D.h"
+#include "flamegpu/runtime/messaging/Array3D.h"
 
 /**
  * ######################################################
@@ -42,7 +45,8 @@
  *  It is required to have the correct constructor format, and to inherit from MsgSpecialisationHandler.
  *  
  *  The method buildIndex() is called the first time messages are read after message output. This
- *  is useful if your messaging type required a special index (e.g. Spatial messaging PBM).
+ *  is useful if your messaging type required a special index (e.g. Spatial messaging PBM). Read list 
+ *  (d_list) must contain the sorted message data on exit from the method.
  *  
  *  The method getMetaDataDevicePtr() returns a pointer to a structure on the device that is required for
  *  message input. This pointer is then passed to the constructor of In. This is useful if your messaging

--- a/include/flamegpu/runtime/messaging/Array.h
+++ b/include/flamegpu/runtime/messaging/Array.h
@@ -1,0 +1,527 @@
+#ifndef INCLUDE_FLAMEGPU_RUNTIME_MESSAGING_ARRAY_H_
+#define INCLUDE_FLAMEGPU_RUNTIME_MESSAGING_ARRAY_H_
+
+#include <string>
+#include <memory>
+
+#include "flamegpu/runtime/messaging/None.h"
+#include "flamegpu/runtime/messaging/BruteForce.h"
+#include "flamegpu/model/Variable.h"
+
+/**
+ * Array messaging functionality
+ *
+ * Like an array, each message is assigned an index within a known range
+ * Only one message may exist at each index
+ * Agent functions can access individual messages by requesting them with their index
+ * 
+ * Algorithm:
+ * Every agent outputs a message to the array based on their thread index
+ * They also set the __index variable with the intended output bin
+ * When buildIndex() is called, messages are sorted and errors (multiple messages per bin) are detected
+ */
+class MsgArray {
+ public:
+    /**
+     * Common size type
+     */
+    typedef MsgNone::size_type size_type;
+
+    class Message;      // Forward declare inner classes
+    class iterator;     // Forward declare inner classes
+    struct Data;        // Forward declare inner classes
+    class Description;  // Forward declare inner classes
+    /**
+     * MetaData required by brute force during message reads
+     */
+    struct MetaData {
+        /**
+         * Length
+         */
+        size_type length;
+    };
+    /**
+     * This class is accessible via FLAMEGPU_DEVICE_API.message_in if MsgArray is specified in FLAMEGPU_AGENT_FUNCTION
+     * It gives access to functionality for reading array messages
+     */
+    class In {
+        /**
+         * Message has full access to In, they are treated as the same class so share everything
+         * Reduces/memory data duplication
+         */
+        friend class MsgArray::Message;
+
+     public:
+        /**
+         * This class is created when a search origin is provided to MsgArray::In::operator()(size_type, size_type, size_type = 1)
+         * It provides iterator access to a subset of the full message list, according to the provided search origin and radius
+         * 
+         * @see MsgArray::In::operator()(size_type, size_type)
+         */
+        class Filter {
+            /**
+             * Message has full access to Filter, they are treated as the same class so share everything
+             * Reduces/memory data duplication
+             */
+            friend class Message;
+
+         public:
+            /**
+             * Provides access to a specific message
+             * Returned by the iterator
+             * @see In::Filter::iterator
+             */
+            class Message {
+                /**
+                 * Paired Filter class which created the iterator
+                 */
+                const Filter &_parent;
+                /**
+                 * Relative position within the Moore neighbourhood
+                 * This is initialised based on user provided radius
+                 */
+                int relative_cell;
+                /**
+                 * Index into memory of currently pointed message
+                 */
+                size_type index_1d = 0;
+
+             public:
+                /**
+                 * Constructs a message and directly initialises all of it's member variables
+                 * @note See member variable documentation for their purposes
+                 */
+                __device__ Message(const Filter &parent, const int &relative_x)
+                    : _parent(parent) {
+                    relative_cell = relative_x;
+                }
+                /**
+                 * Equality operator
+                 * Compares all internal member vars for equality
+                 * @note Does not compare _parent
+                 */
+                __device__ bool operator==(const Message& rhs) const {
+                    return this->index_1d == rhs.index_1d
+                        && this->_parent.loc == rhs._parent.loc;
+                }
+                /**
+                 * Inequality operator
+                 * Returns inverse of equality operator
+                 * @see operator==(const Message&)
+                 */
+                __device__ bool operator!=(const Message& rhs) const { return !(*this == rhs); }
+                /**
+                 * Updates the message to return variables from the next cell in the Moore neighbourhood
+                 * @return Returns itself
+                 */
+                __device__ Message& operator++();
+                /**
+                 * Returns x array index of message
+                 */
+                __device__ size_type getX() const {
+                    return (this->_parent.loc + relative_cell + this->_parent.length) % this->_parent.length;
+                }
+                /**
+                 * Returns the value for the current message attached to the named variable
+                 * @param variable_name Name of the variable
+                 * @tparam T type of the variable
+                 * @tparam N Length of variable name (this should be implicit if a string literal is passed to variable name)
+                 * @return The specified variable, else 0x0 if an error occurs
+                 */
+                template<typename T, unsigned int N>
+                __device__ T getVariable(const char(&variable_name)[N]) const;
+            };
+            /**
+             * Stock iterator for iterating MsgSpatial3D::In::Filter::Message objects
+             */
+            class iterator : public std::iterator <std::random_access_iterator_tag, void, void, void, void> {
+                /**
+                 * The message returned to the user
+                 */
+                Message _message;
+
+             public:
+                /**
+                 * Constructor
+                 * This iterator is constructed by MsgArray::In::Filter::begin()(size_type, size_type)
+                 * @see MsgArray::In::Operator()(size_type, size_type)
+                 */
+                __device__ iterator(const Filter &parent, const int &relative_x)
+                    : _message(parent, relative_x) {
+                    // Increment to find first message
+                    ++_message;
+                }
+                /**
+                 * Moves to the next message
+                 * (Prefix increment operator)
+                 */
+                __device__ iterator& operator++() { ++_message;  return *this; }
+                /**
+                 * Moves to the next message
+                 * (Postfix increment operator, returns value prior to increment)
+                 */
+                __device__ iterator operator++(int) {
+                    iterator temp = *this;
+                    ++*this;
+                    return temp;
+                }
+                /**
+                 * Equality operator
+                 * Compares message
+                 */
+                __device__ bool operator==(const iterator& rhs) const { return  _message == rhs._message; }
+                /**
+                 * Inequality operator
+                 * Compares message
+                 */
+                __device__ bool operator!=(const iterator& rhs) const { return  _message != rhs._message; }
+                /**
+                 * Dereferences the iterator to return the message object, for accessing variables
+                 */
+                __device__ Message& operator*() { return _message; }
+                /**
+                 * Dereferences the iterator to return the message object, for accessing variables
+                 */
+                __device__ Message* operator->() { return &_message; }
+            };
+            /**
+             * Constructor, takes the search parameters requried
+             * @param _length Pointer to message list length
+             * @param _combined_hash agentfn+message hash for accessing message data
+             * @param x Search origin x coord
+             * @param _radius Search radius
+             */
+            __device__ Filter(const size_type &_length, const Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &_radius);
+            /**
+             * Returns an iterator to the start of the message list subset about the search origin
+             */
+            inline __device__ iterator begin(void) const {
+                // Bin before initial bin, as the constructor calls increment operator
+                return iterator(*this, -radius - 1);
+            }
+            /**
+             * Returns an iterator to the position beyond the end of the message list subset
+             * @note This iterator is the same for all message list subsets
+             */
+            inline __device__ iterator end(void) const {
+                // Final bin, as the constructor calls increment operator
+                return iterator(*this, radius);
+            }
+
+         private:
+            /**
+             * Search origin
+             */
+            size_type loc;
+            /**
+             * Search radius
+             */
+            const size_type radius;
+            /**
+             * Message list length
+             */
+            const size_type length;
+            /**
+             * CURVE hash for accessing message data
+             * agent function hash + message hash
+             */
+            Curve::NamespaceHash combined_hash;
+        };
+        /**
+         * Constructer
+         * Initialises member variables
+         * @param agentfn_hash Added to msg_hash to produce combined_hash
+         * @param msg_hash Added to agentfn_hash to produce combined_hash
+         * @param metadata Reinterpreted as type MsgArray::MetaData to extract length
+         */
+        __device__ In(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *metadata)
+            : combined_hash(agentfn_hash + msg_hash)
+            , length(reinterpret_cast<const MetaData*>(metadata)->length)
+        { }
+        /**
+         * Returns a Filter object which provides access to message iterator
+         * for iterating a subset of messages including those within the radius of the search origin
+         * this excludes the message at the search origin
+         *
+         * @param x Search origin x coord
+         * @param radius Search radius
+         * @note radius 1 is 2 cells
+         * @note radius 2 is 4 cells
+         * @note If radius is >= half of the array dimensions, cells will be doubly read
+         * @note radius of 0 is unsupported
+         */
+        inline __device__ Filter operator() (const size_type &x, const size_type &radius = 1) const {
+            assert(radius > 0);  // Radius of 0 is bad
+            return Filter(length, combined_hash, x, radius);
+        }
+        /**
+         * Returns the length of the message list.
+         */
+        __device__ size_type size(void) const {
+            return length;
+        }
+        __device__ Message at(const size_type &index) const {
+            return Message(*this, index);
+        }
+
+     private:
+         /**
+          * CURVE hash for accessing message data
+          * agent function hash + message hash
+          */
+        Curve::NamespaceHash combined_hash;
+        /**
+         * Metadata struct for accessing messages
+         */
+        const size_type length;
+    };
+    /**
+     * Provides access to a specific message
+     * Returned by In::at(size_type)
+     * @see In::at(size_type)
+     */
+    class Message {
+         /**
+          * Paired In class which created the iterator
+          */
+        const MsgArray::In &_parent;
+        /**
+         * Position within the message list
+         */
+        size_type index;
+
+     public:
+        /**
+         * Constructs a message and directly initialises all of it's member variables
+         * index is always init to 0
+         * @note See member variable documentation for their purposes
+         */
+        __device__ Message(const MsgArray::In &parent, const size_type &_index) : _parent(parent), index(_index) {}
+        /**
+         * Equality operator
+         * Compares all internal member vars for equality
+         * @note Does not compare _parent
+         */
+        __device__ bool operator==(const Message& rhs) const { return  this->index == rhs.index; }
+        /**
+         * Inequality operator
+         * Returns inverse of equality operator
+         * @see operator==(const Message&)
+         */
+        __device__ bool operator!=(const Message& rhs) const { return  this->index != rhs.index; }
+        /**
+         * Returns the index of the message within the full message list
+         */
+        __device__ size_type getIndex() const { return this->index; }
+        /**
+         * Returns the value for the current message attached to the named variable
+         * @param variable_name Name of the variable
+         * @tparam T type of the variable
+         * @tparam N Length of variable name (this should be implicit if a string literal is passed to variable name)
+         * @return The specified variable, else 0x0 if an error occurs
+         */
+        template<typename T, unsigned int N>
+        __device__ T getVariable(const char(&variable_name)[N]) const;
+    };
+    /**
+     * This class is accessible via FLAMEGPU_DEVICE_API.message_out if MsgArray is specified in FLAMEGPU_AGENT_FUNCTION
+     * It gives access to functionality for outputting array messages
+     */
+    class Out {
+     public:
+        /**
+         * Constructer
+         * Initialises member variables
+         * @param agentfn_hash Added to msg_hash to produce combined_hash
+         * @param msg_hash Added to agentfn_hash to produce combined_hash
+         * @param _streamId Stream index, used for optional message output flag array
+         */
+        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *, unsigned int _streamId)
+            : combined_hash(agentfn_hash + msg_hash)
+            , streamId(_streamId)
+        { }
+        /**
+         * Sets the array index to store the message in
+         */
+        __device__ void setIndex(const size_type &id) const;
+        /**
+         * Sets the specified variable for this agents message
+         * @param variable_name Name of the variable
+         * @tparam T type of the variable
+         * @tparam N Length of variable name (this should be implicit if a string literal is passed to variable name)
+         * @return The specified variable, else 0x0 if an error occurs
+         */
+        template<typename T, unsigned int N>
+        __device__ void setVariable(const char(&variable_name)[N], T value) const;
+
+     protected:
+        /**
+         * CURVE hash for accessing message data
+         * agentfn_hash + msg_hash
+         */
+        Curve::NamespaceHash combined_hash;
+        /**
+         * Stream index used for setting optional message output flag
+         */
+        unsigned int streamId;
+    };
+    /**
+     * Blank handler, brute force requires no index or special allocations
+     * Only stores the length on device
+     */
+    class CUDAModelHandler : public MsgSpecialisationHandler {
+     public:
+        /**
+         * Constructor
+         * Allocates memory on device for message list length
+         * @param a Parent CUDAMessage, used to access message settings, data ptrs etc
+         */
+         explicit CUDAModelHandler(CUDAMessage &a);
+        /** 
+         * Destructor.
+         * Should free any local host memory (device memory cannot be freed in destructors)
+         */
+        ~CUDAModelHandler() { }
+        /**
+         * Sort messages according to index
+         * Detect and report any duplicate indicies/gaps
+         */
+        void buildIndex() override;
+        /**
+         * Allocates memory for the constructed index.
+         * The memory allocation is checked by build index.
+         */
+        void allocateMetaDataDevicePtr() override;
+        /**
+         * Releases memory for the constructed index.
+         */
+        void freeMetaDataDevicePtr() override;
+        /**
+         * Returns a pointer to the metadata struct, this is required for reading the message data
+         */
+        const void *getMetaDataDevicePtr() const override { return d_metadata; }
+
+     private:
+        /**
+         * Host copy of metadata struct (message list length)
+         */
+        MetaData hd_metadata;
+        /**
+         * Pointer to device copy of metadata struct (message list length)
+         */
+        MetaData *d_metadata;
+        /**
+         * Owning CUDAMessage, provides access to message storage etc
+         */
+        CUDAMessage &sim_message;
+        /**
+         * Buffer used by buildIndex if array length > agent count
+         */
+        unsigned int *d_write_flag;
+        /**
+         * Allocated length of d_write_flag (in number of uint, not bytes)
+         */
+        size_type d_write_flag_len;
+    };
+    /**
+     * Internal data representation of Array messages within model description hierarchy
+     * @see Description
+     */
+    struct Data : public MsgBruteForce::Data {
+        friend class ModelDescription;
+        friend struct ModelData;
+        size_type length;
+        virtual ~Data() = default;
+
+        std::unique_ptr<MsgSpecialisationHandler> getSpecialisationHander(CUDAMessage &owner) const override;
+
+        /**
+         * Used internally to validate that the corresponding Msg type is attached via the agent function shim.
+         * @return The std::type_index of the Msg type which must be used.
+         */
+        std::type_index getType() const override;
+
+     protected:
+         Data *clone(ModelData *const newParent) override;
+        /**
+         * Copy constructor
+         * This is unsafe, should only be used internally, use clone() instead
+         */
+         Data(ModelData *const, const Data &other);
+        /**
+         * Normal constructor, only to be called by ModelDescription
+         */
+         Data(ModelData *const, const std::string &message_name);
+    };
+    /**
+     * User accessible interface to Array messages within mode description hierarchy
+     * @see Data
+     */
+    class Description : public MsgBruteForce::Description {
+        /**
+         * Data store class for this description, constructs instances of this class
+         */
+        friend struct Data;
+
+     protected:
+        /**
+         * Constructors
+         */
+         Description(ModelData *const _model, Data *const data);
+        /**
+         * Default copy constructor, not implemented
+         */
+         Description(const Description &other_message) = delete;
+        /**
+         * Default move constructor, not implemented
+         */
+         Description(Description &&other_message) noexcept = delete;
+        /**
+         * Default copy assignment, not implemented
+         */
+         Description& operator=(const Description &other_message) = delete;
+        /**
+         * Default move assignment, not implemented
+         */
+         Description& operator=(Description &&other_message) noexcept = delete;
+
+     public:
+        void setLength(const size_type &len);
+
+        size_type getLength() const;
+    };
+};
+template<typename T, unsigned int N>
+__device__ T MsgArray::Message::getVariable(const char(&variable_name)[N]) const {
+    // Ensure that the message is within bounds.
+    if (index < this->_parent.length) {
+        // get the value from curve using the stored hashes and message index.
+        return Curve::getVariable<T>(variable_name, this->_parent.combined_hash, index);
+    } else {
+        // @todo - Improved error handling of out of bounds message access? Return a default value or assert?
+        return static_cast<T>(0);
+    }
+}
+template<typename T, unsigned int N>
+__device__ T MsgArray::In::Filter::Message::getVariable(const char(&variable_name)[N]) const {
+    // Ensure that the message is within bounds.
+    if (index_1d < this->_parent.length) {
+        // get the value from curve using the stored hashes and message index.
+        return Curve::getVariable<T>(variable_name, this->_parent.combined_hash, index_1d);
+    } else {
+        // @todo - Improved error handling of out of bounds message access? Return a default value or assert?
+        return static_cast<T>(0);
+    }
+}
+
+template<typename T, unsigned int N>
+__device__ void MsgArray::Out::setVariable(const char(&variable_name)[N], T value) const {  // message name or variable name
+    unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
+
+    // set the variable using curve
+    Curve::setVariable<T>(variable_name, combined_hash, value, index);
+
+    // setIndex() sets the optional msg scan flag
+}
+
+#endif  // INCLUDE_FLAMEGPU_RUNTIME_MESSAGING_ARRAY_H_

--- a/include/flamegpu/runtime/messaging/Array2D.h
+++ b/include/flamegpu/runtime/messaging/Array2D.h
@@ -1,0 +1,566 @@
+#ifndef INCLUDE_FLAMEGPU_RUNTIME_MESSAGING_ARRAY2D_H_
+#define INCLUDE_FLAMEGPU_RUNTIME_MESSAGING_ARRAY2D_H_
+
+#include <string>
+#include <memory>
+#include <array>
+
+#include "flamegpu/runtime/messaging/None.h"
+#include "flamegpu/runtime/messaging/BruteForce.h"
+#include "flamegpu/model/Variable.h"
+
+/**
+ * Array messaging functionality
+ *
+ * Like an array, each message is assigned an index within a known range
+ * Only one message may exist at each index
+ * Agent functions can access individual messages by requesting them with their index
+ * 
+ * Algorithm:
+ * Every agent outputs a message to the array based on their thread index
+ * They also set the __index variable with the intended output bin
+ * When buildIndex() is called, messages are sorted and errors (multiple messages per bin) are detected
+ */
+class MsgArray2D {
+ public:
+    /**
+     * Common size type
+     */
+    typedef MsgNone::size_type size_type;
+
+    class Message;      // Forward declare inner classes
+    class iterator;     // Forward declare inner classes
+    struct Data;        // Forward declare inner classes
+    class Description;  // Forward declare inner classes
+    /**
+     * MetaData required by brute force during message reads
+     */
+    struct MetaData {
+        /**
+         * Dimensions of array
+         */
+        size_type dimensions[2];
+        /**
+         * Total number of elements
+         */
+        size_type length;
+    };
+    /**
+     * This class is accessible via FLAMEGPU_DEVICE_API.message_in if MsgArray2D is specified in FLAMEGPU_AGENT_FUNCTION
+     * It gives access to functionality for reading array messages
+     */
+    class In {
+        /**
+         * Message has full access to In, they are treated as the same class so share everything
+         * Reduces/memory data duplication
+         */
+        friend class MsgArray2D::Message;
+
+     public:
+        /**
+         * This class is created when a search origin is provided to MsgArray2D::In::operator()(size_type, size_type, size_type = 1)
+         * It provides iterator access to a subset of the full message list, according to the provided search origin and radius
+         * 
+         * @see MsgArray2D::In::operator()(size_type, size_type, size_type)
+         */
+        class Filter {
+            /**
+             * Message has full access to Filter, they are treated as the same class so share everything
+             * Reduces/memory data duplication
+             */
+            friend class Message;
+
+         public:
+            /**
+             * Provides access to a specific message
+             * Returned by the iterator
+             * @see In::Filter::iterator
+             */
+            class Message {
+                /**
+                 * Paired Filter class which created the iterator
+                 */
+                const Filter &_parent;
+                /**
+                 * Relative position within the Moore neighbourhood
+                 * This is initialised based on user provided radius
+                 */
+                int relative_cell[2];
+                /**
+                 * Index into memory of currently pointed message
+                 */
+                size_type index_1d = 0;
+
+             public:
+                /**
+                 * Constructs a message and directly initialises all of it's member variables
+                 * @note See member variable documentation for their purposes
+                 */
+                __device__ Message(const Filter &parent, const int &relative_x, const int &relative_y)
+                    : _parent(parent) {
+                    relative_cell[0] = relative_x;
+                    relative_cell[1] = relative_y;
+                }
+                /**
+                 * Equality operator
+                 * Compares all internal member vars for equality
+                 * @note Does not compare _parent
+                 */
+                __device__ bool operator==(const Message& rhs) const {
+                    return this->index_1d == rhs.index_1d
+                        && this->_parent.loc[0] == rhs._parent.loc[0]
+                        && this->_parent.loc[1] == rhs._parent.loc[1];
+                }
+                /**
+                 * Inequality operator
+                 * Returns inverse of equality operator
+                 * @see operator==(const Message&)
+                 */
+                __device__ bool operator!=(const Message& rhs) const { return !(*this == rhs); }
+                /**
+                 * Updates the message to return variables from the next cell in the Moore neighbourhood
+                 * @return Returns itself
+                 */
+                __device__ Message& operator++();
+                /**
+                 * Returns x array index of message
+                 */
+                __device__ size_type getX() const {
+                    return (this->_parent.loc[0] + relative_cell[0] + this->_parent.metadata->dimensions[0]) % this->_parent.metadata->dimensions[0];
+                }
+                /**
+                 * Returns y array index of message
+                 */
+                __device__ size_type getY() const {
+                    return (this->_parent.loc[1] + relative_cell[1] + this->_parent.metadata->dimensions[1]) % this->_parent.metadata->dimensions[1];
+                }
+                /**
+                 * Returns the value for the current message attached to the named variable
+                 * @param variable_name Name of the variable
+                 * @tparam T type of the variable
+                 * @tparam N Length of variable name (this should be implicit if a string literal is passed to variable name)
+                 * @return The specified variable, else 0x0 if an error occurs
+                 */
+                template<typename T, unsigned int N>
+                __device__ T getVariable(const char(&variable_name)[N]) const;
+            };
+            /**
+             * Stock iterator for iterating MsgSpatial3D::In::Filter::Message objects
+             */
+            class iterator : public std::iterator <std::random_access_iterator_tag, void, void, void, void> {
+                /**
+                 * The message returned to the user
+                 */
+                Message _message;
+
+             public:
+                /**
+                 * Constructor
+                 * This iterator is constructed by MsgArray2D::In::Filter::begin()(size_type, size_type, size_type)
+                 * @see MsgArray2D::In::Operator()(size_type, size_type, size_type)
+                 */
+                __device__ iterator(const Filter &parent, const int &relative_x, const int &relative_y)
+                    : _message(parent, relative_x, relative_y) {
+                    // Increment to find first message
+                    ++_message;
+                }
+                /**
+                 * Moves to the next message
+                 * (Prefix increment operator)
+                 */
+                __device__ iterator& operator++() { ++_message;  return *this; }
+                /**
+                 * Moves to the next message
+                 * (Postfix increment operator, returns value prior to increment)
+                 */
+                __device__ iterator operator++(int) {
+                    iterator temp = *this;
+                    ++*this;
+                    return temp;
+                }
+                /**
+                 * Equality operator
+                 * Compares message
+                 */
+                __device__ bool operator==(const iterator& rhs) const { return  _message == rhs._message; }
+                /**
+                 * Inequality operator
+                 * Compares message
+                 */
+                __device__ bool operator!=(const iterator& rhs) const { return  _message != rhs._message; }
+                /**
+                 * Dereferences the iterator to return the message object, for accessing variables
+                 */
+                __device__ Message& operator*() { return _message; }
+                /**
+                 * Dereferences the iterator to return the message object, for accessing variables
+                 */
+                __device__ Message* operator->() { return &_message; }
+            };
+            /**
+             * Constructor, takes the search parameters requried
+             * @param _metadata Pointer to message list metadata
+             * @param _combined_hash agentfn+message hash for accessing message data
+             * @param x Search origin x coord
+             * @param y Search origin y coord
+             * @param _radius Search radius
+             */
+            __device__ Filter(const MetaData *_metadata, const Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &y, const size_type &_radius);
+            /**
+             * Returns an iterator to the start of the message list subset about the search origin
+             */
+            inline __device__ iterator begin(void) const {
+                // Bin before initial bin, as the constructor calls increment operator
+                return iterator(*this, -radius, -radius-1);
+            }
+            /**
+             * Returns an iterator to the position beyond the end of the message list subset
+             * @note This iterator is the same for all message list subsets
+             */
+            inline __device__ iterator end(void) const {
+                // Final bin, as the constructor calls increment operator
+                return iterator(*this, radius, radius);
+            }
+
+         private:
+            /**
+             * Search origin
+             */
+            size_type loc[2];
+            /**
+             * Search radius
+             */
+            const size_type radius;
+            /**
+             * Pointer to message list metadata, e.g. environment bounds, search radius, PBM location
+             */
+            const MetaData *metadata;
+            /**
+             * CURVE hash for accessing message data
+             * agent function hash + message hash
+             */
+            Curve::NamespaceHash combined_hash;
+        };
+        /**
+         * Constructer
+         * Initialises member variables
+         * @param agentfn_hash Added to msg_hash to produce combined_hash
+         * @param msg_hash Added to agentfn_hash to produce combined_hash
+         * @param _metadata Reinterpreted as type MsgArray2D::MetaData
+         */
+        __device__ In(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *_metadata)
+            : combined_hash(agentfn_hash + msg_hash)
+            , metadata(reinterpret_cast<const MetaData*>(_metadata))
+        { }
+        /**
+         * Returns a Filter object which provides access to message iterator
+         * for iterating a subset of messages including those within the radius of the search origin
+         * this excludes the message at the search origin
+         *
+         * @param x Search origin x coord
+         * @param y Search origin y coord
+         * @param radius Search radius
+         * @note radius 1 is 8 cells in 3x3
+         * @note radius 2 is 24 cells in 5x5
+         * @note If radius is >= half of the array dimensions, cells will be doubly read
+         * @note radius of 0 is unsupported
+         */
+        inline __device__ Filter operator() (const size_type &x, const size_type &y, const size_type &radius = 1) const {
+            assert(radius > 0);  // Radius of 0 is bad
+            return Filter(metadata, combined_hash, x, y, radius);
+        }
+        /**
+         * Returns the x dimension size of the message list
+         */
+        __device__ size_type getDimX() const {
+            return metadata->dimensions[0];
+        }
+        /**
+         * Returns the y dimension size of the message list
+         */
+        __device__ size_type getDimY() const {
+            return metadata->dimensions[1];
+        }
+        /**
+         * Returns the length of the message list.
+         * xDim x yDim
+         */
+        __device__ size_type size(void) const {
+            return metadata->length;
+        }
+        __device__ Message at(const size_type &x, const size_type &y) const {
+            const size_type index_1d =
+                y * metadata->dimensions[0] +
+                x;
+            return Message(*this, index_1d);
+        }
+
+     private:
+         /**
+          * CURVE hash for accessing message data
+          * agent function hash + message hash
+          */
+        Curve::NamespaceHash combined_hash;
+        /**
+         * Metadata struct for accessing messages
+         */
+        const MetaData * const metadata;
+    };
+    /**
+     * Provides access to a specific message
+     * Returned by In::at(size_type)
+     * @see In::at(size_type)
+     */
+    class Message {
+         /**
+          * Paired In class which created the iterator
+          */
+        const MsgArray2D::In &_parent;
+        /**
+         * Position within the message list
+         */
+        size_type index;
+
+     public:
+        /**
+         * Constructs a message and directly initialises all of it's member variables
+         * index is always init to 0
+         * @note See member variable documentation for their purposes
+         */
+        __device__ Message(const MsgArray2D::In &parent, const size_type &_index) : _parent(parent), index(_index) {}
+        /**
+         * Equality operator
+         * Compares all internal member vars for equality
+         * @note Does not compare _parent
+         */
+        __device__ bool operator==(const Message& rhs) const { return  this->index == rhs.index; }
+        /**
+         * Inequality operator
+         * Returns inverse of equality operator
+         * @see operator==(const Message&)
+         */
+        __device__ bool operator!=(const Message& rhs) const { return  this->index != rhs.index; }
+        /**
+         * Returns the index of the message within the full message list
+         */
+        __device__ size_type getIndex() const { return this->index; }
+        /**
+         * Returns the value for the current message attached to the named variable
+         * @param variable_name Name of the variable
+         * @tparam T type of the variable
+         * @tparam N Length of variable name (this should be implicit if a string literal is passed to variable name)
+         * @return The specified variable, else 0x0 if an error occurs
+         */
+        template<typename T, unsigned int N>
+        __device__ T getVariable(const char(&variable_name)[N]) const;
+    };
+    /**
+     * This class is accessible via FLAMEGPU_DEVICE_API.message_out if MsgArray2D is specified in FLAMEGPU_AGENT_FUNCTION
+     * It gives access to functionality for outputting array messages
+     */
+    class Out {
+     public:
+        /**
+         * Constructer
+         * Initialises member variables
+         * @param agentfn_hash Added to msg_hash to produce combined_hash
+         * @param msg_hash Added to agentfn_hash to produce combined_hash
+         * @param _streamId Stream index, used for optional message output flag array
+         */
+        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *_metadata, unsigned int _streamId)
+            : combined_hash(agentfn_hash + msg_hash)
+            , streamId(_streamId)
+            , metadata(reinterpret_cast<const MetaData*>(_metadata))
+        { }
+        /**
+         * Sets the array index to store the message in
+         */
+        __device__ void setIndex(const size_type &x, const size_type &y) const;
+        /**
+         * Sets the specified variable for this agents message
+         * @param variable_name Name of the variable
+         * @tparam T type of the variable
+         * @tparam N Length of variable name (this should be implicit if a string literal is passed to variable name)
+         * @return The specified variable, else 0x0 if an error occurs
+         */
+        template<typename T, unsigned int N>
+        __device__ void setVariable(const char(&variable_name)[N], T value) const;
+
+     protected:
+        /**
+         * CURVE hash for accessing message data
+         * agentfn_hash + msg_hash
+         */
+        Curve::NamespaceHash combined_hash;
+        /**
+         * Stream index used for setting optional message output flag
+         */
+        unsigned int streamId;
+        /**
+         * Metadata struct for accessing messages
+         */
+        const MetaData * const metadata;
+    };
+    /**
+     * Blank handler, brute force requires no index or special allocations
+     * Only stores the length on device
+     */
+    class CUDAModelHandler : public MsgSpecialisationHandler {
+     public:
+        /**
+         * Constructor
+         * Allocates memory on device for message list length
+         * @param a Parent CUDAMessage, used to access message settings, data ptrs etc
+         */
+         explicit CUDAModelHandler(CUDAMessage &a);
+        /** 
+         * Destructor.
+         * Should free any local host memory (device memory cannot be freed in destructors)
+         */
+        ~CUDAModelHandler() { }
+        /**
+         * Sort messages according to index
+         * Detect and report any duplicate indicies/gaps
+         */
+        void buildIndex() override;
+        /**
+         * Allocates memory for the constructed index.
+         * The memory allocation is checked by build index.
+         */
+        void allocateMetaDataDevicePtr() override;
+        /**
+         * Releases memory for the constructed index.
+         */
+        void freeMetaDataDevicePtr() override;
+        /**
+         * Returns a pointer to the metadata struct, this is required for reading the message data
+         */
+        const void *getMetaDataDevicePtr() const override { return d_metadata; }
+
+     private:
+        /**
+         * Host copy of metadata struct (message list length)
+         */
+        MetaData hd_metadata;
+        /**
+         * Pointer to device copy of metadata struct (message list length)
+         */
+        MetaData *d_metadata;
+        /**
+         * Owning CUDAMessage, provides access to message storage etc
+         */
+        CUDAMessage &sim_message;
+        /**
+         * Buffer used by buildIndex if array length > agent count
+         */
+        unsigned int *d_write_flag;
+        /**
+         * Allocated length of d_write_flag (in number of uint, not bytes)
+         */
+        size_type d_write_flag_len;
+    };
+    /**
+     * Internal data representation of Array messages within model description hierarchy
+     * @see Description
+     */
+    struct Data : public MsgBruteForce::Data {
+        friend class ModelDescription;
+        friend struct ModelData;
+        std::array<size_type, 2> dimensions;
+        virtual ~Data() = default;
+
+        std::unique_ptr<MsgSpecialisationHandler> getSpecialisationHander(CUDAMessage &owner) const override;
+
+        /**
+         * Used internally to validate that the corresponding Msg type is attached via the agent function shim.
+         * @return The std::type_index of the Msg type which must be used.
+         */
+        std::type_index getType() const override;
+
+     protected:
+         Data *clone(ModelData *const newParent) override;
+        /**
+         * Copy constructor
+         * This is unsafe, should only be used internally, use clone() instead
+         */
+         Data(ModelData *const, const Data &other);
+        /**
+         * Normal constructor, only to be called by ModelDescription
+         */
+         Data(ModelData *const, const std::string &message_name);
+    };
+    /**
+     * User accessible interface to Array messages within mode description hierarchy
+     * @see Data
+     */
+    class Description : public MsgBruteForce::Description {
+        /**
+         * Data store class for this description, constructs instances of this class
+         */
+        friend struct Data;
+
+     protected:
+        /**
+         * Constructors
+         */
+         Description(ModelData *const _model, Data *const data);
+        /**
+         * Default copy constructor, not implemented
+         */
+         Description(const Description &other_message) = delete;
+        /**
+         * Default move constructor, not implemented
+         */
+         Description(Description &&other_message) noexcept = delete;
+        /**
+         * Default copy assignment, not implemented
+         */
+         Description& operator=(const Description &other_message) = delete;
+        /**
+         * Default move assignment, not implemented
+         */
+         Description& operator=(Description &&other_message) noexcept = delete;
+
+     public:
+         void setDimensions(const size_type &len_x, const size_type &len_y);
+         void setDimensions(const std::array<size_type, 2> &dims);
+
+        std::array<size_type, 2> getDimensions() const;
+        size_type getDimX() const;
+        size_type getDimY() const;
+    };
+};
+template<typename T, unsigned int N>
+__device__ T MsgArray2D::Message::getVariable(const char(&variable_name)[N]) const {
+    // Ensure that the message is within bounds.
+    if (index < this->_parent.metadata->length) {
+        // get the value from curve using the stored hashes and message index.
+        return Curve::getVariable<T>(variable_name, this->_parent.combined_hash, index);
+    } else {
+        // @todo - Improved error handling of out of bounds message access? Return a default value or assert?
+        return static_cast<T>(0);
+    }
+}
+template<typename T, unsigned int N>
+__device__ T MsgArray2D::In::Filter::Message::getVariable(const char(&variable_name)[N]) const {
+    // Ensure that the message is within bounds.
+    if (index_1d < this->_parent.metadata->length) {
+        // get the value from curve using the stored hashes and message index.
+        return Curve::getVariable<T>(variable_name, this->_parent.combined_hash, index_1d);
+    } else {
+        // @todo - Improved error handling of out of bounds message access? Return a default value or assert?
+        return static_cast<T>(0);
+    }
+}
+
+template<typename T, unsigned int N>
+__device__ void MsgArray2D::Out::setVariable(const char(&variable_name)[N], T value) const {  // message name or variable name
+    unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
+
+    // set the variable using curve
+    Curve::setVariable<T>(variable_name, combined_hash, value, index);
+
+    // setIndex() sets the optional msg scan flag
+}
+
+#endif  // INCLUDE_FLAMEGPU_RUNTIME_MESSAGING_ARRAY2D_H_

--- a/include/flamegpu/runtime/messaging/Array3D.h
+++ b/include/flamegpu/runtime/messaging/Array3D.h
@@ -1,0 +1,585 @@
+#ifndef INCLUDE_FLAMEGPU_RUNTIME_MESSAGING_ARRAY3D_H_
+#define INCLUDE_FLAMEGPU_RUNTIME_MESSAGING_ARRAY3D_H_
+
+#include <string>
+#include <memory>
+#include <array>
+
+#include "flamegpu/runtime/messaging/None.h"
+#include "flamegpu/runtime/messaging/BruteForce.h"
+#include "flamegpu/runtime/messaging/Array2D.h"
+#include "flamegpu/model/Variable.h"
+
+/**
+ * Array messaging functionality
+ *
+ * Like an array, each message is assigned an index within a known range
+ * Only one message may exist at each index
+ * Agent functions can access individual messages by requesting them with their index
+ * 
+ * Algorithm:
+ * Every agent outputs a message to the array based on their thread index
+ * They also set the __index variable with the intended output bin
+ * When buildIndex() is called, messages are sorted and errors (multiple messages per bin) are detected
+ */
+class MsgArray3D {
+ public:
+    /**
+     * Common size type
+     */
+    typedef MsgNone::size_type size_type;
+
+    class Message;      // Forward declare inner classes
+    class iterator;     // Forward declare inner classes
+    struct Data;        // Forward declare inner classes
+    class Description;  // Forward declare inner classes
+    /**
+     * MetaData required by brute force during message reads
+     */
+    struct MetaData {
+        /**
+         * Dimensions of array
+         */
+        size_type dimensions[3];
+        /**
+         * Total number of elements
+         */
+        size_type length;
+    };
+    /**
+     * This class is accessible via FLAMEGPU_DEVICE_API.message_in if MsgArray3D is specified in FLAMEGPU_AGENT_FUNCTION
+     * It gives access to functionality for reading array messages
+     */
+    class In {
+        /**
+         * Message has full access to In, they are treated as the same class so share everything
+         * Reduces/memory data duplication
+         */
+        friend class MsgArray3D::Message;
+
+     public:
+        /**
+         * This class is created when a search origin is provided to MsgArray2D::In::operator()(size_type, size_type, size_type = 1)
+         * It provides iterator access to a subset of the full message list, according to the provided search origin and radius
+         * 
+         * @see MsgArray2D::In::operator()(size_type, size_type, size_type)
+         */
+        class Filter {
+            /**
+             * Message has full access to Filter, they are treated as the same class so share everything
+             * Reduces/memory data duplication
+             */
+            friend class Message;
+
+         public:
+            /**
+             * Provides access to a specific message
+             * Returned by the iterator
+             * @see In::Filter::iterator
+             */
+            class Message {
+                /**
+                 * Paired Filter class which created the iterator
+                 */
+                const Filter &_parent;
+                /**
+                 * Relative position within the Moore neighbourhood
+                 * This is initialised based on user provided radius
+                 */
+                int relative_cell[3];
+                /**
+                 * Index into memory of currently pointed message
+                 */
+                size_type index_1d = 0;
+
+             public:
+                /**
+                 * Constructs a message and directly initialises all of it's member variables
+                 * @note See member variable documentation for their purposes
+                 */
+                __device__ Message(const Filter &parent, const int &relative_x, const int &relative_y, const int &relative_z)
+                    : _parent(parent) {
+                    relative_cell[0] = relative_x;
+                    relative_cell[1] = relative_y;
+                    relative_cell[2] = relative_z;
+                }
+                /**
+                 * Equality operator
+                 * Compares all internal member vars for equality
+                 * @note Does not compare _parent
+                 */
+                __device__ bool operator==(const Message& rhs) const {
+                    return this->index_1d == rhs.index_1d
+                        && this->_parent.loc[0] == rhs._parent.loc[0]
+                        && this->_parent.loc[1] == rhs._parent.loc[1]
+                        && this->_parent.loc[2] == rhs._parent.loc[2];
+                }
+                /**
+                 * Inequality operator
+                 * Returns inverse of equality operator
+                 * @see operator==(const Message&)
+                 */
+                __device__ bool operator!=(const Message& rhs) const { return !(*this == rhs); }
+                /**
+                 * Updates the message to return variables from the next cell in the Moore neighbourhood
+                 * @return Returns itself
+                 */
+                __device__ Message& operator++();
+                /**
+                 * Returns x array index of message
+                 */
+                __device__ size_type getX() const {
+                    return (this->_parent.loc[0] + relative_cell[0] + this->_parent.metadata->dimensions[0]) % this->_parent.metadata->dimensions[0];
+                }
+                /**
+                 * Returns y array index of message
+                 */
+                __device__ size_type getY() const {
+                    return (this->_parent.loc[1] + relative_cell[1] + this->_parent.metadata->dimensions[1]) % this->_parent.metadata->dimensions[1];
+                }
+                /**
+                 * Returns z array index of message
+                 */
+                __device__ size_type getZ() const {
+                    return (this->_parent.loc[2] + relative_cell[2] + this->_parent.metadata->dimensions[2]) % this->_parent.metadata->dimensions[2];
+                }
+                /**
+                 * Returns the value for the current message attached to the named variable
+                 * @param variable_name Name of the variable
+                 * @tparam T type of the variable
+                 * @tparam N Length of variable name (this should be implicit if a string literal is passed to variable name)
+                 * @return The specified variable, else 0x0 if an error occurs
+                 */
+                template<typename T, unsigned int N>
+                __device__ T getVariable(const char(&variable_name)[N]) const;
+            };
+            /**
+             * Stock iterator for iterating MsgSpatial3D::In::Filter::Message objects
+             */
+            class iterator : public std::iterator <std::random_access_iterator_tag, void, void, void, void> {
+                /**
+                 * The message returned to the user
+                 */
+                Message _message;
+
+             public:
+                /**
+                 * Constructor
+                 * This iterator is constructed by MsgArray3D::In::Filter::begin()(size_type, size_type, size_type, size_type)
+                 * @see MsgArray3D::In::Operator()(size_type, size_type, size_type, size_type)
+                 */
+                __device__ iterator(const Filter &parent, const int &relative_x, const int &relative_y, const int &relative_z)
+                    : _message(parent, relative_x, relative_y, relative_z) {
+                    // Increment to find first message
+                    ++_message;
+                }
+                /**
+                 * Moves to the next message
+                 * (Prefix increment operator)
+                 */
+                __device__ iterator& operator++() { ++_message;  return *this; }
+                /**
+                 * Moves to the next message
+                 * (Postfix increment operator, returns value prior to increment)
+                 */
+                __device__ iterator operator++(int) {
+                    iterator temp = *this;
+                    ++*this;
+                    return temp;
+                }
+                /**
+                 * Equality operator
+                 * Compares message
+                 */
+                __device__ bool operator==(const iterator& rhs) const { return  _message == rhs._message; }
+                /**
+                 * Inequality operator
+                 * Compares message
+                 */
+                __device__ bool operator!=(const iterator& rhs) const { return  _message != rhs._message; }
+                /**
+                 * Dereferences the iterator to return the message object, for accessing variables
+                 */
+                __device__ Message& operator*() { return _message; }
+                /**
+                 * Dereferences the iterator to return the message object, for accessing variables
+                 */
+                __device__ Message* operator->() { return &_message; }
+            };
+            /**
+             * Constructor, takes the search parameters requried
+             * @param _metadata Pointer to message list metadata
+             * @param _combined_hash agentfn+message hash for accessing message data
+             * @param x Search origin x coord
+             * @param y Search origin y coord
+             * @param z Search origin z coord
+             * @param _radius Search radius
+             */
+            __device__ Filter(const MetaData *_metadata, const Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &y, const size_type &z, const size_type &_radius);
+            /**
+             * Returns an iterator to the start of the message list subset about the search origin
+             */
+            inline __device__ iterator begin(void) const {
+                // Bin before initial bin, as the constructor calls increment operator
+                return iterator(*this, -radius, -radius, -radius-1);
+            }
+            /**
+             * Returns an iterator to the position beyond the end of the message list subset
+             * @note This iterator is the same for all message list subsets
+             */
+            inline __device__ iterator end(void) const {
+                // Final bin, as the constructor calls increment operator
+                return iterator(*this, radius, radius, radius);
+            }
+
+         private:
+            /**
+             * Search origin
+             */
+            size_type loc[3];
+            /**
+             * Search radius
+             */
+            const size_type radius;
+            /**
+             * Pointer to message list metadata, e.g. environment bounds, search radius, PBM location
+             */
+            const MetaData *metadata;
+            /**
+             * CURVE hash for accessing message data
+             * agent function hash + message hash
+             */
+            Curve::NamespaceHash combined_hash;
+        };
+        /**
+         * Constructer
+         * Initialises member variables
+         * @param agentfn_hash Added to msg_hash to produce combined_hash
+         * @param msg_hash Added to agentfn_hash to produce combined_hash
+         * @param _metadata Reinterpreted as type MsgArray3D::MetaData
+         */
+        __device__ In(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *_metadata)
+            : combined_hash(agentfn_hash + msg_hash)
+            , metadata(reinterpret_cast<const MetaData*>(_metadata))
+        { }
+        /**
+         * Returns a Filter object which provides access to message iterator
+         * for iterating a subset of messages including those within the radius of the search origin
+         * this excludes the message at the search origin
+         *
+         * @param x Search origin x coord
+         * @param y Search origin y coord
+         * @param z Search origin y coord
+         * @param radius Search radius
+         * @note radius 1 is 26 cells in 3x3x3
+         * @note radius 2 is 124 cells in 5x5x5
+         * @note If radius is >= half of the array dimensions, cells will be doubly read
+         * @note radius of 0 is unsupported
+         */
+        inline __device__ Filter operator() (const size_type &x, const size_type &y, const size_type &z, const size_type &radius = 1) const {
+            assert(radius > 0);  // Radius of 0 is bad
+            return Filter(metadata, combined_hash, x, y, z, radius);
+        }
+        /**
+         * Returns the x dimension size of the message list
+         */
+        __device__ size_type getDimX() const {
+            return metadata->dimensions[0];
+        }
+        /**
+         * Returns the y dimension size of the message list
+         */
+        __device__ size_type getDimY() const {
+            return metadata->dimensions[1];
+        }
+        /**
+         * Returns the z dimension size of the message list
+         */
+        __device__ size_type getDimZ() const {
+            return metadata->dimensions[2];
+        }
+        /**
+         * Returns the length of the message list.
+         * xDim x yDim x zDim
+         */
+        __device__ size_type size(void) const {
+            return metadata->length;
+        }
+        __device__ Message at(const size_type &x, const size_type &y, const size_type &z) const {
+            const size_type index_1d =
+                z * metadata->dimensions[0] * metadata->dimensions[1]  +
+                y * metadata->dimensions[0]  +
+                x;
+            return Message(*this, index_1d);
+        }
+
+     private:
+         /**
+          * CURVE hash for accessing message data
+          * agent function hash + message hash
+          */
+        Curve::NamespaceHash combined_hash;
+        /**
+         * Metadata struct for accessing messages
+         */
+        const MetaData * const metadata;
+    };
+    /**
+     * Provides access to a specific message
+     * Returned by In::at(size_type)
+     * @see In::at(size_type)
+     */
+    class Message {
+         /**
+          * Paired In class which created the iterator
+          */
+        const MsgArray3D::In &_parent;
+        /**
+         * Position within the message list
+         */
+        size_type index;
+
+     public:
+        /**
+         * Constructs a message and directly initialises all of it's member variables
+         * index is always init to 0
+         * @note See member variable documentation for their purposes
+         */
+        __device__ Message(const MsgArray3D::In &parent, const size_type &_index) : _parent(parent), index(_index) {}
+        /**
+         * Equality operator
+         * Compares all internal member vars for equality
+         * @note Does not compare _parent
+         */
+        __device__ bool operator==(const Message& rhs) const { return  this->index == rhs.index; }
+        /**
+         * Inequality operator
+         * Returns inverse of equality operator
+         * @see operator==(const Message&)
+         */
+        __device__ bool operator!=(const Message& rhs) const { return  this->index != rhs.index; }
+        /**
+         * Returns the index of the message within the full message list
+         */
+        __device__ size_type getIndex() const { return this->index; }
+        /**
+         * Returns the value for the current message attached to the named variable
+         * @param variable_name Name of the variable
+         * @tparam T type of the variable
+         * @tparam N Length of variable name (this should be implicit if a string literal is passed to variable name)
+         * @return The specified variable, else 0x0 if an error occurs
+         */
+        template<typename T, size_type N>
+        __device__ T getVariable(const char(&variable_name)[N]) const;
+    };
+    /**
+     * This class is accessible via FLAMEGPU_DEVICE_API.message_out if MsgArray3D is specified in FLAMEGPU_AGENT_FUNCTION
+     * It gives access to functionality for outputting array messages
+     */
+    class Out {
+     public:
+        /**
+         * Constructer
+         * Initialises member variables
+         * @param agentfn_hash Added to msg_hash to produce combined_hash
+         * @param msg_hash Added to agentfn_hash to produce combined_hash
+         * @param _streamId Stream index, used for optional message output flag array
+         */
+        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *_metadata, unsigned int _streamId)
+            : combined_hash(agentfn_hash + msg_hash)
+            , streamId(_streamId)
+            , metadata(reinterpret_cast<const MetaData*>(_metadata))
+        { }
+        /**
+         * Sets the array index to store the message in
+         */
+        __device__ void setIndex(const size_type &x, const size_type &y, const size_type &z) const;
+        /**
+         * Sets the specified variable for this agents message
+         * @param variable_name Name of the variable
+         * @tparam T type of the variable
+         * @tparam N Length of variable name (this should be implicit if a string literal is passed to variable name)
+         * @return The specified variable, else 0x0 if an error occurs
+         */
+        template<typename T, unsigned int N>
+        __device__ void setVariable(const char(&variable_name)[N], T value) const;
+
+     protected:
+        /**
+         * CURVE hash for accessing message data
+         * agentfn_hash + msg_hash
+         */
+        Curve::NamespaceHash combined_hash;
+        /**
+         * Stream index used for setting optional message output flag
+         */
+        unsigned int streamId;
+        /**
+         * Metadata struct for accessing messages
+         */
+        const MetaData * const metadata;
+    };
+    /**
+     * Blank handler, brute force requires no index or special allocations
+     * Only stores the length on device
+     */
+    class CUDAModelHandler : public MsgSpecialisationHandler {
+     public:
+        /**
+         * Constructor
+         * Allocates memory on device for message list length
+         * @param a Parent CUDAMessage, used to access message settings, data ptrs etc
+         */
+         explicit CUDAModelHandler(CUDAMessage &a);
+        /** 
+         * Destructor.
+         * Should free any local host memory (device memory cannot be freed in destructors)
+         */
+        ~CUDAModelHandler() { }
+        /**
+         * Sort messages according to index
+         * Detect and report any duplicate indicies/gaps
+         */
+        void buildIndex() override;
+        /**
+         * Allocates memory for the constructed index.
+         * The memory allocation is checked by build index.
+         */
+        void allocateMetaDataDevicePtr() override;
+        /**
+         * Releases memory for the constructed index.
+         */
+        void freeMetaDataDevicePtr() override;
+        /**
+         * Returns a pointer to the metadata struct, this is required for reading the message data
+         */
+        const void *getMetaDataDevicePtr() const override { return d_metadata; }
+
+     private:
+        /**
+         * Host copy of metadata struct (message list length)
+         */
+        MetaData hd_metadata;
+        /**
+         * Pointer to device copy of metadata struct (message list length)
+         */
+        MetaData *d_metadata;
+        /**
+         * Owning CUDAMessage, provides access to message storage etc
+         */
+        CUDAMessage &sim_message;
+        /**
+         * Buffer used by buildIndex if array length > agent count
+         */
+        unsigned int *d_write_flag;
+        /**
+         * Allocated length of d_write_flag (in number of uint, not bytes)
+         */
+        size_type d_write_flag_len;
+    };
+    /**
+     * Internal data representation of Array messages within model description hierarchy
+     * @see Description
+     */
+    struct Data : public MsgBruteForce::Data {
+        friend class ModelDescription;
+        friend struct ModelData;
+        std::array<size_type, 3> dimensions;
+        virtual ~Data() = default;
+
+        std::unique_ptr<MsgSpecialisationHandler> getSpecialisationHander(CUDAMessage &owner) const override;
+
+        /**
+         * Used internally to validate that the corresponding Msg type is attached via the agent function shim.
+         * @return The std::type_index of the Msg type which must be used.
+         */
+        std::type_index getType() const override;
+
+     protected:
+         Data *clone(ModelData *const newParent) override;
+        /**
+         * Copy constructor
+         * This is unsafe, should only be used internally, use clone() instead
+         */
+         Data(ModelData *const, const Data &other);
+        /**
+         * Normal constructor, only to be called by ModelDescription
+         */
+         Data(ModelData *const, const std::string &message_name);
+    };
+    /**
+     * User accessible interface to Array messages within mode description hierarchy
+     * @see Data
+     */
+    class Description : public MsgBruteForce::Description {
+        /**
+         * Data store class for this description, constructs instances of this class
+         */
+        friend struct Data;
+
+     protected:
+        /**
+         * Constructors
+         */
+         Description(ModelData *const _model, Data *const data);
+        /**
+         * Default copy constructor, not implemented
+         */
+         Description(const Description &other_message) = delete;
+        /**
+         * Default move constructor, not implemented
+         */
+         Description(Description &&other_message) noexcept = delete;
+        /**
+         * Default copy assignment, not implemented
+         */
+         Description& operator=(const Description &other_message) = delete;
+        /**
+         * Default move assignment, not implemented
+         */
+         Description& operator=(Description &&other_message) noexcept = delete;
+
+     public:
+        void setDimensions(const size_type &len_x, const size_type &len_y, const size_type &len_Z);
+        void setDimensions(const std::array<size_type, 3> &dims);
+
+        std::array<size_type, 3> getDimensions() const;
+        size_type getDimX() const;
+        size_type getDimY() const;
+        size_type getDimZ() const;
+    };
+};
+template<typename T, unsigned int N>
+__device__ T MsgArray3D::Message::getVariable(const char(&variable_name)[N]) const {
+    // Ensure that the message is within bounds.
+    if (index < this->_parent.metadata->length) {
+        // get the value from curve using the stored hashes and message index.
+        return Curve::getVariable<T>(variable_name, this->_parent.combined_hash, index);
+    } else {
+        // @todo - Improved error handling of out of bounds message access? Return a default value or assert?
+        return static_cast<T>(0);
+    }
+}
+template<typename T, unsigned int N>
+__device__ T MsgArray3D::In::Filter::Message::getVariable(const char(&variable_name)[N]) const {
+    // Ensure that the message is within bounds.
+    if (index_1d < this->_parent.metadata->length) {
+        // get the value from curve using the stored hashes and message index.
+        return Curve::getVariable<T>(variable_name, this->_parent.combined_hash, index_1d);
+    } else {
+        // @todo - Improved error handling of out of bounds message access? Return a default value or assert?
+        return static_cast<T>(0);
+    }
+}
+
+template<typename T, unsigned int N>
+__device__ void MsgArray3D::Out::setVariable(const char(&variable_name)[N], T value) const {  // message name or variable name
+    unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
+
+    // set the variable using curve
+    Curve::setVariable<T>(variable_name, combined_hash, value, index);
+
+    // setIndex() sets the optional msg scan flag
+}
+
+#endif  // INCLUDE_FLAMEGPU_RUNTIME_MESSAGING_ARRAY3D_H_

--- a/include/flamegpu/runtime/messaging/BruteForce.h
+++ b/include/flamegpu/runtime/messaging/BruteForce.h
@@ -201,7 +201,7 @@ class MsgBruteForce {
          * @param msg_hash Added to agentfn_hash to produce combined_hash
          * @param _streamId Stream index, used for optional message output flag array
          */
-        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, unsigned int _streamId)
+        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *, unsigned int _streamId)
             : combined_hash(agentfn_hash + msg_hash)
             , streamId(_streamId)
         { }
@@ -403,11 +403,9 @@ class MsgBruteForce {
          * Adds a new variable to the message
          * @param variable_name Name of the variable
          * @tparam T Type of the message variable, this must be an arithmetic type
-         * @tparam N The length of the variable array (1 if not an array, must be greater than 0)
-         * @throws InvalidAgentVar If a variable already exists within the message with the same name
-         * @throws InvalidAgentVar If N is <= 0
+         * @throws InvalidMessageVar If a variable already exists within the message with the same name
          */
-        template<typename T, size_type N = 1>
+        template<typename T>
         void newVariable(const std::string &variable_name);
 
         /**
@@ -426,12 +424,6 @@ class MsgBruteForce {
          * @throws InvalidAgentVar If a variable with the name does not exist within the message
          */
         size_t getVariableSize(const std::string &variable_name) const;
-        /**
-         * @param variable_name Name used to refer to the desired variable
-         * @return The number of elements in the name variable (1 if it isn't an array)
-         * @throws InvalidAgentVar If a variable with the name does not exist within the message
-         */
-        size_type getVariableLength(const std::string &variable_name) const;
         /**
          * @return The total number of variables within the message
          */
@@ -487,12 +479,10 @@ __device__ void MsgBruteForce::Out::setVariable(const char(&variable_name)[N], T
 /**
  * Template implementation
  */
-template<typename T, MsgBruteForce::size_type N>
+template<typename T>
 void MsgBruteForce::Description::newVariable(const std::string &variable_name) {
-    // Array length 0 makes no sense
-    static_assert(N > 0, "A variable cannot have 0 elements.");
     if (message->variables.find(variable_name) == message->variables.end()) {
-        message->variables.emplace(variable_name, Variable(N, T()));
+        message->variables.emplace(variable_name, Variable(1, T()));
         return;
     }
     THROW InvalidMessageVar("Message ('%s') already contains variable '%s', "

--- a/include/flamegpu/runtime/messaging/None.h
+++ b/include/flamegpu/runtime/messaging/None.h
@@ -77,7 +77,7 @@ class MsgNone {
          * Requires CURVE hashes for agent function and message name to retrieve variable memory locations
          * Takes a device pointer to a struct for metadata related to accessing the messages (e.g. an index data structure)
          */
-        __device__ Out(Curve::NamespaceHash /*agent fn hash*/, Curve::NamespaceHash /*message name hash*/, unsigned int /*streamid*/){
+        __device__ Out(Curve::NamespaceHash /*agent fn hash*/, Curve::NamespaceHash /*message name hash*/, const void * /*metadata*/, unsigned int /*streamid*/){
         }
     };
     /**

--- a/include/flamegpu/runtime/messaging/Spatial2D.h
+++ b/include/flamegpu/runtime/messaging/Spatial2D.h
@@ -182,8 +182,18 @@ class MsgSpatial2D {
                 }
                 /**
                  * Moves to the next message
+                 * (Prefix increment operator)
                  */
                 __device__ iterator& operator++() { ++_message;  return *this; }
+                /**
+                 * Moves to the next message
+                 * (Postfix increment operator, returns value prior to increment)
+                 */
+                __device__ iterator operator++(int) {
+                    iterator temp = *this;
+                    ++*this;
+                    return temp;
+                }
                 /**
                  * Equality operator
                  * Compares message
@@ -198,6 +208,10 @@ class MsgSpatial2D {
                  * Dereferences the iterator to return the message object, for accessing variables
                  */
                 __device__ Message& operator*() { return _message; }
+                /**
+                 * Dereferences the iterator to return the message object, for accessing variables
+                 */
+                __device__ Message* operator->() { return &_message; }
             };
             /**
              * Constructor, takes the search parameters requried
@@ -297,8 +311,8 @@ class MsgSpatial2D {
          * @param msg_hash Added to agentfn_hash to produce combined_hash
          * @param _streamId Stream index, used for optional message output flag array
          */
-        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, unsigned int _streamId)
-            : MsgBruteForce::Out(agentfn_hash, msg_hash, _streamId)
+        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *, unsigned int _streamId)
+            : MsgBruteForce::Out(agentfn_hash, msg_hash, nullptr, _streamId)
         { }
         /**
          * Sets the location for this agents message
@@ -474,12 +488,6 @@ class MsgSpatial2D {
         void setMaxX(const float &x);
         void setMaxY(const float &y);
         void setMax(const float &x, const float &y);
-
-        float &Radius();
-        float &MinX();
-        float &MinY();
-        float &MaxX();
-        float &MaxY();
 
         float getRadius() const;
         float getMinX() const;

--- a/include/flamegpu/runtime/messaging/Spatial3D.h
+++ b/include/flamegpu/runtime/messaging/Spatial3D.h
@@ -191,8 +191,18 @@ class MsgSpatial3D {
                 }
                 /**
                  * Moves to the next message
+                 * (Prefix increment operator)
                  */
                 __device__ iterator& operator++() { ++_message;  return *this; }
+                /**
+                 * Moves to the next message
+                 * (Postfix increment operator, returns value prior to increment)
+                 */
+                __device__ iterator operator++(int) {
+                    iterator temp = *this;
+                    ++*this;
+                    return temp;
+                }
                 /**
                  * Equality operator
                  * Compares message
@@ -207,6 +217,10 @@ class MsgSpatial3D {
                  * Dereferences the iterator to return the message object, for accessing variables
                  */
                 __device__ Message& operator*() { return _message; }
+                /**
+                 * Dereferences the iterator to return the message object, for accessing variables
+                 */
+                __device__ Message* operator->() { return &_message; }
             };
             /**
              * Constructor, takes the search parameters requried
@@ -309,8 +323,8 @@ class MsgSpatial3D {
          * @param msg_hash Added to agentfn_hash to produce combined_hash
          * @param _streamId Stream index, used for optional message output flag array
          */
-        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, unsigned int _streamId)
-            : MsgBruteForce::Out(agentfn_hash, msg_hash, _streamId)
+        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *, unsigned int _streamId)
+            : MsgBruteForce::Out(agentfn_hash, msg_hash, nullptr, _streamId)
         { }
         /**
          * Sets the location for this agents message
@@ -506,13 +520,6 @@ class MsgSpatial3D {
         void setMaxZ(const float &z);
         void setMax(const float &x, const float &y, const float &z);
 
-        float &Radius();
-        float &MinX();
-        float &MinY();
-        float &MinZ();
-        float &MaxX();
-        float &MaxY();
-        float &MaxZ();
         float getRadius() const;
         float getMinX() const;
         float getMinY() const;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,6 +100,9 @@ SET(SRC_INCLUDE
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/messaging/BruteForce.h
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/messaging/Spatial2D.h
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/messaging/Spatial3D.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/runtime/messaging/Array.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/runtime/messaging/Array2D.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/runtime/messaging/Array3D.h
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/utility/AgentRandom.cuh
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/utility/DeviceEnvironment.cuh
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/utility/EnvironmentManager.cuh
@@ -133,6 +136,9 @@ SET(SRC_FLAMEGPU2
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/messaging/BruteForce.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/messaging/Spatial2D.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/messaging/Spatial3D.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/runtime/messaging/Array.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/runtime/messaging/Array2D.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/runtime/messaging/Array3D.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/io/xmlReader.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/io/xmlWriter.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/utility/HostEnvironment.cu

--- a/src/flamegpu/pop/AgentPopulation.cu
+++ b/src/flamegpu/pop/AgentPopulation.cu
@@ -87,8 +87,16 @@ AgentStateMemory& AgentPopulation::getStateMemory(const std::string agent_state)
 }
 
 /* this is the current size */
-unsigned int AgentPopulation::getCurrentListSize(const std::string agent_state) {
-    return getStateMemory(agent_state).getStateListSize();
+unsigned int AgentPopulation::getCurrentListSize(const std::string agent_state) const {
+    // check if the state map exists
+    AgentStatesMap::const_iterator iter = states_map.find(agent_state);
+
+    if (iter == states_map.end()) {
+        THROW InvalidStateName("Agent ('%s') state name ('%s') was not found, "
+            "in AgentPopulation::getCurrentListSize().",
+            agent->name.c_str(), agent_state.c_str());
+    }
+    return iter->second->getStateListSize();
 }
 
 const AgentStateMemory& AgentPopulation::getReadOnlyStateMemory(const std::string agent_state) const {

--- a/src/flamegpu/runtime/messaging/Array.cu
+++ b/src/flamegpu/runtime/messaging/Array.cu
@@ -1,0 +1,141 @@
+#include "flamegpu/runtime/messaging/Array.h"
+#include "flamegpu/model/AgentDescription.h"  // Used by Move-Assign
+#include "flamegpu/gpu/CUDAMessage.h"
+#include "flamegpu/gpu/CUDAScatter.h"
+
+/**
+* Sets the array index to store the message in
+*/
+__device__ void MsgArray::Out::setIndex(const size_type &id) const {
+    unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
+
+    // Todo: checking if the output message type is single or optional?  (d_message_type)
+
+    // set the variable using curve
+    Curve::setVariable<size_type>("___INDEX", combined_hash, id, index);
+
+    // Set scan flag incase the message is optional
+    flamegpu_internal::CUDAScanCompaction::ds_configs[flamegpu_internal::CUDAScanCompaction::MESSAGE_OUTPUT][streamId].scan_flag[index] = 1;
+}
+__device__ MsgArray::In::Filter::Filter(const size_type &_length, const Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &_radius)
+    : radius(_radius)
+    , length(_length)
+    , combined_hash(_combined_hash) {
+    loc = x;
+}
+__device__ MsgArray::In::Filter::Message& MsgArray::In::Filter::Message::operator++() {
+    relative_cell++;
+    // Skip origin cell
+    if (relative_cell == 0) {
+        relative_cell++;
+    }
+    // Wrap over boundaries
+    index_1d = (this->_parent.loc + relative_cell + this->_parent.length) % this->_parent.length;
+    return *this;
+}
+/**
+ * Constructor
+ * Allocates memory on device for message list length
+ * @param a Parent CUDAMessage, used to access message settings, data ptrs etc
+ */
+MsgArray::CUDAModelHandler::CUDAModelHandler(CUDAMessage &a)
+    : MsgSpecialisationHandler()
+    , d_metadata(nullptr)
+    , sim_message(a)
+    , d_write_flag(nullptr)
+    , d_write_flag_len(0) {
+    const Data& d = static_cast<const Data &>(a.getMessageDescription());
+    hd_metadata.length = d.length;
+}
+
+void MsgArray::CUDAModelHandler::allocateMetaDataDevicePtr() {
+    if (d_metadata == nullptr) {
+        gpuErrchk(cudaMalloc(&d_metadata, sizeof(MetaData)));
+        gpuErrchk(cudaMemcpy(d_metadata, &hd_metadata, sizeof(MetaData), cudaMemcpyHostToDevice));
+    }
+}
+
+void MsgArray::CUDAModelHandler::freeMetaDataDevicePtr() {
+    if (d_metadata != nullptr) {
+        gpuErrchk(cudaFree(d_metadata));
+    }
+    d_metadata = nullptr;
+
+    if (d_write_flag) {
+        gpuErrchk(cudaFree(d_write_flag));
+    }
+    d_write_flag = nullptr;
+    d_write_flag_len = 0;
+}
+void MsgArray::CUDAModelHandler::buildIndex() {
+    const unsigned int MESSAGE_COUNT = this->sim_message.getMessageCount();
+    // Zero the output arrays
+    auto &read_list = this->sim_message.getReadList();
+    auto &write_list = this->sim_message.getWriteList();
+    for (auto &var : this->sim_message.getMessageDescription().variables) {
+        // Elements is harmless, futureproof for arrays support
+        // hd_metadata.length is used, as message array can be longer than message count
+        gpuErrchk(cudaMemset(write_list.at(var.first), 0, var.second.type_size * var.second.elements * hd_metadata.length));
+    }
+
+    // Reorder messages
+    unsigned int *t_d_write_flag = nullptr;
+    if (MESSAGE_COUNT > hd_metadata.length) {
+        // Use internal memory for d_write_flag
+        if (d_write_flag_len < MESSAGE_COUNT) {
+            // Increase length
+            if (d_write_flag) {
+                gpuErrchk(cudaFree(d_write_flag));
+            }
+            d_write_flag_len = static_cast<unsigned int>(MESSAGE_COUNT * 1.1f);
+            gpuErrchk(cudaMalloc(&d_write_flag, sizeof(unsigned int) * d_write_flag_len));
+        }
+        t_d_write_flag = d_write_flag;
+    }
+    auto &cs = CUDAScatter::getInstance(0);  // Choose proper stream_id in future!d
+    cs.arrayMessageReorder(this->sim_message.getMessageDescription().variables, read_list, write_list, MESSAGE_COUNT, hd_metadata.length, t_d_write_flag);
+    this->sim_message.swap();
+    // Reset message count back to full array length
+    // Array message exposes not output messages as 0
+    if (MESSAGE_COUNT != hd_metadata.length)
+        this->sim_message.setMessageCount(hd_metadata.length);
+    // Detect errors
+    // TODO
+}
+
+
+MsgArray::Data::Data(ModelData *const model, const std::string &message_name)
+    : MsgBruteForce::Data(model, message_name)
+    , length(0) {
+    description = std::unique_ptr<MsgArray::Description>(new MsgArray::Description(model, this));
+    description->newVariable<size_type>("___INDEX");
+}
+MsgArray::Data::Data(ModelData *const model, const Data &other)
+    : MsgBruteForce::Data(model, other)
+    , length(other.length) {
+    description = std::unique_ptr<MsgArray::Description>(model ? new MsgArray::Description(model, this) : nullptr);
+    if (length == 0) {
+        THROW InvalidMessage("Length must not be zero in array message '%s'\n", other.name.c_str());
+    }
+}
+MsgArray::Data *MsgArray::Data::clone(ModelData *const newParent) {
+    return new Data(newParent, *this);
+}
+std::unique_ptr<MsgSpecialisationHandler> MsgArray::Data::getSpecialisationHander(CUDAMessage &owner) const {
+    return std::unique_ptr<MsgSpecialisationHandler>(new CUDAModelHandler(owner));
+}
+std::type_index MsgArray::Data::getType() const { return std::type_index(typeid(MsgArray)); }
+
+
+MsgArray::Description::Description(ModelData *const _model, Data *const data)
+    : MsgBruteForce::Description(_model, data) { }
+
+void MsgArray::Description::setLength(const size_type &len) {
+    if (len == 0) {
+        THROW InvalidArgument("Array messaging length must not be zero.\n");
+    }
+    reinterpret_cast<Data *>(message)->length = len;
+}
+MsgArray::size_type MsgArray::Description::getLength() const {
+    return reinterpret_cast<Data *>(message)->length;
+}

--- a/src/flamegpu/runtime/messaging/Array2D.cu
+++ b/src/flamegpu/runtime/messaging/Array2D.cu
@@ -1,0 +1,165 @@
+#include "flamegpu/runtime/messaging/Array2D.h"
+#include "flamegpu/model/AgentDescription.h"  // Used by Move-Assign
+#include "flamegpu/gpu/CUDAMessage.h"
+#include "flamegpu/gpu/CUDAScatter.h"
+
+/**
+* Sets the array index to store the message in
+*/
+__device__ void MsgArray2D::Out::setIndex(const size_type &x, const size_type &y) const {
+        unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
+        size_type index_1d =
+            y * metadata->dimensions[0] +
+            x;
+        if (x >= metadata->dimensions[0] ||
+            y >= metadata->dimensions[1]) {
+            index_1d = metadata->length;  // Put message in invalid bin, will be caught during sort
+        }
+        // set the variable using curve
+        Curve::setVariable<size_type>("___INDEX", combined_hash, index_1d, index);
+
+        // Set scan flag incase the message is optional
+        flamegpu_internal::CUDAScanCompaction::ds_configs[flamegpu_internal::CUDAScanCompaction::MESSAGE_OUTPUT][streamId].scan_flag[index] = 1;
+}
+__device__ MsgArray2D::In::Filter::Filter(const MetaData *_metadata, const Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &y, const size_type &_radius)
+    : radius(_radius)
+    , metadata(_metadata)
+    , combined_hash(_combined_hash) {
+    loc[0] = x;
+    loc[1] = y;
+}
+__device__ MsgArray2D::In::Filter::Message& MsgArray2D::In::Filter::Message::operator++() {
+    if (relative_cell[1] >= static_cast<int>(_parent.radius)) {
+        relative_cell[1] = -_parent.radius;
+        relative_cell[0]++;
+    } else {
+        relative_cell[1]++;
+    }
+    // Skip origin cell
+    if (relative_cell[0] == 0 && relative_cell[1] == 0) {
+        relative_cell[1]++;
+    }
+    // Wrap over boundaries
+    const unsigned int their_x = (this->_parent.loc[0] + relative_cell[0] + this->_parent.metadata->dimensions[0]) % this->_parent.metadata->dimensions[0];
+    const unsigned int their_y = (this->_parent.loc[1] + relative_cell[1] + this->_parent.metadata->dimensions[1]) % this->_parent.metadata->dimensions[1];
+    // Solve to 1 dimensional bin index
+    index_1d = their_y * this->_parent.metadata->dimensions[0] +
+        their_x;
+    return *this;
+}
+/**
+ * Constructor
+ * Allocates memory on device for message list length
+ * @param a Parent CUDAMessage, used to access message settings, data ptrs etc
+ */
+MsgArray2D::CUDAModelHandler::CUDAModelHandler(CUDAMessage &a)
+    : MsgSpecialisationHandler()
+    , d_metadata(nullptr)
+    , sim_message(a)
+    , d_write_flag(nullptr)
+    , d_write_flag_len(0) {
+    const Data& d = static_cast<const Data &>(a.getMessageDescription());
+    memcpy(&hd_metadata.dimensions, d.dimensions.data(), d.dimensions.size() * sizeof(unsigned int));
+    hd_metadata.length = d.dimensions[0] * d.dimensions[1];
+}
+
+void MsgArray2D::CUDAModelHandler::allocateMetaDataDevicePtr() {
+    if (d_metadata == nullptr) {
+        gpuErrchk(cudaMalloc(&d_metadata, sizeof(MetaData)));
+        gpuErrchk(cudaMemcpy(d_metadata, &hd_metadata, sizeof(MetaData), cudaMemcpyHostToDevice));
+    }
+}
+
+void MsgArray2D::CUDAModelHandler::freeMetaDataDevicePtr() {
+    if (d_metadata != nullptr) {
+        gpuErrchk(cudaFree(d_metadata));
+    }
+    d_metadata = nullptr;
+
+    if (d_write_flag) {
+        gpuErrchk(cudaFree(d_write_flag));
+    }
+    d_write_flag = nullptr;
+    d_write_flag_len = 0;
+}
+void MsgArray2D::CUDAModelHandler::buildIndex() {
+    const unsigned int MESSAGE_COUNT = this->sim_message.getMessageCount();
+    // Zero the output arrays
+    auto &read_list = this->sim_message.getReadList();
+    auto &write_list = this->sim_message.getWriteList();
+    for (auto &var : this->sim_message.getMessageDescription().variables) {
+        // Elements is harmless, futureproof for arrays support
+        // hd_metadata.length is used, as message array can be longer than message count
+        gpuErrchk(cudaMemset(write_list.at(var.first), 0, var.second.type_size * var.second.elements * hd_metadata.length));
+    }
+
+    // Reorder messages
+    unsigned int *t_d_write_flag = nullptr;
+    if (MESSAGE_COUNT > hd_metadata.length) {
+        // Use internal memory for d_write_flag
+        if (d_write_flag_len < MESSAGE_COUNT) {
+            // Increase length
+            if (d_write_flag) {
+                gpuErrchk(cudaFree(d_write_flag));
+            }
+            d_write_flag_len = static_cast<unsigned int>(MESSAGE_COUNT * 1.1f);
+            gpuErrchk(cudaMalloc(&d_write_flag, sizeof(unsigned int) * d_write_flag_len));
+        }
+        t_d_write_flag = d_write_flag;
+    }
+    auto &cs = CUDAScatter::getInstance(0);  // Choose proper stream_id in future!d
+    cs.arrayMessageReorder(this->sim_message.getMessageDescription().variables, read_list, write_list, MESSAGE_COUNT, hd_metadata.length, t_d_write_flag);
+    this->sim_message.swap();
+    // Reset message count back to full array length
+    // Array message exposes not output messages as 0
+    if (MESSAGE_COUNT != hd_metadata.length)
+        this->sim_message.setMessageCount(hd_metadata.length);
+    // Detect errors
+    // TODO
+}
+
+
+MsgArray2D::Data::Data(ModelData *const model, const std::string &message_name)
+    : MsgBruteForce::Data(model, message_name)
+    , dimensions({ 0, 0 }) {
+    description = std::unique_ptr<MsgArray2D::Description>(new MsgArray2D::Description(model, this));
+    description->newVariable<size_type>("___INDEX");
+}
+MsgArray2D::Data::Data(ModelData *const model, const Data &other)
+    : MsgBruteForce::Data(model, other)
+    , dimensions(other.dimensions) {
+    description = std::unique_ptr<MsgArray2D::Description>(model ? new MsgArray2D::Description(model, this) : nullptr);
+    if (dimensions[0] == 0 || dimensions[1] == 0) {
+        THROW InvalidMessage("All dimensions must be ABOVE zero in array2D message '%s'\n", other.name.c_str());
+    }
+}
+MsgArray2D::Data *MsgArray2D::Data::clone(ModelData *const newParent) {
+    return new Data(newParent, *this);
+}
+std::unique_ptr<MsgSpecialisationHandler> MsgArray2D::Data::getSpecialisationHander(CUDAMessage &owner) const {
+    return std::unique_ptr<MsgSpecialisationHandler>(new CUDAModelHandler(owner));
+}
+std::type_index MsgArray2D::Data::getType() const { return std::type_index(typeid(MsgArray2D)); }
+
+
+MsgArray2D::Description::Description(ModelData *const _model, Data *const data)
+    : MsgBruteForce::Description(_model, data) { }
+
+void MsgArray2D::Description::setDimensions(const size_type& len_x, const size_type& len_y) {
+    setDimensions({ len_x , len_y });
+}
+void MsgArray2D::Description::setDimensions(const std::array<size_type, 2> &dims) {
+    if (dims[0] == 0 || dims[1] == 0) {
+        THROW InvalidArgument("All dimensions must be above zero in array2D message.\n");
+    }
+    reinterpret_cast<Data *>(message)->dimensions = dims;
+}
+std::array<MsgArray2D::size_type, 2> MsgArray2D::Description::getDimensions() const {
+    return reinterpret_cast<Data *>(message)->dimensions;
+}
+MsgArray2D::size_type MsgArray2D::Description::getDimX() const {
+    return reinterpret_cast<Data *>(message)->dimensions[0];
+}
+MsgArray2D::size_type MsgArray2D::Description::getDimY() const {
+    return reinterpret_cast<Data *>(message)->dimensions[1];
+}

--- a/src/flamegpu/runtime/messaging/Array3D.cu
+++ b/src/flamegpu/runtime/messaging/Array3D.cu
@@ -1,0 +1,180 @@
+#include "flamegpu/runtime/messaging/Array3D.h"
+#include "flamegpu/model/AgentDescription.h"  // Used by Move-Assign
+#include "flamegpu/gpu/CUDAMessage.h"
+#include "flamegpu/gpu/CUDAScatter.h"
+
+/**
+* Sets the array index to store the message in
+*/
+__device__ void MsgArray3D::Out::setIndex(const size_type &x, const size_type &y, const size_type &z) const {
+    unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
+    size_type index_1d =
+        z * metadata->dimensions[0] * metadata->dimensions[1] +
+        y * metadata->dimensions[0] +
+        x;
+    if (x >= metadata->dimensions[0] ||
+        y >= metadata->dimensions[1] ||
+        z >= metadata->dimensions[2]) {
+        index_1d = metadata->length;  // Put message in invalid bin, will be caught during sort
+    }
+
+    // set the variable using curve
+    Curve::setVariable<size_type>("___INDEX", combined_hash, index_1d, index);
+
+    // Set scan flag incase the message is optional
+    flamegpu_internal::CUDAScanCompaction::ds_configs[flamegpu_internal::CUDAScanCompaction::MESSAGE_OUTPUT][streamId].scan_flag[index] = 1;
+}
+__device__ MsgArray3D::In::Filter::Filter(const MetaData *_metadata, const Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &y, const size_type &z, const size_type &_radius)
+    : radius(_radius)
+    , metadata(_metadata)
+    , combined_hash(_combined_hash) {
+    loc[0] = x;
+    loc[1] = y;
+    loc[2] = z;
+}
+__device__ MsgArray3D::In::Filter::Message& MsgArray3D::In::Filter::Message::operator++() {
+    if (relative_cell[2] >= static_cast<int>(_parent.radius)) {
+        relative_cell[2] = -_parent.radius;
+        if (relative_cell[1] >= static_cast<int>(_parent.radius)) {
+            relative_cell[1] = -_parent.radius;
+            relative_cell[0]++;
+        } else {
+            relative_cell[1]++;
+        }
+    } else {
+        relative_cell[2]++;
+    }
+    // Skip origin cell
+    if (relative_cell[0] == 0 && relative_cell[1] == 0 && relative_cell[2] == 0) {
+        relative_cell[2]++;
+    }
+    // Wrap over boundaries
+    const unsigned int their_x = (this->_parent.loc[0] + relative_cell[0] + this->_parent.metadata->dimensions[0]) % this->_parent.metadata->dimensions[0];
+    const unsigned int their_y = (this->_parent.loc[1] + relative_cell[1] + this->_parent.metadata->dimensions[1]) % this->_parent.metadata->dimensions[1];
+    const unsigned int their_z = (this->_parent.loc[2] + relative_cell[2] + this->_parent.metadata->dimensions[2]) % this->_parent.metadata->dimensions[2];
+    // Solve to 1 dimensional bin index
+    index_1d = their_z * this->_parent.metadata->dimensions[0] * this->_parent.metadata->dimensions[1] +
+               their_y * this->_parent.metadata->dimensions[0] +
+               their_x;
+    return *this;
+}
+
+/**
+ * Constructor
+ * Allocates memory on device for message list length
+ * @param a Parent CUDAMessage, used to access message settings, data ptrs etc
+ */
+MsgArray3D::CUDAModelHandler::CUDAModelHandler(CUDAMessage &a)
+    : MsgSpecialisationHandler()
+    , d_metadata(nullptr)
+    , sim_message(a)
+    , d_write_flag(nullptr)
+    , d_write_flag_len(0) {
+    const Data& d = static_cast<const Data &>(a.getMessageDescription());
+    memcpy(&hd_metadata.dimensions, d.dimensions.data(), d.dimensions.size() * sizeof(unsigned int));
+    hd_metadata.length = d.dimensions[0] * d.dimensions[1] * d.dimensions[2];
+}
+
+void MsgArray3D::CUDAModelHandler::allocateMetaDataDevicePtr() {
+    if (d_metadata == nullptr) {
+        gpuErrchk(cudaMalloc(&d_metadata, sizeof(MetaData)));
+        gpuErrchk(cudaMemcpy(d_metadata, &hd_metadata, sizeof(MetaData), cudaMemcpyHostToDevice));
+    }
+}
+
+void MsgArray3D::CUDAModelHandler::freeMetaDataDevicePtr() {
+    if (d_metadata != nullptr) {
+        gpuErrchk(cudaFree(d_metadata));
+    }
+    d_metadata = nullptr;
+
+    if (d_write_flag) {
+        gpuErrchk(cudaFree(d_write_flag));
+    }
+    d_write_flag = nullptr;
+    d_write_flag_len = 0;
+}
+void MsgArray3D::CUDAModelHandler::buildIndex() {
+    const unsigned int MESSAGE_COUNT = this->sim_message.getMessageCount();
+    // Zero the output arrays
+    auto &read_list = this->sim_message.getReadList();
+    auto &write_list = this->sim_message.getWriteList();
+    for (auto &var : this->sim_message.getMessageDescription().variables) {
+        // Elements is harmless, futureproof for arrays support
+        // hd_metadata.length is used, as message array can be longer than message count
+        gpuErrchk(cudaMemset(write_list.at(var.first), 0, var.second.type_size * var.second.elements * hd_metadata.length));
+    }
+
+    // Reorder messages
+    unsigned int *t_d_write_flag = nullptr;
+    if (MESSAGE_COUNT > hd_metadata.length) {
+        // Use internal memory for d_write_flag
+        if (d_write_flag_len < MESSAGE_COUNT) {
+            // Increase length
+            if (d_write_flag) {
+                gpuErrchk(cudaFree(d_write_flag));
+            }
+            d_write_flag_len = static_cast<unsigned int>(MESSAGE_COUNT * 1.1f);
+            gpuErrchk(cudaMalloc(&d_write_flag, sizeof(unsigned int) * d_write_flag_len));
+        }
+        t_d_write_flag = d_write_flag;
+    }
+    auto &cs = CUDAScatter::getInstance(0);  // Choose proper stream_id in future!d
+    cs.arrayMessageReorder(this->sim_message.getMessageDescription().variables, read_list, write_list, MESSAGE_COUNT, hd_metadata.length, t_d_write_flag);
+    this->sim_message.swap();
+    // Reset message count back to full array length
+    // Array message exposes not output messages as 0
+    if (MESSAGE_COUNT != hd_metadata.length)
+        this->sim_message.setMessageCount(hd_metadata.length);
+    // Detect errors
+    // TODO
+}
+
+
+MsgArray3D::Data::Data(ModelData *const model, const std::string &message_name)
+    : MsgBruteForce::Data(model, message_name)
+    , dimensions({0, 0, 0}) {
+    description = std::unique_ptr<MsgArray3D::Description>(new MsgArray3D::Description(model, this));
+    description->newVariable<size_type>("___INDEX");
+}
+MsgArray3D::Data::Data(ModelData *const model, const Data &other)
+    : MsgBruteForce::Data(model, other)
+    , dimensions(other.dimensions) {
+    description = std::unique_ptr<MsgArray3D::Description>(model ? new MsgArray3D::Description(model, this) : nullptr);
+    if (dimensions[0] == 0 || dimensions[1] == 0 || dimensions[2] == 0) {
+        THROW InvalidMessage("All dimensions must be above zero in array3D message '%s'\n", other.name.c_str());
+    }
+}
+MsgArray3D::Data *MsgArray3D::Data::clone(ModelData *const newParent) {
+    return new Data(newParent, *this);
+}
+std::unique_ptr<MsgSpecialisationHandler> MsgArray3D::Data::getSpecialisationHander(CUDAMessage &owner) const {
+    return std::unique_ptr<MsgSpecialisationHandler>(new CUDAModelHandler(owner));
+}
+std::type_index MsgArray3D::Data::getType() const { return std::type_index(typeid(MsgArray3D)); }
+
+
+MsgArray3D::Description::Description(ModelData *const _model, Data *const data)
+    : MsgBruteForce::Description(_model, data) { }
+
+void MsgArray3D::Description::setDimensions(const size_type& len_x, const size_type& len_y, const size_type& len_z) {
+    setDimensions({ len_x , len_y, len_z});
+}
+void MsgArray3D::Description::setDimensions(const std::array<size_type, 3> &dims) {
+    if (dims[0] == 0 || dims[1] == 0 || dims[2] == 0) {
+        THROW InvalidArgument("All dimensions must be above zero in array3D message.\n");
+    }
+    reinterpret_cast<Data *>(message)->dimensions = dims;
+}
+std::array<MsgArray3D::size_type, 3> MsgArray3D::Description::getDimensions() const {
+    return reinterpret_cast<Data *>(message)->dimensions;
+}
+MsgArray2D::size_type MsgArray3D::Description::getDimX() const {
+    return reinterpret_cast<Data *>(message)->dimensions[0];
+}
+MsgArray2D::size_type MsgArray3D::Description::getDimY() const {
+    return reinterpret_cast<Data *>(message)->dimensions[1];
+}
+MsgArray2D::size_type MsgArray3D::Description::getDimZ() const {
+    return reinterpret_cast<Data *>(message)->dimensions[2];
+}

--- a/src/flamegpu/runtime/messaging/BruteForce.cu
+++ b/src/flamegpu/runtime/messaging/BruteForce.cu
@@ -107,15 +107,6 @@ size_t MsgBruteForce::Description::getVariableSize(const std::string &variable_n
         "in MessageDescription::getVariableSize().",
         message->name.c_str(), variable_name.c_str());
 }
-ModelData::size_type MsgBruteForce::Description::getVariableLength(const std::string &variable_name) const {
-    auto f = message->variables.find(variable_name);
-    if (f != message->variables.end()) {
-        return f->second.elements;
-    }
-    THROW InvalidMessageVar("Message ('%s') does not contain variable '%s', "
-        "in MessageDescription::getVariableLength().",
-        message->name.c_str(), variable_name.c_str());
-}
 ModelData::size_type MsgBruteForce::Description::getVariablesCount() const {
     // Downcast, will never have more than UINT_MAX variables
     return static_cast<ModelData::size_type>(message->variables.size());

--- a/src/flamegpu/runtime/messaging/Spatial2D.cu
+++ b/src/flamegpu/runtime/messaging/Spatial2D.cu
@@ -312,22 +312,6 @@ void MsgSpatial2D::Description::setMax(const float &x, const float &y) {
     reinterpret_cast<Data *>(message)->maxY = y;
 }
 
-float &MsgSpatial2D::Description::Radius() {
-    return reinterpret_cast<Data *>(message)->radius;
-}
-float &MsgSpatial2D::Description::MinX() {
-    return reinterpret_cast<Data *>(message)->minX;
-}
-float &MsgSpatial2D::Description::MinY() {
-    return reinterpret_cast<Data *>(message)->minY;
-}
-float &MsgSpatial2D::Description::MaxX() {
-    return reinterpret_cast<Data *>(message)->maxX;
-}
-float &MsgSpatial2D::Description::MaxY() {
-    return reinterpret_cast<Data *>(message)->maxY;
-}
-
 float MsgSpatial2D::Description::getRadius() const {
     return reinterpret_cast<Data *>(message)->radius;
 }

--- a/src/flamegpu/runtime/messaging/Spatial3D.cu
+++ b/src/flamegpu/runtime/messaging/Spatial3D.cu
@@ -305,28 +305,6 @@ void MsgSpatial3D::Description::setMax(const float &x, const float &y, const flo
     reinterpret_cast<Data *>(message)->maxZ = z;
 }
 
-float &MsgSpatial3D::Description::Radius() {
-    return reinterpret_cast<Data *>(message)->radius;
-}
-float &MsgSpatial3D::Description::MinX() {
-    return reinterpret_cast<Data *>(message)->minX;
-}
-float &MsgSpatial3D::Description::MinY() {
-    return reinterpret_cast<Data *>(message)->minY;
-}
-float &MsgSpatial3D::Description::MinZ() {
-    return reinterpret_cast<Data *>(message)->minZ;
-}
-float &MsgSpatial3D::Description::MaxX() {
-    return reinterpret_cast<Data *>(message)->maxX;
-}
-float &MsgSpatial3D::Description::MaxY() {
-    return reinterpret_cast<Data *>(message)->maxY;
-}
-float &MsgSpatial3D::Description::MaxZ() {
-    return reinterpret_cast<Data *>(message)->maxZ;
-}
-
 float MsgSpatial3D::Description::getRadius() const {
     return reinterpret_cast<Data *>(message)->radius;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -119,6 +119,9 @@ SET(TEST_CASE_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_spatial_2d.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_spatial_3d.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_brute_force.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_array.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_array_2d.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_array_3d.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_append_truncate.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/util/test_compute_capability.cu
 )

--- a/tests/test_cases/model/test_message.cu
+++ b/tests/test_cases/model/test_message.cu
@@ -23,17 +23,13 @@ TEST(MessageDescriptionTest, variables) {
     EXPECT_EQ(m.getVariablesCount(), 2u);
     // Cannot create variable with same name
     EXPECT_THROW(m.newVariable<int64_t>(VARIABLE_NAME1), InvalidMessageVar);
-    auto newVarArray3 = &MsgBruteForce::Description::newVariable<int64_t, 3>;  // Use function ptr, can't do more than 1 template arg inside macro
-    EXPECT_THROW((m.*newVarArray3)(VARIABLE_NAME1), InvalidMessageVar);
     // Variable have the right name
     EXPECT_TRUE(m.hasVariable(VARIABLE_NAME1));
     EXPECT_TRUE(m.hasVariable(VARIABLE_NAME2));
     // Returned variable data is same
-    EXPECT_EQ(1u, m.getVariableLength(VARIABLE_NAME1));
-    EXPECT_EQ(1u, m.getVariableLength(VARIABLE_NAME2));
     EXPECT_EQ(sizeof(float), m.getVariableSize(VARIABLE_NAME1));
-    EXPECT_EQ(sizeof(int16_t), m.getVariableSize(VARIABLE_NAME2));
     EXPECT_EQ(std::type_index(typeid(float)), m.getVariableType(VARIABLE_NAME1));
+    EXPECT_EQ(sizeof(int16_t), m.getVariableSize(VARIABLE_NAME2));
     EXPECT_EQ(std::type_index(typeid(int16_t)), m.getVariableType(VARIABLE_NAME2));
 }
 TEST(MessageDescriptionTest, variables_array) {
@@ -42,16 +38,14 @@ TEST(MessageDescriptionTest, variables_array) {
     EXPECT_FALSE(m.hasVariable(VARIABLE_NAME1));
     EXPECT_FALSE(m.hasVariable(VARIABLE_NAME2));
     EXPECT_EQ(m.getVariablesCount(), 0u);
-    m.newVariable<float, 2>(VARIABLE_NAME1);
+    m.newVariable<float>(VARIABLE_NAME1);
     EXPECT_EQ(m.getVariablesCount(), 1u);
     m.newVariable<int16_t>(VARIABLE_NAME3);
     EXPECT_EQ(m.getVariablesCount(), 2u);
-    m.newVariable<int16_t, 56>(VARIABLE_NAME2);
+    m.newVariable<int16_t>(VARIABLE_NAME2);
     EXPECT_EQ(m.getVariablesCount(), 3u);
     // Cannot create variable with same name
     EXPECT_THROW(m.newVariable<int64_t>(VARIABLE_NAME1), InvalidMessageVar);
-    auto newVarArray3 = &MsgBruteForce::Description::newVariable<int64_t, 3>;  // Use function ptr, can't do more than 1 template arg inside macro
-    EXPECT_THROW((m.*newVarArray3)(VARIABLE_NAME1), InvalidMessageVar);
     // Cannot create array of length 0 (disabled, blocked at compilation with static_assert)
     // auto newVarArray0 = &MessageDescription::newVariable<int64_t, 0>;  // Use function ptr, can't do more than 1 template arg inside macro
     // EXPECT_THROW((m.*newVarArray0)(VARIABLE_NAME4), InvalidMessageVar);
@@ -59,8 +53,6 @@ TEST(MessageDescriptionTest, variables_array) {
     EXPECT_TRUE(m.hasVariable(VARIABLE_NAME1));
     EXPECT_TRUE(m.hasVariable(VARIABLE_NAME2));
     // Returned variable data is same
-    EXPECT_EQ(2u, m.getVariableLength(VARIABLE_NAME1));
-    EXPECT_EQ(56u, m.getVariableLength(VARIABLE_NAME2));
     EXPECT_EQ(sizeof(float), m.getVariableSize(VARIABLE_NAME1));
     EXPECT_EQ(sizeof(int16_t), m.getVariableSize(VARIABLE_NAME2));
     EXPECT_EQ(std::type_index(typeid(float)), m.getVariableType(VARIABLE_NAME1));

--- a/tests/test_cases/runtime/messaging/test_array.cu
+++ b/tests/test_cases/runtime/messaging/test_array.cu
@@ -1,0 +1,308 @@
+#include <chrono>
+#include <algorithm>
+
+#include "gtest/gtest.h"
+
+#include "flamegpu/flame_api.h"
+#include "flamegpu/runtime/flamegpu_api.h"
+
+namespace test_message_array {
+    const char *MODEL_NAME = "Model";
+    const char *AGENT_NAME = "Agent";
+    const char *MESSAGE_NAME = "Message";
+    const char *IN_FUNCTION_NAME = "InFunction";
+    const char *OUT_FUNCTION_NAME = "OutFunction";
+    const char *IN_LAYER_NAME = "InLayer";
+    const char *OUT_LAYER_NAME = "OutLayer";
+    const unsigned int AGENT_COUNT = 128;
+FLAMEGPU_AGENT_FUNCTION(OutFunction, MsgNone, MsgArray) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("message_write");
+    FLAMEGPU->message_out.setVariable<unsigned int>("index_times_3", index * 3);
+    FLAMEGPU->message_out.setIndex(index);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(OutOptionalFunction, MsgNone, MsgArray) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("message_write");
+    if (index % 2 == 0) {
+        FLAMEGPU->message_out.setVariable<unsigned int>("index_times_3", index * 3);
+        FLAMEGPU->message_out.setIndex(index);
+    }
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(OutBad, MsgNone, MsgArray) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("message_write");
+    FLAMEGPU->message_out.setVariable<unsigned int>("index_times_3", index * 3);
+    FLAMEGPU->message_out.setIndex(index == 13 ? 0 : index);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(InFunction, MsgArray, MsgNone) {
+    const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
+    const auto &message = FLAMEGPU->message_in.at(my_index);
+    FLAMEGPU->setVariable("message_read", message.getVariable<unsigned int>("index_times_3"));
+    return ALIVE;
+}
+TEST(TestMessage_Array, Mandatory) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray::Description &msg = m.newMessage<MsgArray>(MESSAGE_NAME);
+    msg.setLength(AGENT_COUNT);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, InFunction);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Create a list of numbers
+    std::array<unsigned int, AGENT_COUNT> numbers;
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        numbers[i] = i;
+    }
+    // Shuffle the list of numbers
+    const unsigned seed = static_cast<unsigned int>(std::chrono::system_clock::now().time_since_epoch().count());
+    std::shuffle(numbers.begin(), numbers.end(), std::default_random_engine(seed));
+    // Assign the numbers in shuffled order to agents
+    AgentPopulation pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getNextInstance();
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", numbers[i]);
+    }
+    // Set pop in model
+    CUDAAgentModel c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getInstanceAt(i);
+        const unsigned int index = ai.getVariable<unsigned int>("index");
+        const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
+        EXPECT_EQ(index * 3, message_read);
+    }
+}
+TEST(TestMessage_Array, Optional) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray::Description &msg = m.newMessage<MsgArray>(MESSAGE_NAME);
+    msg.setLength(AGENT_COUNT);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutOptionalFunction);
+    fo.setMessageOutput(msg);
+    fo.setMessageOutputOptional(true);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, InFunction);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Create a list of numbers
+    std::array<unsigned int, AGENT_COUNT> numbers;
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        numbers[i] = i;
+    }
+    // Shuffle the list of numbers
+    const unsigned seed = static_cast<unsigned int>(std::chrono::system_clock::now().time_since_epoch().count());
+    std::shuffle(numbers.begin(), numbers.end(), std::default_random_engine(seed));
+    // Assign the numbers in shuffled order to agents
+    AgentPopulation pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getNextInstance();
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", numbers[i]);
+    }
+    // Set pop in model
+    CUDAAgentModel c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    // Validate each agent has same result
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getInstanceAt(i);
+        unsigned int index = ai.getVariable<unsigned int>("index");
+        const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
+        index = index % 2 == 0 ? index : 0;
+        EXPECT_EQ(index * 3, message_read);
+    }
+}
+
+FLAMEGPU_AGENT_FUNCTION(OutSimple, MsgNone, MsgArray) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
+    FLAMEGPU->message_out.setIndex(index);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(MooreTest1, MsgArray, MsgNone) {
+    const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
+
+    // Iterate and check it aligns
+    auto filter = FLAMEGPU->message_in(my_index);
+    auto msg = filter.begin();
+    unsigned int message_read = 0;
+    for (int i = -1; i <= 1; ++i) {
+        // Skip ourself
+        if (i != 0) {
+            // Wrap over boundaries
+            const unsigned int their_x = (my_index + i + FLAMEGPU->message_in.size()) % FLAMEGPU->message_in.size();
+            if (msg->getX() == their_x)
+                message_read++;
+            ++msg;
+        }
+    }
+    if (msg == filter.end())
+        message_read++;
+    FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(MooreTest2, MsgArray, MsgNone) {
+    const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
+
+    // Iterate and check it aligns
+    auto filter = FLAMEGPU->message_in(my_index, 2);
+    auto msg = filter.begin();
+    unsigned int message_read = 0;
+    for (int i = -2; i <= 2; ++i) {
+        // Skip ourself
+        if (i != 0) {
+            // Wrap over boundaries
+            const unsigned int their_x = (my_index + i + FLAMEGPU->message_in.size()) % FLAMEGPU->message_in.size();
+            if (msg->getX() == their_x)
+                message_read++;
+            ++msg;
+        }
+    }
+    if (msg == filter.end())
+        message_read++;
+    FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
+    return ALIVE;
+}
+TEST(TestMessage_Array, Moore1) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray::Description &msg = m.newMessage<MsgArray>(MESSAGE_NAME);
+    msg.setLength(AGENT_COUNT);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutSimple);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, MooreTest1);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentPopulation pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getNextInstance();
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+    }
+    // Set pop in model
+    CUDAAgentModel c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has read 8 correct messages
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getInstanceAt(i);
+        const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
+        EXPECT_EQ(3u, message_read);
+    }
+}
+TEST(TestMessage_Array, Moore2) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray::Description &msg = m.newMessage<MsgArray>(MESSAGE_NAME);
+    msg.setLength(AGENT_COUNT);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutSimple);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, MooreTest2);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentPopulation pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getNextInstance();
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+    }
+    // Set pop in model
+    CUDAAgentModel c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has read 8 correct messages
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getInstanceAt(i);
+        const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
+        EXPECT_EQ(5u, message_read);
+    }
+}
+// Exception tests
+TEST(TestMessage_Array, DuplicateOutputException) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray::Description &msg = m.newMessage<MsgArray>(MESSAGE_NAME);
+    msg.setLength(AGENT_COUNT);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutBad);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, InFunction);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Create a list of numbers
+    std::array<unsigned int, AGENT_COUNT> numbers;
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        numbers[i] = i;
+    }
+    // Shuffle the list of numbers
+    const unsigned seed = static_cast<unsigned int>(std::chrono::system_clock::now().time_since_epoch().count());
+    std::shuffle(numbers.begin(), numbers.end(), std::default_random_engine(seed));
+    // Assign the numbers in shuffled order to agents
+    AgentPopulation pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getNextInstance();
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", numbers[i]);
+    }
+    // Set pop in model
+    CUDAAgentModel c(m);
+    c.setPopulationData(pop);
+    EXPECT_THROW(c.step(), ArrayMessageWriteConflict);
+}
+TEST(TestMessage_Array, ArrayLenZeroException) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray::Description &msg = m.newMessage<MsgArray>(MESSAGE_NAME);
+    EXPECT_THROW(msg.setLength(0), InvalidArgument);
+}
+TEST(TestMessage_Array, UnsetLength) {
+    ModelDescription model(MODEL_NAME);
+    MsgArray::Description &message = model.newMessage<MsgArray>(MESSAGE_NAME);
+    // message.setLength(5);  // Intentionally commented out
+    EXPECT_THROW(CUDAAgentModel m(model), InvalidMessage);
+}
+
+}  // namespace test_message_array

--- a/tests/test_cases/runtime/messaging/test_array_2d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_2d.cu
@@ -1,0 +1,335 @@
+#include <chrono>
+#include <algorithm>
+
+#include "gtest/gtest.h"
+
+#include "flamegpu/flame_api.h"
+#include "flamegpu/runtime/flamegpu_api.h"
+
+namespace test_message_array_2d {
+    const char *MODEL_NAME = "Model";
+    const char *AGENT_NAME = "Agent";
+    const char *MESSAGE_NAME = "Message";
+    const char *IN_FUNCTION_NAME = "InFunction";
+    const char *OUT_FUNCTION_NAME = "OutFunction";
+    const char *IN_LAYER_NAME = "InLayer";
+    const char *OUT_LAYER_NAME = "OutLayer";
+    const unsigned int SQRT_AGENT_COUNT = 12;
+    __device__ const unsigned int dSQRT_AGENT_COUNT = 12;
+    const unsigned int AGENT_COUNT = SQRT_AGENT_COUNT * (SQRT_AGENT_COUNT + 1);
+FLAMEGPU_AGENT_FUNCTION(OutFunction, MsgNone, MsgArray2D) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("message_write");
+    FLAMEGPU->message_out.setVariable<unsigned int>("index_times_3", index * 3);
+    const unsigned int index_x = index % dSQRT_AGENT_COUNT;
+    const unsigned int index_y = index / dSQRT_AGENT_COUNT;
+    FLAMEGPU->message_out.setIndex(index_x, index_y);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(OutOptionalFunction, MsgNone, MsgArray2D) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("message_write");
+    if (index % 2 == 0) {
+        FLAMEGPU->message_out.setVariable<unsigned int>("index_times_3", index * 3);
+        const unsigned int index_x = index % dSQRT_AGENT_COUNT;
+        const unsigned int index_y = index / dSQRT_AGENT_COUNT;
+        FLAMEGPU->message_out.setIndex(index_x, index_y);
+    }
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(OutBad, MsgNone, MsgArray2D) {
+    unsigned int index = FLAMEGPU->getVariable<unsigned int>("message_write");
+    FLAMEGPU->message_out.setVariable<unsigned int>("index_times_3", index * 3);
+    index = index == 13 ? 0 : index;
+    const unsigned int index_x = index % dSQRT_AGENT_COUNT;
+    const unsigned int index_y = index / dSQRT_AGENT_COUNT;
+    FLAMEGPU->message_out.setIndex(index_x, index_y);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(InFunction, MsgArray2D, MsgNone) {
+    const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
+    const unsigned int index_x = my_index % dSQRT_AGENT_COUNT;
+    const unsigned int index_y = my_index / dSQRT_AGENT_COUNT;
+    const auto &message = FLAMEGPU->message_in.at(index_x, index_y);
+    FLAMEGPU->setVariable("message_read", message.getVariable<unsigned int>("index_times_3"));
+    return ALIVE;
+}
+TEST(TestMessage_Array2D, Mandatory) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray2D::Description &msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
+    msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT + 1);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, InFunction);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Create a list of numbers
+    std::array<unsigned int, AGENT_COUNT> numbers;
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        numbers[i] = i;
+    }
+    // Shuffle the list of numbers
+    const unsigned seed = static_cast<unsigned int>(std::chrono::system_clock::now().time_since_epoch().count());
+    std::shuffle(numbers.begin(), numbers.end(), std::default_random_engine(seed));
+    // Assign the numbers in shuffled order to agents
+    AgentPopulation pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getNextInstance();
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", numbers[i]);
+    }
+    // Set pop in model
+    CUDAAgentModel c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getInstanceAt(i);
+        const unsigned int index = ai.getVariable<unsigned int>("index");
+        const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
+        EXPECT_EQ(index * 3, message_read);
+    }
+}
+TEST(TestMessage_Array2D, Optional) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray2D::Description &msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
+    msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT + 1);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutOptionalFunction);
+    fo.setMessageOutput(msg);
+    fo.setMessageOutputOptional(true);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, InFunction);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Create a list of numbers
+    std::array<unsigned int, AGENT_COUNT> numbers;
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        numbers[i] = i;
+    }
+    // Shuffle the list of numbers
+    const unsigned seed = static_cast<unsigned int>(std::chrono::system_clock::now().time_since_epoch().count());
+    std::shuffle(numbers.begin(), numbers.end(), std::default_random_engine(seed));
+    // Assign the numbers in shuffled order to agents
+    AgentPopulation pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getNextInstance();
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", numbers[i]);
+    }
+    // Set pop in model
+    CUDAAgentModel c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    // Validate each agent has same result
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getInstanceAt(i);
+        unsigned int index = ai.getVariable<unsigned int>("index");
+        const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
+        index = index % 2 == 0 ? index : 0;
+        EXPECT_EQ(index * 3, message_read);
+    }
+}
+
+FLAMEGPU_AGENT_FUNCTION(OutSimple, MsgNone, MsgArray2D) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
+    const unsigned int index_x = index % dSQRT_AGENT_COUNT;
+    const unsigned int index_y = index / dSQRT_AGENT_COUNT;
+    FLAMEGPU->message_out.setIndex(index_x, index_y);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(MooreTest1, MsgArray2D, MsgNone) {
+    const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
+    const unsigned int index_x = my_index % dSQRT_AGENT_COUNT;
+    const unsigned int index_y = my_index / dSQRT_AGENT_COUNT;
+
+    // Iterate and check it aligns
+    auto filter = FLAMEGPU->message_in(index_x, index_y);
+    auto msg = filter.begin();
+    unsigned int message_read = 0;
+    for (int i = -1; i <= 1; ++i) {
+        for (int j = -1; j <= 1; ++j) {
+            // Skip ourself
+            if (!(i == 0 && j == 0)) {
+                // Wrap over boundaries
+                const unsigned int their_x = (index_x + i + FLAMEGPU->message_in.getDimX()) % FLAMEGPU->message_in.getDimX();
+                const unsigned int their_y = (index_y + j + FLAMEGPU->message_in.getDimY()) % FLAMEGPU->message_in.getDimY();
+                if (msg->getX() == their_x && msg->getY() == their_y)
+                    message_read++;
+                ++msg;
+            }
+        }
+    }
+    if (msg == filter.end())
+        message_read++;
+    FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(MooreTest2, MsgArray2D, MsgNone) {
+    const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
+    const unsigned int index_x = my_index % dSQRT_AGENT_COUNT;
+    const unsigned int index_y = my_index / dSQRT_AGENT_COUNT;
+
+    // Iterate and check it aligns
+    auto filter = FLAMEGPU->message_in(index_x, index_y, 2);
+    auto msg = filter.begin();
+    unsigned int message_read = 0;
+    for (int i = -2; i <= 2; ++i) {
+        for (int j = -2; j <= 2; ++j) {
+            // Skip ourself
+            if (!(i == 0 && j == 0)) {
+                // Wrap over boundaries
+                const unsigned int their_x = (index_x + i + FLAMEGPU->message_in.getDimX()) % FLAMEGPU->message_in.getDimX();
+                const unsigned int their_y = (index_y + j + FLAMEGPU->message_in.getDimY()) % FLAMEGPU->message_in.getDimY();
+                if (msg->getX() == their_x && msg->getY() == their_y)
+                    message_read++;
+                ++msg;
+            }
+        }
+    }
+    if (msg == filter.end())
+        message_read++;
+    FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
+    return ALIVE;
+}
+TEST(TestMessage_Array2D, Moore1) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray2D::Description &msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
+    msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT + 1);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutSimple);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, MooreTest1);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentPopulation pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getNextInstance();
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+    }
+    // Set pop in model
+    CUDAAgentModel c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has read 8 correct messages
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getInstanceAt(i);
+        const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
+        EXPECT_EQ(9u, message_read);
+    }
+}
+TEST(TestMessage_Array2D, Moore2) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray2D::Description &msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
+    msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT + 1);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutSimple);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, MooreTest2);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentPopulation pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getNextInstance();
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+    }
+    // Set pop in model
+    CUDAAgentModel c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has read 8 correct messages
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getInstanceAt(i);
+        const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
+        EXPECT_EQ(25u, message_read);
+    }
+}
+
+// Exception tests
+TEST(TestMessage_Array2D, DuplicateOutputException) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray2D::Description &msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
+    msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutBad);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, InFunction);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Create a list of numbers
+    std::array<unsigned int, AGENT_COUNT> numbers;
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        numbers[i] = i;
+    }
+    // Shuffle the list of numbers
+    const unsigned seed = static_cast<unsigned int>(std::chrono::system_clock::now().time_since_epoch().count());
+    std::shuffle(numbers.begin(), numbers.end(), std::default_random_engine(seed));
+    // Assign the numbers in shuffled order to agents
+    AgentPopulation pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getNextInstance();
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", numbers[i]);
+    }
+    // Set pop in model
+    CUDAAgentModel c(m);
+    c.setPopulationData(pop);
+    EXPECT_THROW(c.step(), ArrayMessageWriteConflict);
+}
+TEST(TestMessage_Array2D, ArrayLenZeroException) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray2D::Description &msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
+    EXPECT_THROW(msg.setDimensions(0, SQRT_AGENT_COUNT), InvalidArgument);
+    EXPECT_THROW(msg.setDimensions({ 0, SQRT_AGENT_COUNT }), InvalidArgument);
+    EXPECT_THROW(msg.setDimensions(SQRT_AGENT_COUNT, 0), InvalidArgument);
+    EXPECT_THROW(msg.setDimensions({ SQRT_AGENT_COUNT, 0 }), InvalidArgument);
+}
+TEST(TestMessage_Array2D, UnsetDimensions) {
+    ModelDescription model(MODEL_NAME);
+    MsgArray2D::Description &message = model.newMessage<MsgArray2D>(MESSAGE_NAME);
+    // message.setDimensions(5, 5);  // Intentionally commented out
+    EXPECT_THROW(CUDAAgentModel m(model), InvalidMessage);
+}
+
+}  // namespace test_message_array_2d

--- a/tests/test_cases/runtime/messaging/test_array_3d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_3d.cu
@@ -1,0 +1,350 @@
+#include <chrono>
+#include <algorithm>
+
+#include "gtest/gtest.h"
+
+#include "flamegpu/flame_api.h"
+#include "flamegpu/runtime/flamegpu_api.h"
+
+namespace test_message_array_3d {
+    const char *MODEL_NAME = "Model";
+    const char *AGENT_NAME = "Agent";
+    const char *MESSAGE_NAME = "Message";
+    const char *IN_FUNCTION_NAME = "InFunction";
+    const char *OUT_FUNCTION_NAME = "OutFunction";
+    const char *IN_LAYER_NAME = "InLayer";
+    const char *OUT_LAYER_NAME = "OutLayer";
+    const unsigned int CBRT_AGENT_COUNT = 6;
+    __device__ const unsigned int dCBRT_AGENT_COUNT = 6;
+    const unsigned int AGENT_COUNT = CBRT_AGENT_COUNT * (CBRT_AGENT_COUNT + 2) * (CBRT_AGENT_COUNT+1);
+FLAMEGPU_AGENT_FUNCTION(OutFunction, MsgNone, MsgArray3D) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("message_write");
+    FLAMEGPU->message_out.setVariable<unsigned int>("index_times_3", index * 3);
+    const unsigned int index_x = index % (dCBRT_AGENT_COUNT);
+    const unsigned int index_y = (index / dCBRT_AGENT_COUNT) % (dCBRT_AGENT_COUNT + 1);
+    const unsigned int index_z = index / ((dCBRT_AGENT_COUNT) * (dCBRT_AGENT_COUNT + 1));
+    FLAMEGPU->message_out.setIndex(index_x, index_y, index_z);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(OutOptionalFunction, MsgNone, MsgArray3D) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("message_write");
+    if (index % 2 == 0) {
+        FLAMEGPU->message_out.setVariable<unsigned int>("index_times_3", index * 3);
+        const unsigned int index_x = index % (dCBRT_AGENT_COUNT);
+        const unsigned int index_y = (index / dCBRT_AGENT_COUNT) % (dCBRT_AGENT_COUNT + 1);
+        const unsigned int index_z = index / ((dCBRT_AGENT_COUNT) * (dCBRT_AGENT_COUNT + 1));
+        FLAMEGPU->message_out.setIndex(index_x, index_y, index_z);
+    }
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(OutBad, MsgNone, MsgArray3D) {
+    unsigned int index = FLAMEGPU->getVariable<unsigned int>("message_write");
+    FLAMEGPU->message_out.setVariable<unsigned int>("index_times_3", index * 3);
+    index = index == 13 ? 0 : index;
+    const unsigned int index_x = index % (dCBRT_AGENT_COUNT);
+    const unsigned int index_y = (index / dCBRT_AGENT_COUNT) % (dCBRT_AGENT_COUNT + 1);
+    const unsigned int index_z = index / ((dCBRT_AGENT_COUNT) * (dCBRT_AGENT_COUNT + 1));
+    FLAMEGPU->message_out.setIndex(index_x, index_y, index_z);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(InFunction, MsgArray3D, MsgNone) {
+    const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
+    const unsigned int index_x = my_index % (dCBRT_AGENT_COUNT);
+    const unsigned int index_y = (my_index / dCBRT_AGENT_COUNT) % (dCBRT_AGENT_COUNT + 1);
+    const unsigned int index_z = my_index / ((dCBRT_AGENT_COUNT) * (dCBRT_AGENT_COUNT + 1));
+    const auto &message = FLAMEGPU->message_in.at(index_x, index_y, index_z);
+    FLAMEGPU->setVariable("message_read", message.getVariable<unsigned int>("index_times_3"));
+    return ALIVE;
+}
+TEST(TestMessage_Array3D, Mandatory) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray3D::Description &msg = m.newMessage<MsgArray3D>(MESSAGE_NAME);
+    msg.setDimensions(CBRT_AGENT_COUNT, CBRT_AGENT_COUNT + 1, CBRT_AGENT_COUNT + 2);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, InFunction);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Create a list of numbers
+    std::array<unsigned int, AGENT_COUNT> numbers;
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        numbers[i] = i;
+    }
+    // Shuffle the list of numbers
+    const unsigned seed = static_cast<unsigned int>(std::chrono::system_clock::now().time_since_epoch().count());
+    std::shuffle(numbers.begin(), numbers.end(), std::default_random_engine(seed));
+    // Assign the numbers in shuffled order to agents
+    AgentPopulation pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getNextInstance();
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", numbers[i]);
+    }
+    // Set pop in model
+    CUDAAgentModel c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getInstanceAt(i);
+        const unsigned int index = ai.getVariable<unsigned int>("index");
+        const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
+        EXPECT_EQ(index * 3, message_read);
+    }
+}
+TEST(TestMessage_Array3D, Optional) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray3D::Description &msg = m.newMessage<MsgArray3D>(MESSAGE_NAME);
+    msg.setDimensions(CBRT_AGENT_COUNT, CBRT_AGENT_COUNT + 1, CBRT_AGENT_COUNT + 2);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutOptionalFunction);
+    fo.setMessageOutput(msg);
+    fo.setMessageOutputOptional(true);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, InFunction);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Create a list of numbers
+    std::array<unsigned int, AGENT_COUNT> numbers;
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        numbers[i] = i;
+    }
+    // Shuffle the list of numbers
+    const unsigned seed = static_cast<unsigned int>(std::chrono::system_clock::now().time_since_epoch().count());
+    std::shuffle(numbers.begin(), numbers.end(), std::default_random_engine(seed));
+    // Assign the numbers in shuffled order to agents
+    AgentPopulation pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getNextInstance();
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", numbers[i]);
+    }
+    // Set pop in model
+    CUDAAgentModel c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    // Validate each agent has same result
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getInstanceAt(i);
+        unsigned int index = ai.getVariable<unsigned int>("index");
+        const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
+        index = index % 2 == 0 ? index : 0;
+        EXPECT_EQ(index * 3, message_read);
+    }
+}
+
+FLAMEGPU_AGENT_FUNCTION(OutSimple, MsgNone, MsgArray3D) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
+    const unsigned int index_x = index % (dCBRT_AGENT_COUNT);
+    const unsigned int index_y = (index / dCBRT_AGENT_COUNT) % (dCBRT_AGENT_COUNT + 1);
+    const unsigned int index_z = index / ((dCBRT_AGENT_COUNT) * (dCBRT_AGENT_COUNT + 1));
+    FLAMEGPU->message_out.setIndex(index_x, index_y, index_z);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(MooreTest1, MsgArray3D, MsgNone) {
+    const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
+    const unsigned int index_x = my_index % (dCBRT_AGENT_COUNT);
+    const unsigned int index_y = (my_index / dCBRT_AGENT_COUNT) % (dCBRT_AGENT_COUNT + 1);
+    const unsigned int index_z = my_index / ((dCBRT_AGENT_COUNT) * (dCBRT_AGENT_COUNT + 1));
+
+    // Iterate and check it aligns
+    auto filter = FLAMEGPU->message_in(index_x, index_y, index_z);
+    auto msg = filter.begin();
+    unsigned int message_read = 0;
+    for (int i = -1; i <= 1; ++i) {
+        for (int j = -1; j <= 1; ++j) {
+            for (int k = -1; k <= 1; ++k) {
+                // Skip ourself
+                if (!(i == 0 && j == 0 && k == 0)) {
+                    // Wrap over boundaries
+                    const unsigned int their_x = (index_x + i + FLAMEGPU->message_in.getDimX()) % FLAMEGPU->message_in.getDimX();
+                    const unsigned int their_y = (index_y + j + FLAMEGPU->message_in.getDimY()) % FLAMEGPU->message_in.getDimY();
+                    const unsigned int their_z = (index_z + k + FLAMEGPU->message_in.getDimZ()) % FLAMEGPU->message_in.getDimZ();
+                    if (msg->getX() == their_x && msg->getY() == their_y && msg->getZ() == their_z)
+                        message_read++;
+                    ++msg;
+                }
+            }
+        }
+    }
+    if (msg == filter.end())
+        message_read++;
+    FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(MooreTest2, MsgArray3D, MsgNone) {
+    const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
+    const unsigned int index_x = my_index % (dCBRT_AGENT_COUNT);
+    const unsigned int index_y = (my_index / dCBRT_AGENT_COUNT) % (dCBRT_AGENT_COUNT + 1);
+    const unsigned int index_z = my_index / ((dCBRT_AGENT_COUNT) * (dCBRT_AGENT_COUNT + 1));
+
+    // Iterate and check it aligns
+    auto filter = FLAMEGPU->message_in(index_x, index_y, index_z, 2);
+    auto msg = filter.begin();
+    unsigned int message_read = 0;
+    for (int i = -2; i <= 2; ++i) {
+        for (int j = -2; j <= 2; ++j) {
+            for (int k = -2; k <= 2; ++k) {
+                // Skip ourself
+                if (!(i == 0 && j == 0 && k == 0)) {
+                    // Wrap over boundaries
+                    const unsigned int their_x = (index_x + i + FLAMEGPU->message_in.getDimX()) % FLAMEGPU->message_in.getDimX();
+                    const unsigned int their_y = (index_y + j + FLAMEGPU->message_in.getDimY()) % FLAMEGPU->message_in.getDimY();
+                    const unsigned int their_z = (index_z + k + FLAMEGPU->message_in.getDimZ()) % FLAMEGPU->message_in.getDimZ();
+                    if (msg->getX() == their_x && msg->getY() == their_y && msg->getZ() == their_z)
+                        message_read++;
+                    ++msg;
+                }
+            }
+        }
+    }
+    if (msg == filter.end())
+        message_read++;
+    FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
+    return ALIVE;
+}
+TEST(TestMessage_Array3D, Moore1) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray3D::Description &msg = m.newMessage<MsgArray3D>(MESSAGE_NAME);
+    msg.setDimensions(CBRT_AGENT_COUNT, CBRT_AGENT_COUNT + 1, CBRT_AGENT_COUNT + 2);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutSimple);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, MooreTest1);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentPopulation pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getNextInstance();
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+    }
+    // Set pop in model
+    CUDAAgentModel c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has read 8 correct messages
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getInstanceAt(i);
+        const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
+        EXPECT_EQ(27u, message_read);
+    }
+}
+TEST(TestMessage_Array3D, Moore2) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray3D::Description &msg = m.newMessage<MsgArray3D>(MESSAGE_NAME);
+    msg.setDimensions(CBRT_AGENT_COUNT, CBRT_AGENT_COUNT + 1, CBRT_AGENT_COUNT + 2);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutSimple);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, MooreTest2);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentPopulation pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getNextInstance();
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+    }
+    // Set pop in model
+    CUDAAgentModel c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has read 8 correct messages
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getInstanceAt(i);
+        const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
+        EXPECT_EQ(125u, message_read);
+    }
+}
+
+// Exception tests
+TEST(TestMessage_Array3D, DuplicateOutputException) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray3D::Description &msg = m.newMessage<MsgArray3D>(MESSAGE_NAME);
+    msg.setDimensions(CBRT_AGENT_COUNT, CBRT_AGENT_COUNT + 1, CBRT_AGENT_COUNT + 2);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutBad);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, InFunction);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Create a list of numbers
+    std::array<unsigned int, AGENT_COUNT> numbers;
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        numbers[i] = i;
+    }
+    // Shuffle the list of numbers
+    const unsigned seed = static_cast<unsigned int>(std::chrono::system_clock::now().time_since_epoch().count());
+    std::shuffle(numbers.begin(), numbers.end(), std::default_random_engine(seed));
+    // Assign the numbers in shuffled order to agents
+    AgentPopulation pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getNextInstance();
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", numbers[i]);
+    }
+    // Set pop in model
+    CUDAAgentModel c(m);
+    c.setPopulationData(pop);
+    EXPECT_THROW(c.step(), ArrayMessageWriteConflict);
+}
+TEST(TestMessage_Array3D, ArrayLenZeroException) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray3D::Description &msg = m.newMessage<MsgArray3D>(MESSAGE_NAME);
+    EXPECT_THROW(msg.setDimensions(0, 0, CBRT_AGENT_COUNT), InvalidArgument);
+    EXPECT_THROW(msg.setDimensions({ 0, 0, CBRT_AGENT_COUNT }), InvalidArgument);
+    EXPECT_THROW(msg.setDimensions(0, CBRT_AGENT_COUNT, 0), InvalidArgument);
+    EXPECT_THROW(msg.setDimensions({ 0, CBRT_AGENT_COUNT, 0 }), InvalidArgument);
+    EXPECT_THROW(msg.setDimensions(CBRT_AGENT_COUNT, 0, 0), InvalidArgument);
+    EXPECT_THROW(msg.setDimensions({ CBRT_AGENT_COUNT, 0, 0 }), InvalidArgument);
+}
+TEST(TestMessage_Array3D, UnsetDimensions) {
+    ModelDescription model(MODEL_NAME);
+    MsgArray3D::Description &message = model.newMessage<MsgArray3D>(MESSAGE_NAME);
+    // message.setDimensions(5, 5, 5);  // Intentionally commented out
+    EXPECT_THROW(CUDAAgentModel m(model), InvalidMessage);
+}
+
+}  // namespace test_message_array_3d


### PR DESCRIPTION
Addresses #82 (unsure if it counts as closing or not. vague issue)
**Changelog:**
* Adds `MsgArray` type with Moore iteration, and mandatory/optional output, exception unit tests
* Adds `MsgArray2D` type with Moore iteration, and mandatory/optional output, exception unit tests
* Adds `MsgArray3D` type with Moore iteration, and mandatory/optional output, exception unit tests
* Remove a redundant branch from `CUDAMessage::swap(bool, const unsigned int &, const unsigned int&)` (this relates to earlier bugfixes.
* Fixes spatial messaging tests (#211)
* Removes redundant 2nd template arg from `MsgBruteForce::Description::newVariable()` that would have allowed array vars to be added to messages (but not used).
* `MsgSpatial2D::Description` exception unit tests
* `MsgSpatial3D::Description` exception unit tests
* Example `Game of Life`
* Adds postfix `operator++` and `operator->` to all Msg iterators.