### PR TITLE
Disable MSVC warning 4100 - unreferenced formal parameter.

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -205,6 +205,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler /wd4505")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4505")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4505")
+    # unreferenced formal parameter warnings disabled - tests make use of it.
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler /wd4100")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4100")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4100")
     set(CUDA_DEVICE_LINK_FLAGS "${CUDA_DEVICE_LINK_FLAGS} -Xcompiler /wd4100")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /experimental:external")
     # These flags don't currently have any effect on how CMake passes system-private includes to msvc

--- a/tests/helpers/host_reductions_common.h
+++ b/tests/helpers/host_reductions_common.h
@@ -1,10 +1,20 @@
 #ifndef TESTS_HELPERS_HOST_REDUCTIONS_COMMON_H_
 #define TESTS_HELPERS_HOST_REDUCTIONS_COMMON_H_
 
-#include <array>
-#include <random>
+#ifdef _MSC_VER
+#pragma warning(push)
+// conversion warnings inside header (e.g. int vs std::_Array_iterator<int, 256>)
+#pragma warning(disable:4244)
+#pragma warning(disable:4389)
 #include <numeric>
 #include <algorithm>
+#pragma warning(pop)
+#else
+#include <numeric>
+#include <algorithm>
+#endif
+#include <array>
+#include <random>
 #include <vector>
 
 #include "gtest/gtest.h"


### PR DESCRIPTION
This warning is hard to avoid with agent/host functions which do not refernece the FLAMEGPU object.

Untested on windows