### PR TITLE
Sets tests Debug builds to use '--gtest_catch_exceptions=0'

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ Automatic updating of GoogleTest can be disabled by passing `-DBUILD_TESTS=OFF`.
 
 *Known Issues:* The tests do not build under the combination of Visual Studio 2015 and CUDA 9.0 or 9.1. Use CUDA 9.2 or newer if you require the tests.
 
+GoogleTest runtime documentation can be found [here](https://github.com/google/googletest/blob/master/googletest/docs/advanced.md).
+In particular `--gtest_catch_exceptions=0` may be useful during test development, so that unhandled exceptions are passed straight to the debugger.
+
 ##### Documentation
 
 If you wish to build the documentation, [doxygen](http://www.doxygen.nl/) must be available on your system.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -162,6 +162,10 @@ CMAKE_SET_TARGET_FOLDER("gtest" "Tests/Dependencies")
 # Also set as startup project (if top level project)
 set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"  PROPERTY VS_STARTUP_PROJECT "${PROJECT_NAME}")
 
+# Set the default (visual studio) debugger configure_file
+set_target_properties("${PROJECT_NAME}" PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                                                   VS_DEBUGGER_COMMAND_ARGUMENTS "$<$<CONFIG:Debug>:--gtest_catch_exceptions=0>")
+
 option(TEST_DEV_MODE "Create a mini project for fast building of tests during development" OFF)
 if(TEST_DEV_MODE)
     # DEVELOPMENT TESTING THING (Compact repeated version of above)
@@ -185,4 +189,8 @@ if(TEST_DEV_MODE)
     target_link_libraries("${PROJECT_NAME}" gtest)
     # target_link_libraries("${PROJECT_NAME}" gmock) # Currently unused
     CMAKE_SET_TARGET_FOLDER("${PROJECT_NAME}" "Tests")
+    
+    # Set the default (visual studio) debugger configure_file
+    set_target_properties("${PROJECT_NAME}" PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                                                       VS_DEBUGGER_COMMAND_ARGUMENTS "$<$<CONFIG:Debug>:--gtest_catch_exceptions=0>")
 endif()


### PR DESCRIPTION
This stops googletest handling exceptions, which loses the call stack from which they are thrown (which makes debugging exceptions thrown during tests a real pain).

Also affectes tests_dev

As mentioned on slack:
> If you want similar on linux @ptheywood, without remembering that arg. It's documented that setting a similar env var also works.
> Could modify the testing main to set that env var within the session on debug?
https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#disabling-catching-test-thrown-exceptions

```C
#include <cstdlib>

putenv("GTEST_CATCH_EXCEPTIONS=0");
```

*Edit: I tried the put env var version on Windows, whilst it compiles (angry note in vs about deprecated), it doesn't work. Runtime arg one is fine though. With debugger, confirmed it checks env var before `main()`, so `putenv()` isn't an option. A nasty option would be to manually add it to the runtime args which are forwarded to gtest under debug.*