### PR TITLE
This should fix the issue templates to work with GitHub properly.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug report
-about: Create a report to help us improve
-title: '[BugReport]'
-labels: ''
+about: Report a problem with flamegpu2
+title: ''
+labels: triage required
 assignees: ''
 
 ---
@@ -27,6 +27,7 @@ If applicable, add screenshots to help explain your problem.
  - OS: [e.g. Ubuntu 16.04, Windows 10]
  - CUDA version: [e.g. 10.1]
  - GPU [e.g. Titan X (Pascal)]
+ - GPU Driver Version [e.g. 445.75]
 
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
+about: Suggest an idea for flamegpu2
 title: '[FeatureReq]'
 labels: ''
 assignees: ''


### PR DESCRIPTION
I added Issue templates a long while back, but placed them in the wrong directory, this fixes that with a small tweak to their content.

*This isn't strictly necessary until release, but should be harmless (worst case its 2 clicks rather than 1 to create new issues sans template).*