### PR TITLE
Replicate standard output from FLAME GPU 1

### DIFF
--- a/examples/host_functions/src/main.cu
+++ b/examples/host_functions/src/main.cu
@@ -69,7 +69,7 @@ FLAMEGPU_EXIT_CONDITION(exit_condition) {
 }
 
 
-int main(void) {
+int main(int argc, const char ** argv) {
     ModelDescription model("host_functions_example");
 
     {  // agent
@@ -124,6 +124,7 @@ int main(void) {
     CUDAAgentModel cuda_model(model);
     cuda_model.SimulationConfig().steps = 0;
     cuda_model.setPopulationData(population);
+    cuda_model.initialise(argc, argv);
     cuda_model.simulate();
 
     cuda_model.getPopulationData(population);

--- a/include/flamegpu/sim/Simulation.h
+++ b/include/flamegpu/sim/Simulation.h
@@ -21,6 +21,7 @@ class Simulation {
         unsigned int random_seed;
         unsigned int steps = 0;
         bool verbose = false;
+        bool timing = false;
     };
     virtual ~Simulation() = default;
     explicit Simulation(const ModelDescription& model);

--- a/include/flamegpu/sim/Simulation.h
+++ b/include/flamegpu/sim/Simulation.h
@@ -20,6 +20,7 @@ class Simulation {
         std::string xml_input_file;
         unsigned int random_seed;
         unsigned int steps = 0;
+        bool verbose = false;
     };
     virtual ~Simulation() = default;
     explicit Simulation(const ModelDescription& model);

--- a/src/flamegpu/gpu/CUDAAgentModel.cu
+++ b/src/flamegpu/gpu/CUDAAgentModel.cu
@@ -58,6 +58,11 @@ bool CUDAAgentModel::step() {
     // Ensure singletons have been initialised
     initialiseSingletons();
 
+    // If verbose, print the step number.
+    if (getSimulationConfig().verbose) {
+        fprintf(stdout, "Processing Simulation Step %u\n", step_count);
+    }
+
     step_count++;
     unsigned int nStreams = 1;
     std::string message_name;

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -103,6 +103,12 @@ int Simulation::checkArgs(int argc, const char** argv) {
             config.random_seed = static_cast<unsigned int>(strtoul(argv[++i], nullptr, 0));
             continue;
         }
+        // -v/--verbose, Verbose FLAME GPU output.
+        if (arg.compare("--verbose") == 0 || arg.compare("-v") == 0) {
+            // Reinitialise RandomManager state
+            config.verbose = true;
+            continue;
+        }
         // Test this arg with the derived class
         if (checkArgs_derived(argc, argv, i)) {
             continue;
@@ -118,9 +124,10 @@ void Simulation::printHelp(const char* executable) {
     printf("Usage: %s [-s steps] [-d device_id] [-r random_seed]\n", executable);
     printf("Optional Arguments:\n");
     const char *line_fmt = "%-18s %s\n";
-    printf(line_fmt, "-i, --in", "Initial state file (XML)");
-    printf(line_fmt, "-s, --steps", "Number of simulation iterations");
-    printf(line_fmt, "-r, --random", "RandomManager seed");
+    printf(line_fmt, "-i, --in <file.xml>", "Initial state file (XML)");
+    printf(line_fmt, "-s, --steps <steps>", "Number of simulation iterations");
+    printf(line_fmt, "-r, --random <seed>", "RandomManager seed");
+    printf(line_fmt, "-v, --verbose", "Verbose FLAME GPU output");
     printHelp_derived();
 }
 

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -113,11 +113,6 @@ int Simulation::checkArgs(int argc, const char** argv) {
             config.timing = true;
             continue;
         }
-        // -no-timing, do not output timing values..
-        if (arg.compare("--no-timing") == 0) {
-            config.timing = false;
-            continue;
-        }
         // Test this arg with the derived class
         if (checkArgs_derived(argc, argv, i)) {
             continue;
@@ -138,7 +133,6 @@ void Simulation::printHelp(const char* executable) {
     printf(line_fmt, "-r, --random <seed>", "RandomManager seed");
     printf(line_fmt, "-v, --verbose", "Verbose FLAME GPU output");
     printf(line_fmt, "-t, --timing", "Output timing information to stdout");
-    printf(line_fmt, "    --no-timing", "Do not output timing information to stdout");
     printHelp_derived();
 }
 

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -105,8 +105,17 @@ int Simulation::checkArgs(int argc, const char** argv) {
         }
         // -v/--verbose, Verbose FLAME GPU output.
         if (arg.compare("--verbose") == 0 || arg.compare("-v") == 0) {
-            // Reinitialise RandomManager state
             config.verbose = true;
+            continue;
+        }
+        // -t/--timing, Output timing information to stdout
+        if (arg.compare("--timing") == 0 || arg.compare("-t") == 0) {
+            config.timing = true;
+            continue;
+        }
+        // -no-timing, do not output timing values..
+        if (arg.compare("--no-timing") == 0) {
+            config.timing = false;
             continue;
         }
         // Test this arg with the derived class
@@ -128,6 +137,8 @@ void Simulation::printHelp(const char* executable) {
     printf(line_fmt, "-s, --steps <steps>", "Number of simulation iterations");
     printf(line_fmt, "-r, --random <seed>", "RandomManager seed");
     printf(line_fmt, "-v, --verbose", "Verbose FLAME GPU output");
+    printf(line_fmt, "-t, --timing", "Output timing information to stdout");
+    printf(line_fmt, "    --no-timing", "Do not output timing information to stdout");
     printHelp_derived();
 }
 


### PR DESCRIPTION
+ [x]  Add -v/--verbose flag to Simulation. CUDAAgentModel then prints iteration number to stdout.
+ [x] Add -t/--timing flag to Simulation. CUDAAgentModel then times and outputs the simulation timing.

Closes #210