### PR TITLE
Check CUDA version at cmake time.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,23 @@ project(FLAMEGPU2 LANGUAGES NONE)
 set(CMAKE_SKIP_INSTALL_RULES TRUE)
 set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}" CACHE INTERNAL ""  FORCE)
 
-# See what languages are supported
+# See if the minimum CUDA version is available. If not, only enable documentation building.
+set(MINIMUM_SUPPORTED_CUDA_VERSION 9.0)
 include(CheckLanguage)
+# See if CUDA is available
 check_language(CUDA)
-if(CMAKE_CUDA_COMPILER STREQUAL NOTFOUND)
+# If so, enable CUDA to check the version.
+if(CMAKE_CUDA_COMPILER)
+    enable_language(CUDA)
+endif()
+# If CUDA is not available, or the minimum version is too low only build the docs.
+if(NOT CMAKE_CUDA_COMPILER OR CMAKE_CUDA_COMPILER_VERSION VERSION_LESS ${MINIMUM_SUPPORTED_CUDA_VERSION})
+    if(NOT CMAKE_CUDA_COMPILER)
+        message(STATUS "Documentation-only build: CUDA toolkit required for library compilation.")
+    else()
+        message(STATUS "Documentation-only build: CUDA ${MINIMUM_SUPPORTED_CUDA_VERSION} or greater is required for library compilation.")
+    endif()
     #Not able to build code, so just make docs    
-    message("Suitable compilers for building code not found.\n" "Attempting generation of minimal documentation only project.")    
     get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR} REALPATH)
     include(./cmake/doxygen.cmake)
     if(${BUILD_API_DOCUMENTATION})

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Only documentation can be built without the required dependencies (however Doxyg
 #### Required
 
 * [CMake](https://cmake.org/) >= 3.12
-* [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit) >= 8.0
+* [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit) >= 9.0
 * *Linux:*
   * [make](https://www.gnu.org/software/make/)
   * gcc (version requirements [here](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#system-requirements))


### PR DESCRIPTION

Updates the root cmake to check CUDA version is (if available) new enough to build flamegpu2.

CUDA 9.0 is required for `--std=c++14`.

Also updates the readme.

If CUDA is available but `< 9.0` the following is output to stdout:

```
Detecting CUDA compile features - done
-- Documentation-only build: CUDA 9.0 or greater is required for library compilation.
-- Found Doxygen: /usr/bin/doxygen (found version "1.8.13") found components: doxygen dot missing components: mscgen dia
```

If CUDA is not available the following is output to stdout:

```
Looking for a CUDA compiler - NOTFOUND
-- Documentation-only build: CUDA toolkit required for library compilation.
-- Found Doxygen: /usr/bin/doxygen (found version "1.8.13") found components: doxygen dot missing components: mscgen dia
```

Closes #250 