### PR TITLE
Doxygen Tweaks

### DIFF
--- a/cmake/doxygen.cmake
+++ b/cmake/doxygen.cmake
@@ -46,8 +46,9 @@ function(create_doxygen_target FLAMEGPU_ROOT DOXY_OUT_DIR XML_PATH)
         # Limit diagram graph node count / depth for simply diagrams.
         set(DOXYGEN_DOT_GRAPH_MAX_NODES   100)
         set(DOXYGEN_MAX_DOT_GRAPH_DEPTH   0)
-        # Select diagram output format {png, YES/NO}, {svg, YES}, {svg, NO} 
+        # Select diagram output format i.e png or svg
         set(DOXYGEN_DOT_IMAGE_FORMAT      png)
+        # If using svg the interactivity can be enabled if desired.
         set(DOXYGEN_INTERACTIVE_SVG       NO)
         # Replace full absolute paths with relative paths to the project root.
         set(DOXYGEN_FULL_PATH_NAMES       YES)

--- a/cmake/doxygen.cmake
+++ b/cmake/doxygen.cmake
@@ -45,7 +45,7 @@ function(create_doxygen_target FLAMEGPU_ROOT DOXY_OUT_DIR XML_PATH)
         set(DOXYGEN_EXTENSION_MAPPING     "cu=C++" "cuh=C++" "cuhpp=C++")
         # Limit diagram graph node count / depth for simply diagrams.
         set(DOXYGEN_DOT_GRAPH_MAX_NODES   100)
-        set(DOXYGEN_MAX_DOT_GRAPH_DEPTH   0)
+        set(DOXYGEN_MAX_DOT_GRAPH_DEPTH   1)
         # Select diagram output format i.e png or svg
         set(DOXYGEN_DOT_IMAGE_FORMAT      png)
         # If using svg the interactivity can be enabled if desired.

--- a/cmake/doxygen.cmake
+++ b/cmake/doxygen.cmake
@@ -34,18 +34,25 @@ function(create_doxygen_target FLAMEGPU_ROOT DOXY_OUT_DIR XML_PATH)
         set(DOXYGEN_UML_LOOK              YES)
         set(DOXYGEN_UML_LIMIT_NUM_FIELDS  50)
         set(DOXYGEN_TEMPLATE_RELATIONS    YES)
-        set(DOXYGEN_DOT_GRAPH_MAX_NODES   100)
-        set(DOXYGEN_MAX_DOT_GRAPH_DEPTH   0)
         set(DOXYGEN_DOT_TRANSPARENT       NO)
         set(DOXYGEN_CALL_GRAPH            YES)
         set(DOXYGEN_CALLER_GRAPH          YES)
         set(DOXYGEN_GENERATE_TREEVIEW     YES)
-        set(DOXYGEN_DOT_IMAGE_FORMAT      png) # can be  svg, but the add --> DOXYGEN_INTERACTIVE_SVG      = YES
         set(DOXYGEN_EXTRACT_PRIVATE       YES)
         set(DOXYGEN_EXTRACT_STATIC        YES)
         set(DOXYGEN_EXTRACT_LOCAL_METHODS NO)
         set(DOXYGEN_FILE_PATTERNS         "*.h" "*.cuh" "*.c" "*.cpp" "*.cu" "*.cuhpp" "*.md" "*.hh" "*.hxx" "*.hpp" "*.h++" "*.cc" "*.cxx" "*.c++")
         set(DOXYGEN_EXTENSION_MAPPING     "cu=C++" "cuh=C++" "cuhpp=C++")
+        # Limit diagram graph node count / depth for simply diagrams.
+        set(DOXYGEN_DOT_GRAPH_MAX_NODES   100)
+        set(DOXYGEN_MAX_DOT_GRAPH_DEPTH   0)
+        # Select diagram output format {png, YES/NO}, {svg, YES}, {svg, NO} 
+        set(DOXYGEN_DOT_IMAGE_FORMAT      png)
+        set(DOXYGEN_INTERACTIVE_SVG       NO)
+        # Replace full absolute paths with relative paths to the project root.
+        set(DOXYGEN_FULL_PATH_NAMES       YES)
+        set(DOXYGEN_STRIP_FROM_PATH       ${FLAMEGPU_ROOT})
+        set(DOXYGEN_STRIP_FROM_INC_PATH   ${FLAMEGPU_ROOT})
         # These are required for expanding FGPUException definition macros to be documented
         set(DOXYGEN_ENABLE_PREPROCESSING  YES)
         set(DOXYGEN_MACRO_EXPANSION       YES)


### PR DESCRIPTION
This PR is for making tweaks to the doxygen configuraiton.

So far: 
+ [x] Strips absolute paths to be `FLAMEGPU_ROOT` relative i.e. in diagrams `/home/user/path/to/flamegpu/include/flamegpu/model/AgentFunctionDescription.h` becomes `include/flamegpu/model/AgentFunctionDescription.h`

I'd also suggest:

+ [x] restricting the number of layers to which diagrams are generated to `1` via `set(DOXYGEN_MAX_DOT_GRAPH_DEPTH   1)`. 

This greatly simplifies the include dependency diagrams so they are actually legible, but does lose some information on dependency chains. 
Links are generated so that you can easily follow dependency chains through (red boxes).

I.e. for `AgentFunctionDescription.h`:

With `DOXYGEN_MAX_DOT_GRAPH_DEPTH = 0`

![image](https://user-images.githubusercontent.com/628937/81557638-360cdc00-9384-11ea-875b-40524334b29e.png)


And with `DOXYGEN_MAX_DOT_GRAPH_DEPTH = 1`

![image](https://user-images.githubusercontent.com/628937/81557701-5046ba00-9384-11ea-8fe4-f7c04b4f75bc.png)


And with `DOXYGEN_MAX_DOT_GRAPH_DEPTH = 2`

![image](https://user-images.githubusercontent.com/628937/81557752-68b6d480-9384-11ea-827c-3d869dd0a49d.png)

