### PR TITLE
Remove redundant args sent to runtime compilation.

### DIFF
--- a/src/flamegpu/gpu/CUDAAgent.cu
+++ b/src/flamegpu/gpu/CUDAAgent.cu
@@ -561,25 +561,11 @@ void CUDAAgent::addInstantitateRTCFunction(const AgentFunctionData& func, bool f
     std::string include_fgpu;
     include_fgpu = "-I" + std::string(env_inc_fgp2);
     options.push_back(include_fgpu);
-    // std::cout << "fgpu include option is " << include_fgpu << '\n';     // TODO: Remove DEBUG
 
     // cuda path
     std::string include_cuda;
     include_cuda = "--include-path=" + std::string(env_cuda_path) + "/include";
     options.push_back(include_cuda);
-    // std::cout << "cuda include option is " << include_cuda << '\n';     // TODO: Remove DEBUG
-
-    // add __CUDACC_RTC__ symbol
-    std::string rtc_symbol;
-    rtc_symbol = "-D__CUDACC_RTC__";
-    options.push_back(rtc_symbol);
-    // std::cout << "RTC pre-processor symbol is " << rtc_symbol << '\n';     // TODO: Remove DEBUG
-
-    // rdc
-    std::string rdc;
-    rdc = "-rdc=true";
-    options.push_back(rdc);
-    // std::cout << "rdc option is " << rdc << '\n';                       // TODO: Remove DEBUG
 
     // curve rtc header
     CurveRTCHost curve_header;


### PR DESCRIPTION
`__CUDACC_RTC__` is defined by the compiler, need not be specified.

`-rdc=true` is not used (RTC does not support linking with executing assembly), and carries a runtime overhead to performance (e.g. ~10% slower).

Tested this in Visual Studio 2015

Longer term, we might want to think about if we can remove `rdc=true` from the main library, we'd simply need to find a convenient way of managing our use of constant memory.


--------------
Unrelated note, most of the RTC tests have this compilation warning (with or without the change), unsure if its visual studio 2015 specific.

```
---------------------------------------------------
--- JIT compile log for rtc_env_func_program ---
---------------------------------------------------
dynamic/curve_rtc_dynamic.h(45): warning: extern declaration of the entity Curve::UNKNOWN_VARIABLE is treated as a static definition

flamegpu/exception/FGPUStaticAssert.h(14): warning: extern declaration of the entity FGPU_SA::integral_constant<bool, (bool)0> ::value is treated as a static definition

flamegpu/exception/FGPUStaticAssert.h(14): warning: extern declaration of the entity FGPU_SA::integral_constant<bool, (bool)1> ::value is treated as a static definition

flamegpu/gpu/CUDAScanCompaction.h(77): warning: extern declaration of the entity flamegpu_internal::CUDAScanCompaction::hd_configs is treated as a static definition

flamegpu/runtime/utility/DeviceEnvironment.cuh(16): warning: extern declaration of the entity flamegpu_internal::c_deviceEnvErrorPattern is treated as a static definition
```