### PR TITLE
Fix segfault under linux by stopping cudaFree in CUDAScatter destructor

### DIFF
--- a/src/flamegpu/gpu/CUDAScatter.cu
+++ b/src/flamegpu/gpu/CUDAScatter.cu
@@ -15,7 +15,12 @@ CUDAScatter::CUDAScatter()
     , data_len(0) {
 }
 CUDAScatter::~CUDAScatter() {
-    free();
+    /* @note - Do not clear cuda memory in the destructor of singletons.
+     This is because order of static destruction in c++ is undefined
+     So the cuda driver is not guaranteed to still exist when the static is destroyed.
+     As this is only ever destroyed at exit time, it's not a real memory leak either.
+    */
+    // free();
 }
 void CUDAScatter::free() {
     if (d_data) {


### PR DESCRIPTION
This is a temporary fix until #232 is implemented, where a non-singleton / non-static instance will manage the cuda memory.