### PR TITLE
Reserved names

### DIFF
--- a/include/flamegpu/model/AgentDescription.h
+++ b/include/flamegpu/model/AgentDescription.h
@@ -222,6 +222,10 @@ class AgentDescription {
  */
 template <typename T, ModelData::size_type N>
 void AgentDescription::newVariable(const std::string &variable_name, const std::array<T, N> &default_value) {
+    if (!variable_name.empty() && variable_name[0] == '_') {
+        THROW ReservedName("Agent variable names cannot begin with '_', this is reserved for internal usage, "
+            "in AgentDescription::newVariable().");
+    }
     std::string lower_variable_name = variable_name;
     for (auto& c : lower_variable_name)
         c = static_cast<char>(tolower(c));

--- a/include/flamegpu/model/EnvironmentDescription.h
+++ b/include/flamegpu/model/EnvironmentDescription.h
@@ -222,6 +222,10 @@ class EnvironmentDescription {
  */
 template<typename T>
 void EnvironmentDescription::add(const std::string &name, const T &value, const bool &isConst) {
+    if (!name.empty() && name[0] == '_') {
+        THROW ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
+            "in EnvironmentDescription::add().");
+    }
     // Limited to Arithmetic types
     // Compound types would allow host pointers inside structs to be passed
     static_assert(std::is_arithmetic<T>::value || std::is_enum<T>::value,
@@ -235,6 +239,10 @@ void EnvironmentDescription::add(const std::string &name, const T &value, const 
 }
 template<typename T, EnvironmentManager::size_type N>
 void EnvironmentDescription::add(const std::string &name, const std::array<T, N> &value, const bool &isConst) {
+    if (!name.empty() && name[0] == '_') {
+        THROW ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
+            "in EnvironmentDescription::add().");
+    }
     // Limited to Arithmetic types
     // Compound types would allow host pointers inside structs to be passed
     static_assert(std::is_arithmetic<T>::value || std::is_enum<T>::value,
@@ -327,6 +335,10 @@ T EnvironmentDescription::get(const std::string &name, const EnvironmentManager:
  */
 template<typename T>
 T EnvironmentDescription::set(const std::string &name, const T &value) {
+    if (!name.empty() && name[0] == '_') {
+        THROW ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
+            "in EnvironmentDescription::set().");
+    }
     // Limited to Arithmetic types
     // Compound types would allow host pointers inside structs to be passed
     static_assert(std::is_arithmetic<T>::value || std::is_enum<T>::value,
@@ -350,6 +362,10 @@ T EnvironmentDescription::set(const std::string &name, const T &value) {
 }
 template<typename T, EnvironmentManager::size_type N>
 std::array<T, N> EnvironmentDescription::set(const std::string &name, const std::array<T, N> &value) {
+    if (!name.empty() && name[0] == '_') {
+        THROW ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
+            "in EnvironmentDescription::set().");
+    }
     // Limited to Arithmetic types
     // Compound types would allow host pointers inside structs to be passed
     static_assert(std::is_arithmetic<T>::value || std::is_enum<T>::value,
@@ -379,6 +395,10 @@ std::array<T, N> EnvironmentDescription::set(const std::string &name, const std:
 }
 template<typename T>
 T EnvironmentDescription::set(const std::string &name, const EnvironmentManager::size_type &index, const T &value) {
+    if (!name.empty() && name[0] == '_') {
+        THROW ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
+            "in EnvironmentDescription::set().");
+    }
     // Limited to Arithmetic types
     // Compound types would allow host pointers inside structs to be passed
     static_assert(std::is_arithmetic<T>::value || std::is_enum<T>::value,
@@ -411,6 +431,10 @@ T EnvironmentDescription::set(const std::string &name, const EnvironmentManager:
  */
 template<typename T>
 void EnvironmentDescription::remove(const std::string &name) {
+    if (!name.empty() && name[0] == '_') {
+        THROW ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
+            "in EnvironmentDescription::remove().");
+    }
     // Limited to Arithmetic types
     // Compound types would allow host pointers inside structs to be passed
     static_assert(std::is_arithmetic<T>::value || std::is_enum<T>::value,

--- a/include/flamegpu/runtime/flamegpu_device_api.h
+++ b/include/flamegpu/runtime/flamegpu_device_api.h
@@ -239,6 +239,9 @@ __device__ T FLAMEGPU_READ_ONLY_DEVICE_API::getVariable(const char(&variable_nam
 template<typename MsgIn, typename MsgOut>
 template<typename T, unsigned int N>
 __device__ void FLAMEGPU_DEVICE_API<MsgIn, MsgOut>::setVariable(const char(&variable_name)[N], T value) {
+    if (variable_name[0] == '_') {
+        return;  // Fail silently
+    }
     // simple indexing assumes index is the thread number (this may change later)
     unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
     // set the variable using curve
@@ -268,6 +271,9 @@ __device__ T FLAMEGPU_READ_ONLY_DEVICE_API::getVariable(const char(&variable_nam
 template<typename MsgIn, typename MsgOut>
 template<typename T, unsigned int N, unsigned int M>
 __device__ void FLAMEGPU_DEVICE_API<MsgIn, MsgOut>::setVariable(const char(&variable_name)[M], const unsigned int &array_index, const T &value) {
+    if (variable_name[0] == '_') {
+        return;  // Fail silently
+    }
     // simple indexing assumes index is the thread number (this may change later)
     unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
 
@@ -278,6 +284,9 @@ __device__ void FLAMEGPU_DEVICE_API<MsgIn, MsgOut>::setVariable(const char(&vari
 template<typename MsgIn, typename MsgOut>
 template<typename T, unsigned int N>
 __device__ void FLAMEGPU_DEVICE_API<MsgIn, MsgOut>::AgentOut::setVariable(const char(&variable_name)[N], T value) const {
+    if (variable_name[0] == '_') {
+        return;  // Fail silently
+    }
     if (agent_output_hash) {
         // simple indexing assumes index is the thread number (this may change later)
         unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
@@ -292,6 +301,9 @@ __device__ void FLAMEGPU_DEVICE_API<MsgIn, MsgOut>::AgentOut::setVariable(const 
 template<typename MsgIn, typename MsgOut>
 template<typename T, unsigned int N, unsigned int M>
 __device__ void FLAMEGPU_DEVICE_API<MsgIn, MsgOut>::AgentOut::setVariable(const char(&variable_name)[M], const unsigned int &array_index, T value) const {
+    if (variable_name[0] == '_') {
+        return;  // Fail silently
+    }
     if (agent_output_hash) {
         // simple indexing assumes index is the thread number (this may change later)
         unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;

--- a/include/flamegpu/runtime/flamegpu_host_new_agent_api.h
+++ b/include/flamegpu/runtime/flamegpu_host_new_agent_api.h
@@ -257,14 +257,26 @@ class FLAMEGPU_HOST_NEW_AGENT_API {
      */
     template<typename T>
     void setVariable(const std::string &var_name, const T &val) {
+        if (!var_name.empty() && var_name[0] == '_') {
+            THROW ReservedName("Agent variable names cannot begin with '_', this is reserved for internal usage, "
+                "in FLAMEGPU_HOST_NEW_AGENT_API::setVariable().");
+        }
         s->setVariable<T>(var_name, val);
     }
     template<typename T, unsigned int N>
     void setVariable(const std::string &var_name, const std::array<T, N> &val) {
+        if (!var_name.empty() && var_name[0] == '_') {
+            THROW ReservedName("Agent variable names cannot begin with '_', this is reserved for internal usage, "
+                "in FLAMEGPU_HOST_NEW_AGENT_API::setVariable().");
+        }
         s->setVariable<T, N>(var_name, val);
     }
     template<typename T>
     void setVariable(const std::string &var_name, const unsigned int &index, const T &val) {
+        if (!var_name.empty() && var_name[0] == '_') {
+            THROW ReservedName("Agent variable names cannot begin with '_', this is reserved for internal usage, "
+                "in FLAMEGPU_HOST_NEW_AGENT_API::setVariable().");
+        }
         s->setVariable<T>(var_name, index, val);
     }
     /**

--- a/include/flamegpu/runtime/messaging/Array.h
+++ b/include/flamegpu/runtime/messaging/Array.h
@@ -516,6 +516,9 @@ __device__ T MsgArray::In::Filter::Message::getVariable(const char(&variable_nam
 
 template<typename T, unsigned int N>
 __device__ void MsgArray::Out::setVariable(const char(&variable_name)[N], T value) const {  // message name or variable name
+    if (variable_name[0] == '_') {
+        return;  // Fail silently
+    }
     unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
 
     // set the variable using curve

--- a/include/flamegpu/runtime/messaging/Array2D.h
+++ b/include/flamegpu/runtime/messaging/Array2D.h
@@ -555,6 +555,9 @@ __device__ T MsgArray2D::In::Filter::Message::getVariable(const char(&variable_n
 
 template<typename T, unsigned int N>
 __device__ void MsgArray2D::Out::setVariable(const char(&variable_name)[N], T value) const {  // message name or variable name
+    if (variable_name[0] == '_') {
+        return;  // Fail silently
+    }
     unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
 
     // set the variable using curve

--- a/include/flamegpu/runtime/messaging/Array3D.h
+++ b/include/flamegpu/runtime/messaging/Array3D.h
@@ -574,6 +574,9 @@ __device__ T MsgArray3D::In::Filter::Message::getVariable(const char(&variable_n
 
 template<typename T, unsigned int N>
 __device__ void MsgArray3D::Out::setVariable(const char(&variable_name)[N], T value) const {  // message name or variable name
+    if (variable_name[0] == '_') {
+        return;  // Fail silently
+    }
     unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
 
     // set the variable using curve

--- a/include/flamegpu/runtime/messaging/BruteForce.h
+++ b/include/flamegpu/runtime/messaging/BruteForce.h
@@ -465,6 +465,9 @@ __device__ T MsgBruteForce::Message::getVariable(const char(&variable_name)[N]) 
 */
 template<typename T, unsigned int N>
 __device__ void MsgBruteForce::Out::setVariable(const char(&variable_name)[N], T value) const {  // message name or variable name
+    if (variable_name[0] == '_') {
+        return;  // Fail silently
+    }
     unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;  // + d_message_count;
 
     // Todo: checking if the output message type is single or optional?  (d_message_type)
@@ -481,6 +484,10 @@ __device__ void MsgBruteForce::Out::setVariable(const char(&variable_name)[N], T
  */
 template<typename T>
 void MsgBruteForce::Description::newVariable(const std::string &variable_name) {
+    if (!variable_name.empty() && variable_name[0] == '_') {
+        THROW ReservedName("Message variable names cannot begin with '_', this is reserved for internal usage, "
+            "in MsgBruteForce::Description::newVariable().");
+    }
     if (message->variables.find(variable_name) == message->variables.end()) {
         message->variables.emplace(variable_name, Variable(1, T()));
         return;

--- a/include/flamegpu/runtime/utility/HostEnvironment.cuh
+++ b/include/flamegpu/runtime/utility/HostEnvironment.cuh
@@ -139,10 +139,18 @@ class HostEnvironment {
  */
 template<typename T>
 void HostEnvironment::add(const std::string &name, const T &value, const bool &isConst) const {
+    if (!name.empty() && name[0] == '_') {
+        THROW ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
+            "in HostEnvironment::add().");
+    }
     env_mgr.add<T>({ model_name, name }, value, isConst);
 }
 template<typename T, EnvironmentManager::size_type N>
 void HostEnvironment::add(const std::string &name, const std::array<T, N> &value, const bool &isConst) const {
+    if (!name.empty() && name[0] == '_') {
+        THROW ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
+            "in HostEnvironment::add().");
+    }
     env_mgr.add<T, N>({ model_name, name }, value, isConst);
 }
 
@@ -151,14 +159,26 @@ void HostEnvironment::add(const std::string &name, const std::array<T, N> &value
  */
 template<typename T>
 T HostEnvironment::set(const std::string &name, const T &value) const {
+    if (!name.empty() && name[0] == '_') {
+        THROW ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
+            "in HostEnvironment::set().");
+    }
     return env_mgr.set<T>({ model_name, name }, value);
 }
 template<typename T, EnvironmentManager::size_type N>
 std::array<T, N> HostEnvironment::set(const std::string &name, const std::array<T, N> &value) const {
+    if (!name.empty() && name[0] == '_') {
+        THROW ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
+            "in HostEnvironment::set().");
+    }
     return env_mgr.set<T, N>({ model_name, name }, value);
 }
 template<typename T>
 T HostEnvironment::set(const std::string &name, const EnvironmentManager::size_type &index, const T &value) const {
+    if (!name.empty() && name[0] == '_') {
+        THROW ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
+            "in HostEnvironment::set().");
+    }
     return env_mgr.set<T>({ model_name, name }, index, value);
 }
 

--- a/src/flamegpu/model/EnvironmentDescription.cu
+++ b/src/flamegpu/model/EnvironmentDescription.cu
@@ -36,6 +36,10 @@ void EnvironmentDescription::add(const std::string &name, const char *ptr, const
 }
 
 void EnvironmentDescription::setConst(const std::string &name, const bool &isConst) {
+    if (!name.empty() && name[0] == '_') {
+        THROW ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
+            "in EnvironmentDescription::setConst().");
+    }
     for (auto &i : properties) {
         if (i.first == name) {
             i.second.isConst = isConst;

--- a/src/flamegpu/runtime/messaging/Array.cu
+++ b/src/flamegpu/runtime/messaging/Array.cu
@@ -108,7 +108,7 @@ MsgArray::Data::Data(ModelData *const model, const std::string &message_name)
     : MsgBruteForce::Data(model, message_name)
     , length(0) {
     description = std::unique_ptr<MsgArray::Description>(new MsgArray::Description(model, this));
-    description->newVariable<size_type>("___INDEX");
+    variables.emplace("___INDEX", Variable(1, size_type()));
 }
 MsgArray::Data::Data(ModelData *const model, const Data &other)
     : MsgBruteForce::Data(model, other)

--- a/src/flamegpu/runtime/messaging/Array2D.cu
+++ b/src/flamegpu/runtime/messaging/Array2D.cu
@@ -123,7 +123,7 @@ MsgArray2D::Data::Data(ModelData *const model, const std::string &message_name)
     : MsgBruteForce::Data(model, message_name)
     , dimensions({ 0, 0 }) {
     description = std::unique_ptr<MsgArray2D::Description>(new MsgArray2D::Description(model, this));
-    description->newVariable<size_type>("___INDEX");
+    variables.emplace("___INDEX", Variable(1, size_type()));
 }
 MsgArray2D::Data::Data(ModelData *const model, const Data &other)
     : MsgBruteForce::Data(model, other)

--- a/src/flamegpu/runtime/messaging/Array3D.cu
+++ b/src/flamegpu/runtime/messaging/Array3D.cu
@@ -135,7 +135,7 @@ MsgArray3D::Data::Data(ModelData *const model, const std::string &message_name)
     : MsgBruteForce::Data(model, message_name)
     , dimensions({0, 0, 0}) {
     description = std::unique_ptr<MsgArray3D::Description>(new MsgArray3D::Description(model, this));
-    description->newVariable<size_type>("___INDEX");
+    variables.emplace("___INDEX", Variable(1, size_type()));
 }
 MsgArray3D::Data::Data(ModelData *const model, const Data &other)
     : MsgBruteForce::Data(model, other)

--- a/tests/test_cases/gpu/test_cuda_agent_model.cu
+++ b/tests/test_cases/gpu/test_cuda_agent_model.cu
@@ -48,7 +48,7 @@ TEST(TestCUDAAgentModel, AllDeviceIdValues) {
         bool shouldThrowCCException = !util::compute_capability::checkComputeCapability(i);
         // Initialise and run a simple model on each device in the system. This test is pointless on single GPU machines.
         ModelDescription m(MODEL_NAME);
-        AgentDescription &a = m.newAgent(AGENT_NAME);
+        m.newAgent(AGENT_NAME);
         // Scoping
         {
             CUDAAgentModel c(m);

--- a/tests/test_cases/model/test_agent.cu
+++ b/tests/test_cases/model/test_agent.cu
@@ -173,5 +173,20 @@ TEST(AgentDescriptionTest, agent_outputs) {
     f2.setAgentOutput(b);
     EXPECT_EQ(a.getAgentOutputsCount(), 1u);
 }
+TEST(AgentDescriptionTest, reserved_name) {
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME1);
+    EXPECT_THROW(a.newVariable<int>("_"), ReservedName);
+    EXPECT_THROW(a.newVariable<int>("name"), ReservedName);
+    EXPECT_THROW(a.newVariable<int>("state"), ReservedName);
+    EXPECT_THROW(a.newVariable<int>("nAme"), ReservedName);
+    EXPECT_THROW(a.newVariable<int>("sTate"), ReservedName);
+    auto array_version = &AgentDescription::newVariable<int, 3>;
+    EXPECT_THROW((a.*array_version)("_", {}), ReservedName);
+    EXPECT_THROW((a.*array_version)("name", {}), ReservedName);
+    EXPECT_THROW((a.*array_version)("state", {}), ReservedName);
+    EXPECT_THROW((a.*array_version)("nAme", {}), ReservedName);
+    EXPECT_THROW((a.*array_version)("sTate", {}), ReservedName);
+}
 
 }  // namespace test_agent

--- a/tests/test_cases/model/test_environment_description.cu
+++ b/tests/test_cases/model/test_environment_description.cu
@@ -356,3 +356,14 @@ TEST(EnvironmentDescriptionTest, ExceptionPropertyDoesntExist) {
     EXPECT_THROW(ed.get<float>("a", 1), InvalidEnvProperty);
     EXPECT_THROW(ed.remove<float>("a"), InvalidEnvProperty);
 }
+
+TEST(EnvironmentDescriptionTest, reserved_name) {
+    EnvironmentDescription ed;
+    EXPECT_THROW(ed.add<int>("_", 1), ReservedName);
+    EXPECT_THROW(ed.set<int>("_", 1), ReservedName);
+    EXPECT_THROW(ed.setConst("_", true), ReservedName);
+    auto add = &EnvironmentDescription::add<int, 2>;
+    auto set = &EnvironmentDescription::set<int, 2>;
+    EXPECT_THROW((ed.*add)("_", { 1, 2 }, false), ReservedName);
+    EXPECT_THROW((ed.*set)("_", { 1, 2 }), ReservedName);
+}

--- a/tests/test_cases/runtime/messaging/test_array.cu
+++ b/tests/test_cases/runtime/messaging/test_array.cu
@@ -300,9 +300,14 @@ TEST(TestMessage_Array, ArrayLenZeroException) {
 }
 TEST(TestMessage_Array, UnsetLength) {
     ModelDescription model(MODEL_NAME);
-    MsgArray::Description &message = model.newMessage<MsgArray>(MESSAGE_NAME);
+    model.newMessage<MsgArray>(MESSAGE_NAME);
     // message.setLength(5);  // Intentionally commented out
     EXPECT_THROW(CUDAAgentModel m(model), InvalidMessage);
+}
+TEST(TestMessage_Array, reserved_name) {
+    ModelDescription model(MODEL_NAME);
+    MsgArray::Description &message = model.newMessage<MsgArray>(MESSAGE_NAME);
+    EXPECT_THROW(message.newVariable<int>("_"), ReservedName);
 }
 
 }  // namespace test_message_array

--- a/tests/test_cases/runtime/messaging/test_array_2d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_2d.cu
@@ -327,9 +327,14 @@ TEST(TestMessage_Array2D, ArrayLenZeroException) {
 }
 TEST(TestMessage_Array2D, UnsetDimensions) {
     ModelDescription model(MODEL_NAME);
-    MsgArray2D::Description &message = model.newMessage<MsgArray2D>(MESSAGE_NAME);
+    model.newMessage<MsgArray2D>(MESSAGE_NAME);
     // message.setDimensions(5, 5);  // Intentionally commented out
     EXPECT_THROW(CUDAAgentModel m(model), InvalidMessage);
+}
+TEST(TestMessage_Array2D, reserved_name) {
+    ModelDescription model(MODEL_NAME);
+    MsgArray2D::Description &message = model.newMessage<MsgArray2D>(MESSAGE_NAME);
+    EXPECT_THROW(message.newVariable<int>("_"), ReservedName);
 }
 
 }  // namespace test_message_array_2d

--- a/tests/test_cases/runtime/messaging/test_array_3d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_3d.cu
@@ -342,9 +342,14 @@ TEST(TestMessage_Array3D, ArrayLenZeroException) {
 }
 TEST(TestMessage_Array3D, UnsetDimensions) {
     ModelDescription model(MODEL_NAME);
-    MsgArray3D::Description &message = model.newMessage<MsgArray3D>(MESSAGE_NAME);
+    model.newMessage<MsgArray3D>(MESSAGE_NAME);
     // message.setDimensions(5, 5, 5);  // Intentionally commented out
     EXPECT_THROW(CUDAAgentModel m(model), InvalidMessage);
+}
+TEST(TestMessage_Array3D, reserved_name) {
+    ModelDescription model(MODEL_NAME);
+    MsgArray3D::Description &message = model.newMessage<MsgArray3D>(MESSAGE_NAME);
+    EXPECT_THROW(message.newVariable<int>("_"), ReservedName);
 }
 
 }  // namespace test_message_array_3d

--- a/tests/test_cases/runtime/messaging/test_brute_force.cu
+++ b/tests/test_cases/runtime/messaging/test_brute_force.cu
@@ -262,4 +262,10 @@ TEST(TestMessage_BruteForce, Optional2) {
     }
 }
 
+TEST(TestMessage_BruteForce, reserved_name) {
+    ModelDescription m(MODEL_NAME);
+    MsgBruteForce::Description &msg = m.newMessage(MESSAGE_NAME);
+    EXPECT_THROW(msg.newVariable<int>("_"), ReservedName);
+}
+
 }  // namespace test_message_brute_force

--- a/tests/test_cases/runtime/messaging/test_spatial_2d.cu
+++ b/tests/test_cases/runtime/messaging/test_spatial_2d.cu
@@ -356,5 +356,10 @@ TEST(Spatial2DMsgTest, UnsetMin) {
     message.setMin(5, 5);
     EXPECT_THROW(CUDAAgentModel m(model), InvalidMessage);
 }
+TEST(Spatial2DMsgTest, reserved_name) {
+    ModelDescription model("Spatial2DMsgTestModel");
+    MsgSpatial2D::Description &message = model.newMessage<MsgSpatial2D>("location");
+    EXPECT_THROW(message.newVariable<int>("_"), ReservedName);
+}
 
 }  // namespace test_message_spatial2d

--- a/tests/test_cases/runtime/messaging/test_spatial_3d.cu
+++ b/tests/test_cases/runtime/messaging/test_spatial_3d.cu
@@ -394,4 +394,9 @@ TEST(Spatial3DMsgTest, UnsetMin) {
     message.setMin(5, 5, 5);
     EXPECT_THROW(CUDAAgentModel m(model), InvalidMessage);
 }
+TEST(Spatial3DMsgTest, reserved_name) {
+    ModelDescription model("Spatial3DMsgTestModel");
+    MsgSpatial3D::Description &message = model.newMessage<MsgSpatial3D>("location");
+    EXPECT_THROW(message.newVariable<int>("_"), ReservedName);
+}
 }  // namespace test_message_spatial3d

--- a/tests/test_cases/runtime/test_host_agent_creation.cu
+++ b/tests/test_cases/runtime/test_host_agent_creation.cu
@@ -650,4 +650,25 @@ TEST(HostAgentCreationTest, HostAgentBirth_ArrayNotSuitableGet) {
     CUDAAgentModel sim(model);
     EXPECT_THROW(sim.step(), InvalidAgentVar);
 }
+FLAMEGPU_STEP_FUNCTION(reserved_name_step) {
+    FLAMEGPU->newAgent("agent_name").setVariable<int>("_", 0);
+}
+FLAMEGPU_STEP_FUNCTION(reserved_name_step_array) {
+    FLAMEGPU->newAgent("agent_name").setVariable<int, 3>("_", {});
+}
+TEST(HostAgentCreationTest, reserved_name) {
+    ModelDescription model("model");
+    model.newAgent("agent_name");
+    // Run the init function
+    model.addStepFunction(reserved_name_step);
+    CUDAAgentModel sim(model);
+    EXPECT_THROW(sim.step(), ReservedName);
+}
+TEST(HostAgentCreationTest, reserved_name_array) {
+    ModelDescription model("model");
+    model.newAgent("agent_name");
+    model.addStepFunction(reserved_name_step_array);
+    CUDAAgentModel sim(model);
+    EXPECT_THROW(sim.step(), ReservedName);
+}
 }  // namespace test_host_agent_creation

--- a/tests/test_cases/runtime/test_host_environment.cu
+++ b/tests/test_cases/runtime/test_host_environment.cu
@@ -1609,3 +1609,41 @@ TEST_F(HostEnvironmentTest, BoolWorks) {
     // Test Something
     ms->run(1);
 }
+
+
+FLAMEGPU_STEP_FUNCTION(reserved_name_add_step) {
+    FLAMEGPU->environment.add<int>("_", 1);
+}
+FLAMEGPU_STEP_FUNCTION(reserved_name_add_array_step) {
+    FLAMEGPU->environment.add<int, 2>("_", {1, 2});
+}
+FLAMEGPU_STEP_FUNCTION(reserved_name_set_step) {
+    FLAMEGPU->environment.set<int>("_", 1);
+}
+FLAMEGPU_STEP_FUNCTION(reserved_name_set_array_step) {
+    FLAMEGPU->environment.set<int, 2>("_", { 1, 2 });
+}
+TEST_F(HostEnvironmentTest, reserved_name_add) {
+    ModelDescription model("model");
+    model.addStepFunction(reserved_name_add_step);
+    CUDAAgentModel sim(model);
+    EXPECT_THROW(sim.step(), ReservedName);
+}
+TEST_F(HostEnvironmentTest, reserved_name_add_array) {
+    ModelDescription model("model");
+    model.addStepFunction(reserved_name_add_array_step);
+    CUDAAgentModel sim(model);
+    EXPECT_THROW(sim.step(), ReservedName);
+}
+TEST_F(HostEnvironmentTest, reserved_name_set) {
+    ModelDescription model("model");
+    model.addStepFunction(reserved_name_set_step);
+    CUDAAgentModel sim(model);
+    EXPECT_THROW(sim.step(), ReservedName);
+}
+TEST_F(HostEnvironmentTest, reserved_name_set_array) {
+    ModelDescription model("model");
+    model.addStepFunction(reserved_name_set_array_step);
+    CUDAAgentModel sim(model);
+    EXPECT_THROW(sim.step(), ReservedName);
+}


### PR DESCRIPTION
Closes #206
*This is forked from xml_export, so should be merged after (hence keeping it draft).*

Update Agent, Message, Env vars to not allow variables that begin with `_` to be created or set by the user (haven't bothered disabling read-only methods, majority of cases variable doesn't exist will trigger).

Affected Methods:
* `AgentDescription::newVariable()`
* `FLAMEGPU_DEVICE_API::setVariable()`
* `FLAMEGPU_DEVICE_API::AgentOut::setVariable()`
* `FLAMEGPU_HOST_NEW_AGENT_API::setVariable()`
* `MsgBruteForce::Description::newVariable()` (Inherited by all? message types)
* `MsgBruteForce::Out::setVariable()` (Inherited by most message types)
* `MsgArray::Out::setVariable()`
* `MsgArray2D::Out::setVariable()`
* `MsgArray3D::Out::setVariable()`
* `EnvironmentDescription::add()`
* `EnvironmentDescription::set()`
* `EnvironmentDescription::setConst()`
* `HostEnvironment::add()`
* `HostEnvironment::set()`