### PR TITLE
Exception consistency changes.

### DIFF
--- a/include/flamegpu/exception/FGPUException.h
+++ b/include/flamegpu/exception/FGPUException.h
@@ -60,7 +60,7 @@ class name : public FGPUException {\
         va_start(argp, format);\
         err_message += parseArgs(format, argp);\
         va_end(argp);\
-        fprintf(stderr, "%s", err_message.c_str()); \
+        fprintf(stderr, "%s\n", err_message.c_str()); \
     }\
 }
 #else

--- a/include/flamegpu/io/factory.h
+++ b/include/flamegpu/io/factory.h
@@ -48,7 +48,7 @@ class ReaderFactory {
         }
         */
         THROW UnsupportedFileType("File '%s' is not a type which can be read "
-            "by ReaderFactory::createReader().\n",
+            "by ReaderFactory::createReader().",
             input.c_str());
     }
 };

--- a/include/flamegpu/model/LayerDescription.h
+++ b/include/flamegpu/model/LayerDescription.h
@@ -166,7 +166,7 @@ void LayerDescription::addAgentFunction(AgentFunction /*af*/) {
                                 b->end_state == f.second->end_state) {
                                 THROW InvalidAgentFunc("Agent functions '%s' cannot be added to this layer as agent function '%s' "
                                     "within the layer shares an input or output state, this is not permitted, "
-                                    "in LayerDescription::addAgentFunction()\n",
+                                    "in LayerDescription::addAgentFunction().",
                                     f.second->name.c_str(), b->name.c_str());
                             }
                         }
@@ -176,12 +176,12 @@ void LayerDescription::addAgentFunction(AgentFunction /*af*/) {
                 if (layer->agent_functions.emplace(f.second).second)
                     return;
                 THROW InvalidAgentFunc("Attempted to add same agent function to same layer twice, "
-                    "in LayerDescription::addAgentFunction()\n");
+                    "in LayerDescription::addAgentFunction().");
             }
         }
     }
     THROW InvalidAgentFunc("Agent function was not found, "
-        "in LayerDescription::addAgentFunction()\n");
+        "in LayerDescription::addAgentFunction().");
 }
 
 #endif  // INCLUDE_FLAMEGPU_MODEL_LAYERDESCRIPTION_H_

--- a/include/flamegpu/runtime/flamegpu_host_new_agent_api.h
+++ b/include/flamegpu/runtime/flamegpu_host_new_agent_api.h
@@ -73,13 +73,13 @@ struct NewAgentStorage {
         const auto &var = offsets.vars.find(var_name);
         if (var == offsets.vars.end()) {
             THROW InvalidAgentVar("Variable '%s' not found, "
-                "in NewAgentStorage.setVariable()\n",
+                "in NewAgentStorage.setVariable().",
                 var_name.c_str());
         }
         const auto t_type = std::type_index(typeid(T));
         if (var->second.type != std::type_index(typeid(T))) {
             THROW InvalidVarType("Variable '%s' has type '%s, incorrect  type '%s' was requested, "
-                "in NewAgentStorage.setVariable()\n",
+                "in NewAgentStorage.setVariable().",
                 var_name.c_str(), var->second.type.name(), t_type.name());
         }
         if (var->second.len != sizeof(T)) {
@@ -95,7 +95,7 @@ struct NewAgentStorage {
         const auto &var = offsets.vars.find(var_name);
         if (var == offsets.vars.end()) {
             THROW InvalidAgentVar("Variable '%s' not found, "
-                "in NewAgentStorage.setVariable()\n",
+                "in NewAgentStorage.setVariable().",
                 var_name.c_str());
         }
         // if (var.second.len == 1 || N == 1) {
@@ -106,12 +106,12 @@ struct NewAgentStorage {
         const auto t_type = std::type_index(typeid(T));
         if (var->second.type != std::type_index(typeid(T))) {
             THROW InvalidVarType("Variable '%s' has type '%s, incorrect  type '%s' was requested, "
-                "in NewAgentStorage.setVariable()\n",
+                "in NewAgentStorage.setVariable().",
                 var_name.c_str(), var->second.type.name(), t_type.name());
         }
         if (var->second.len != sizeof(T) * N) {
             THROW InvalidVarArrayLen("Variable '%s' is an array with %u elements, incorrect array of length %u was provided, "
-                "in NewAgentStorage.setVariable()\n",
+                "in NewAgentStorage.setVariable().",
                 var_name.c_str(), var->second.len / sizeof(T), N);
         }
         memcpy(data + var->second.offset, &val, var->second.len);
@@ -121,7 +121,7 @@ struct NewAgentStorage {
         const auto &var = offsets.vars.find(var_name);
         if (var == offsets.vars.end()) {
             THROW InvalidAgentVar("Variable '%s' not found, "
-                "in NewAgentStorage.setVariable()\n",
+                "in NewAgentStorage.setVariable().",
                 var_name.c_str());
         }
         // if (var.second.len == 1) {
@@ -132,12 +132,12 @@ struct NewAgentStorage {
         const auto t_type = std::type_index(typeid(T));
         if (var->second.type != std::type_index(typeid(T))) {
             THROW InvalidVarType("Variable '%s' has type '%s, incorrect  type '%s' was requested, "
-                "in NewAgentStorage.setVariable()\n",
+                "in NewAgentStorage.setVariable().",
                 var_name.c_str(), var->second.type.name(), t_type.name());
         }
         if (var->second.len < sizeof(T) * (index + 1)) {
             THROW OutOfRangeVarArray("Variable '%s' is an array with %u elements, index %u is out of range, "
-                "in NewAgentStorage.setVariable()\n",
+                "in NewAgentStorage.setVariable().",
                 var_name.c_str(), var->second.len / sizeof(T), index);
         }
         memcpy(data + var->second.offset + (index * sizeof(T)), &val, sizeof(T));
@@ -147,13 +147,13 @@ struct NewAgentStorage {
         const auto &var = offsets.vars.find(var_name);
         if (var == offsets.vars.end()) {
             THROW InvalidAgentVar("Variable '%s' not found, "
-                "in NewAgentStorage.getVariable()\n",
+                "in NewAgentStorage.getVariable()",
                 var_name.c_str());
         }
         const auto t_type = std::type_index(typeid(T));
         if (var->second.type != std::type_index(typeid(T))) {
             THROW InvalidVarType("Variable '%s' has type '%s, incorrect  type '%s' was requested, "
-                "in NewAgentStorage.getVariable()\n",
+                "in NewAgentStorage.getVariable().",
                 var_name.c_str(), var->second.type.name(), t_type.name());
         }
         if (var->second.len != sizeof(T)) {
@@ -169,7 +169,7 @@ struct NewAgentStorage {
         const auto &var = offsets.vars.find(var_name);
         if (var == offsets.vars.end()) {
             THROW InvalidAgentVar("Variable '%s' not found, "
-                "in NewAgentStorage.getVariable()\n",
+                "in NewAgentStorage.getVariable().",
                 var_name.c_str());
         }
         // if (var.second.len == 1 || N == 1) {
@@ -180,12 +180,12 @@ struct NewAgentStorage {
         const auto t_type = std::type_index(typeid(T));
         if (var->second.type != std::type_index(typeid(T))) {
             THROW InvalidVarType("Variable '%s' has type '%s, incorrect  type '%s' was requested, "
-                "in NewAgentStorage.getVariable()\n",
+                "in NewAgentStorage.getVariable().",
                 var_name.c_str(), var->second.type.name(), t_type.name());
         }
         if (var->second.len != sizeof(T) * N) {
             THROW InvalidVarArrayLen("Variable '%s' is an array with %u elements, incorrect array of length %u was provided, "
-                "in NewAgentStorage.getVariable()\n",
+                "in NewAgentStorage.getVariable().",
                 var_name.c_str(), var->second.len / sizeof(T), N);
         }
         std::array<T, N> rtn;
@@ -197,7 +197,7 @@ struct NewAgentStorage {
         const auto &var = offsets.vars.find(var_name);
         if (var == offsets.vars.end()) {
             THROW InvalidAgentVar("Variable '%s' not found, "
-                "in NewAgentStorage.getVariable()\n",
+                "in NewAgentStorage.getVariable().",
                 var_name.c_str());
         }
         // if (var.second.len == 1) {
@@ -208,12 +208,12 @@ struct NewAgentStorage {
         const auto t_type = std::type_index(typeid(T));
         if (var->second.type != std::type_index(typeid(T))) {
             THROW InvalidVarType("Variable '%s' has type '%s, incorrect  type '%s' was requested, "
-                "in NewAgentStorage.getVariable()\n",
+                "in NewAgentStorage.getVariable().",
                 var_name.c_str(), var->second.type.name(), t_type.name());
         }
         if (var->second.len < sizeof(T) * (index + 1)) {
             THROW OutOfRangeVarArray("Variable '%s' is an array with %u elements, index %u is out of range, "
-                "in NewAgentStorage.getVariable()\n",
+                "in NewAgentStorage.getVariable().",
                 var_name.c_str(), var->second.len / sizeof(T), index);
         }
         return *reinterpret_cast<T*>(data + var->second.offset + (index * sizeof(T)));

--- a/src/flamegpu/exception/FGPUException.cpp
+++ b/src/flamegpu/exception/FGPUException.cpp
@@ -14,6 +14,7 @@ FGPUException::FGPUException()
         std::stringstream ss;
         ss << file << "(" << line << "): ";
         err_message.append(ss.str());
+        file = nullptr;
     }
 }
 

--- a/src/flamegpu/model/AgentFunctionDescription.cpp
+++ b/src/flamegpu/model/AgentFunctionDescription.cpp
@@ -46,7 +46,7 @@ void AgentFunctionDescription::setInitialState(const std::string &init_state) {
                                             f2->end_state == init_state) {
                                             THROW InvalidAgentFunc("Agent functions's '%s' and '%s', within the same layer "
                                                 "cannot share any input or output states, this is not permitted, "
-                                                "in AgentFunctionDescription::setInitialState()\n",
+                                                "in AgentFunctionDescription::setInitialState().",
                                                 f2->name.c_str(), this->function->name.c_str());
                                         }
                                     }
@@ -60,12 +60,12 @@ void AgentFunctionDescription::setInitialState(const std::string &init_state) {
             this->function->initial_state = init_state;
         } else {
             THROW InvalidStateName("Agent ('%s') does not contain state '%s', "
-                "in AgentFunctionDescription::setInitialState()\n",
+                "in AgentFunctionDescription::setInitialState().",
                 p->name.c_str(), init_state.c_str());
         }
     } else {
         THROW InvalidParent("Agent parent has expired, "
-            "in AgentFunctionDescription::setInitialState()\n");
+            "in AgentFunctionDescription::setInitialState().");
     }
 }
 void AgentFunctionDescription::setEndState(const std::string &exit_state) {
@@ -89,7 +89,7 @@ void AgentFunctionDescription::setEndState(const std::string &exit_state) {
                                             f2->end_state == exit_state) {
                                             THROW InvalidAgentFunc("Agent functions's '%s' and '%s', within the same layer "
                                                 "cannot share any input or output states, this is not permitted, "
-                                                "in AgentFunctionDescription::setEndState()\n",
+                                                "in AgentFunctionDescription::setEndState().",
                                                 f2->name.c_str(), this->function->name.c_str());
                                         }
                                     }
@@ -103,12 +103,12 @@ void AgentFunctionDescription::setEndState(const std::string &exit_state) {
             this->function->end_state = exit_state;
         } else {
             THROW InvalidStateName("Agent ('%s') does not contain state '%s', "
-                "in AgentFunctionDescription::setEndState()\n",
+                "in AgentFunctionDescription::setEndState().",
                 p->name.c_str(), exit_state.c_str());
         }
     } else {
         THROW InvalidParent("Agent parent has expired, "
-            "in AgentFunctionDescription::setEndState()\n");
+            "in AgentFunctionDescription::setEndState().");
     }
 }
 void AgentFunctionDescription::setMessageInput(const std::string &message_name) {
@@ -116,7 +116,7 @@ void AgentFunctionDescription::setMessageInput(const std::string &message_name) 
         if (message_name == other->name) {
             THROW InvalidMessageName("Message '%s' is already bound as message output in agent function %s, "
                 "the same message cannot be input and output by the same function, "
-                "in AgentFunctionDescription::setMessageInput()\n",
+                "in AgentFunctionDescription::setMessageInput().",
                 message_name.c_str(), function->name.c_str());
         }
     }
@@ -126,25 +126,25 @@ void AgentFunctionDescription::setMessageInput(const std::string &message_name) 
             this->function->message_input = a->second;
         } else {
             THROW InvalidMessageType("Message ('%s') type '%s' does not match type '%s' applied to FLAMEGPU_AGENT_FUNCTION, "
-                "in AgentFunctionDescription::setMessageInput()\n",
+                "in AgentFunctionDescription::setMessageInput().",
                 message_name.c_str(), CurveRTCHost::demangle(a->second->getType()).c_str(), this->function->msg_in_type.c_str());
         }
     } else {
         THROW InvalidMessageName("Model ('%s') does not contain message '%s', "
-            "in AgentFunctionDescription::setMessageInput()\n",
+            "in AgentFunctionDescription::setMessageInput().",
             model->name.c_str(), message_name.c_str());
     }
 }
 void AgentFunctionDescription::setMessageInput(MsgBruteForce::Description &message) {
     if (message.model != function->description->model) {
         THROW DifferentModel("Attempted to use agent description from a different model, "
-            "in AgentFunctionDescription::setAgentOutput()\n");
+            "in AgentFunctionDescription::setAgentOutput().");
     }
     if (auto other = function->message_output.lock()) {
         if (message.getName() == other->name) {
             THROW InvalidMessageName("Message '%s' is already bound as message output in agent function %s, "
                 "the same message cannot be input and output by the same function, "
-                "in AgentFunctionDescription::setMessageInput()\n",
+                "in AgentFunctionDescription::setMessageInput().",
                 message.getName().c_str(), function->name.c_str());
         }
     }
@@ -155,17 +155,17 @@ void AgentFunctionDescription::setMessageInput(MsgBruteForce::Description &messa
                 this->function->message_input = a->second;
             } else {
                 THROW InvalidMessageType("Message ('%s') type '%s' does not match type '%s' applied to FLAMEGPU_AGENT_FUNCTION, "
-                    "in AgentFunctionDescription::setMessageInput()\n",
+                    "in AgentFunctionDescription::setMessageInput().",
                     a->second->name.c_str(), CurveRTCHost::demangle(a->second->getType()).c_str(), this->function->msg_in_type.c_str());
             }
         } else {
             THROW InvalidMessage("Message '%s' is not from Model '%s', "
-                "in AgentFunctionDescription::setMessageInput()\n",
+                "in AgentFunctionDescription::setMessageInput().",
                 message.getName().c_str(), model->name.c_str());
         }
     } else {
         THROW InvalidMessageName("Model ('%s') does not contain message '%s', "
-            "in AgentFunctionDescription::setMessageInput()\n",
+            "in AgentFunctionDescription::setMessageInput().",
             model->name.c_str(), message.getName().c_str());
     }
 }
@@ -174,7 +174,7 @@ void AgentFunctionDescription::setMessageOutput(const std::string &message_name)
         if (message_name == other->name) {
             THROW InvalidMessageName("Message '%s' is already bound as message input in agent function %s, "
                 "the same message cannot be input and output by the same function, "
-                "in AgentFunctionDescription::setMessageOutput()\n",
+                "in AgentFunctionDescription::setMessageOutput().",
                 message_name.c_str(), function->name.c_str());
         }
     }
@@ -193,25 +193,25 @@ void AgentFunctionDescription::setMessageOutput(const std::string &message_name)
             }
         } else {
             THROW InvalidMessageType("Message ('%s') type '%s' does not match type '%s' applied to FLAMEGPU_AGENT_FUNCTION, "
-                "in AgentFunctionDescription::setMessageOutput()\n",
+                "in AgentFunctionDescription::setMessageOutput().",
                 message_name.c_str(), CurveRTCHost::demangle(a->second->getType()).c_str(), this->function->msg_in_type.c_str());
         }
     } else {
         THROW InvalidMessageName("Model ('%s') does not contain message '%s', "
-            "in AgentFunctionDescription::setMessageOutput()\n",
+            "in AgentFunctionDescription::setMessageOutput().",
             model->name.c_str(), message_name.c_str());
     }
 }
 void AgentFunctionDescription::setMessageOutput(MsgBruteForce::Description &message) {
     if (message.model != function->description->model) {
         THROW DifferentModel("Attempted to use agent description from a different model, "
-            "in AgentFunctionDescription::setAgentOutput()\n");
+            "in AgentFunctionDescription::setAgentOutput().");
     }
     if (auto other = function->message_input.lock()) {
         if (message.getName() == other->name) {
             THROW InvalidMessageName("Message '%s' is already bound as message input in agent function %s, "
                 "the same message cannot be input and output by the same function, "
-                "in AgentFunctionDescription::setMessageOutput()\n",
+                "in AgentFunctionDescription::setMessageOutput().",
                 message.getName().c_str(), function->name.c_str());
         }
     }
@@ -231,12 +231,12 @@ void AgentFunctionDescription::setMessageOutput(MsgBruteForce::Description &mess
                 }
             } else {
                 THROW InvalidMessageType("Message ('%s') type '%s' does not match type '%s' applied to FLAMEGPU_AGENT_FUNCTION, "
-                    "in AgentFunctionDescription::setMessageOutput()\n",
+                    "in AgentFunctionDescription::setMessageOutput().",
                     a->second->name.c_str(), CurveRTCHost::demangle(a->second->getType()).c_str(), this->function->msg_in_type.c_str());
             }
         } else {
             THROW InvalidMessage("Message '%s' is not from Model '%s', "
-                "in AgentFunctionDescription::setMessageOutput()\n",
+                "in AgentFunctionDescription::setMessageOutput().",
                 message.getName().c_str(), model->name.c_str());
         }
     } else {
@@ -270,19 +270,19 @@ void AgentFunctionDescription::setAgentOutput(const std::string &agent_name, con
             a->second->agent_outputs++;  // Mark inside agent that we are using it as an output
         } else {
             THROW InvalidStateName("Agent ('%s') does not contain state '%s', "
-                "in AgentFunctionDescription::setAgentOutput()\n",
+                "in AgentFunctionDescription::setAgentOutput().",
                 agent_name.c_str(), state.c_str());
         }
     } else {
         THROW InvalidAgentName("Model ('%s') does not contain agent '%s', "
-            "in AgentFunctionDescription::setAgentOutput()\n",
+            "in AgentFunctionDescription::setAgentOutput().",
             model->name.c_str(), agent_name.c_str());
     }
 }
 void AgentFunctionDescription::setAgentOutput(AgentDescription &agent, const std::string state) {
     if (agent.model != function->description->model) {
         THROW DifferentModel("Attempted to use agent description from a different model, "
-            "in AgentFunctionDescription::setAgentOutput()\n");
+            "in AgentFunctionDescription::setAgentOutput().");
     }
     // Set new
     auto a = model->agents.find(agent.getName());
@@ -299,17 +299,17 @@ void AgentFunctionDescription::setAgentOutput(AgentDescription &agent, const std
                 a->second->agent_outputs++;  // Mark inside agent that we are using it as an output
             } else {
                 THROW InvalidStateName("Agent ('%s') does not contain state '%s', "
-                    "in AgentFunctionDescription::setAgentOutput()\n",
+                    "in AgentFunctionDescription::setAgentOutput().",
                     agent.getName().c_str(), state.c_str());
             }
         } else {
             THROW InvalidMessage("Agent '%s' is not from Model '%s', "
-                "in AgentFunctionDescription::setAgentOutput()\n",
+                "in AgentFunctionDescription::setAgentOutput().",
                 agent.getName().c_str(), model->name.c_str());
         }
     } else {
         THROW InvalidMessageName("Model ('%s') does not contain agent '%s', "
-            "in AgentFunctionDescription::setAgentOutput()\n",
+            "in AgentFunctionDescription::setAgentOutput().",
             model->name.c_str(), agent.getName().c_str());
     }
 }
@@ -350,13 +350,13 @@ MsgBruteForce::Description &AgentFunctionDescription::MessageInput() {
     if (auto m = function->message_input.lock())
         return *m->description;
     THROW OutOfBoundsException("Message input has not been set, "
-        "in AgentFunctionDescription::MessageInput()\n");
+        "in AgentFunctionDescription::MessageInput().");
 }
 MsgBruteForce::Description &AgentFunctionDescription::MessageOutput() {
     if (auto m = function->message_output.lock())
         return *m->description;
     THROW OutOfBoundsException("Message output has not been set, "
-        "in AgentFunctionDescription::MessageOutput()\n");
+        "in AgentFunctionDescription::MessageOutput().");
 }
 bool &AgentFunctionDescription::MessageOutputOptional() {
     return function->message_output_optional;
@@ -381,13 +381,13 @@ const MsgBruteForce::Description &AgentFunctionDescription::getMessageInput() co
     if (auto m = function->message_input.lock())
         return *m->description;
     THROW OutOfBoundsException("Message input has not been set, "
-        "in AgentFunctionDescription::getMessageInput()\n");
+        "in AgentFunctionDescription::getMessageInput().");
 }
 const MsgBruteForce::Description &AgentFunctionDescription::getMessageOutput() const {
     if (auto m = function->message_output.lock())
         return *m->description;
     THROW OutOfBoundsException("Message output has not been set, "
-        "in AgentFunctionDescription::getMessageOutput()\n");
+        "in AgentFunctionDescription::getMessageOutput().");
 }
 bool AgentFunctionDescription::getMessageOutputOptional() const {
     return this->function->message_output_optional;
@@ -396,13 +396,13 @@ const AgentDescription &AgentFunctionDescription::getAgentOutput() const {
     if (auto a = function->agent_output.lock())
         return *a->description;
     THROW OutOfBoundsException("Agent output has not been set, "
-        "in AgentFunctionDescription::getAgentOutput()\n");
+        "in AgentFunctionDescription::getAgentOutput().");
 }
 std::string AgentFunctionDescription::getAgentOutputState() const {
     if (auto a = function->agent_output.lock())
         return function->agent_output_state;
     THROW OutOfBoundsException("Agent output has not been set, "
-        "in AgentFunctionDescription::getAgentOutputState()\n");
+        "in AgentFunctionDescription::getAgentOutputState().");
 }
 bool AgentFunctionDescription::getAllowAgentDeath() const {
     return function->has_agent_death;

--- a/src/flamegpu/model/LayerDescription.cpp
+++ b/src/flamegpu/model/LayerDescription.cpp
@@ -18,7 +18,7 @@ void LayerDescription::addAgentFunction(const AgentFunctionDescription &afd) {
         return;
     }
     THROW DifferentModel("Attempted to add agent function description which is from a different model, "
-        "in LayerDescription::addAgentFunction()\n");
+        "in LayerDescription::addAgentFunction().");
 }
 void LayerDescription::addAgentFunction(const std::string &name) {
     // Locate the matching agent function in the model hierarchy
@@ -37,7 +37,7 @@ void LayerDescription::addAgentFunction(const std::string &name) {
                                 b->end_state == f.second->end_state) {
                                 THROW InvalidAgentFunc("Agent functions '%s' cannot be added to this layer as agent function '%s' "
                                     "within the layer shares an input or output state, this is not permitted, "
-                                    "in LayerDescription::addAgentFunction()\n",
+                                    "in LayerDescription::addAgentFunction().",
                                     f.second->name.c_str(), b->name.c_str());
                             }
                         }
@@ -46,7 +46,7 @@ void LayerDescription::addAgentFunction(const std::string &name) {
                 if (layer->agent_functions.insert(f.second).second)
                     return;
                 THROW InvalidAgentFunc("Attempted to add agent function '%s' to same layer twice, "
-                    "in LayerDescription::addAgentFunction()\n",
+                    "in LayerDescription::addAgentFunction().",
                     name.c_str());
             }
         }
@@ -95,7 +95,7 @@ const AgentFunctionDescription &LayerDescription::getAgentFunction(unsigned int 
         return *((*it)->description);
     }
     THROW OutOfBoundsException("Index %d is out of bounds (only %d items exist) "
-        "in LayerDescription.getAgentFunction()\n",
+        "in LayerDescription.getAgentFunction().",
     index, layer->agent_functions.size());
 }
 FLAMEGPU_HOST_FUNCTION_POINTER LayerDescription::getHostFunction(unsigned int index) const {
@@ -106,6 +106,6 @@ FLAMEGPU_HOST_FUNCTION_POINTER LayerDescription::getHostFunction(unsigned int in
         return *it;
     }
     THROW OutOfBoundsException("Index %d is out of bounds (only %d items exist) "
-        "in LayerDescription.getHostFunction()\n",
+        "in LayerDescription.getHostFunction().",
         index, layer->host_functions.size());
 }

--- a/src/flamegpu/runtime/messaging/Spatial2D.cu
+++ b/src/flamegpu/runtime/messaging/Spatial2D.cu
@@ -226,19 +226,19 @@ MsgSpatial2D::Data::Data(ModelData *const model, const Data &other)
     , maxY(other.maxY) {
     description = std::unique_ptr<MsgSpatial2D::Description>(model ? new MsgSpatial2D::Description(model, this) : nullptr);
     if (isnan(radius)) {
-        THROW InvalidMessage("Radius has not been set in spatial message '%s'\n", other.name.c_str());
+        THROW InvalidMessage("Radius has not been set in spatial message '%s'.", other.name.c_str());
     }
     if (isnan(minX)) {
-        THROW InvalidMessage("Environment minimum x bound has not been set in spatial message '%s'\n", other.name.c_str());
+        THROW InvalidMessage("Environment minimum x bound has not been set in spatial message '%s.", other.name.c_str());
     }
     if (isnan(minY)) {
-        THROW InvalidMessage("Environment minimum y bound has not been set in spatial message '%s'\n", other.name.c_str());
+        THROW InvalidMessage("Environment minimum y bound has not been set in spatial message '%s'.", other.name.c_str());
     }
     if (isnan(maxX)) {
-        THROW InvalidMessage("Environment maximum x bound has not been set in spatial message '%s'\n", other.name.c_str());
+        THROW InvalidMessage("Environment maximum x bound has not been set in spatial message '%s'.", other.name.c_str());
     }
     if (isnan(maxY)) {
-        THROW InvalidMessage("Environment maximum y bound has not been set in spatial message '%s'\n", other.name.c_str());
+        THROW InvalidMessage("Environment maximum y bound has not been set in spatial message '%s'.", other.name.c_str());
     }
 }
 MsgSpatial2D::Data *MsgSpatial2D::Data::clone(ModelData *const newParent) {
@@ -262,25 +262,25 @@ void MsgSpatial2D::Description::setRadius(const float &r) {
 void MsgSpatial2D::Description::setMinX(const float &x) {
     if (!isnan(reinterpret_cast<Data *>(message)->maxX) &&
         x >= reinterpret_cast<Data *>(message)->maxX) {
-        THROW InvalidArgument("Spatial messaging minimum bound must be lower than max bound, %f !< %f", x, reinterpret_cast<Data *>(message)->maxX);
+        THROW InvalidArgument("Spatial messaging minimum bound must be lower than max bound, %f !< %f.", x, reinterpret_cast<Data *>(message)->maxX);
     }
     reinterpret_cast<Data *>(message)->minX = x;
 }
 void MsgSpatial2D::Description::setMinY(const float &y) {
     if (!isnan(reinterpret_cast<Data *>(message)->maxY) &&
         y >= reinterpret_cast<Data *>(message)->maxY) {
-        THROW InvalidArgument("Spatial messaging minimum bound must be lower than max bound, %f !< %f", y, reinterpret_cast<Data *>(message)->maxY);
+        THROW InvalidArgument("Spatial messaging minimum bound must be lower than max bound, %f !< %f.", y, reinterpret_cast<Data *>(message)->maxY);
     }
     reinterpret_cast<Data *>(message)->minY = y;
 }
 void MsgSpatial2D::Description::setMin(const float &x, const float &y) {
     if (!isnan(reinterpret_cast<Data *>(message)->maxX) &&
         x >= reinterpret_cast<Data *>(message)->maxX) {
-        THROW InvalidArgument("Spatial messaging minimum bound must be lower than max bound, %f !< %f", x, reinterpret_cast<Data *>(message)->maxX);
+        THROW InvalidArgument("Spatial messaging minimum bound must be lower than max bound, %f !< %f.", x, reinterpret_cast<Data *>(message)->maxX);
     }
     if (!isnan(reinterpret_cast<Data *>(message)->maxY) &&
         y >= reinterpret_cast<Data *>(message)->maxY) {
-        THROW InvalidArgument("Spatial messaging minimum bound must be lower than max bound, %f !< %f", y, reinterpret_cast<Data *>(message)->maxY);
+        THROW InvalidArgument("Spatial messaging minimum bound must be lower than max bound, %f !< %f.", y, reinterpret_cast<Data *>(message)->maxY);
     }
     reinterpret_cast<Data *>(message)->minX = x;
     reinterpret_cast<Data *>(message)->minY = y;
@@ -288,25 +288,25 @@ void MsgSpatial2D::Description::setMin(const float &x, const float &y) {
 void MsgSpatial2D::Description::setMaxX(const float &x) {
     if (!isnan(reinterpret_cast<Data *>(message)->minX) &&
         x <= reinterpret_cast<Data *>(message)->minX) {
-        THROW InvalidArgument("Spatial messaging max x bound must be greater than min bound, %f !> %f", x, reinterpret_cast<Data *>(message)->minX);
+        THROW InvalidArgument("Spatial messaging max x bound must be greater than min bound, %f !> %f.", x, reinterpret_cast<Data *>(message)->minX);
     }
     reinterpret_cast<Data *>(message)->maxX = x;
 }
 void MsgSpatial2D::Description::setMaxY(const float &y) {
     if (!isnan(reinterpret_cast<Data *>(message)->minY) &&
         y <= reinterpret_cast<Data *>(message)->minY) {
-        THROW InvalidArgument("Spatial messaging max y bound must be greater than min bound, %f !> %f", y, reinterpret_cast<Data *>(message)->minY);
+        THROW InvalidArgument("Spatial messaging max y bound must be greater than min bound, %f !> %f.", y, reinterpret_cast<Data *>(message)->minY);
     }
     reinterpret_cast<Data *>(message)->maxY = y;
 }
 void MsgSpatial2D::Description::setMax(const float &x, const float &y) {
     if (!isnan(reinterpret_cast<Data *>(message)->minX) &&
         x <= reinterpret_cast<Data *>(message)->minX) {
-        THROW InvalidArgument("Spatial messaging max x bound must be greater than min bound, %f !> %f", x, reinterpret_cast<Data *>(message)->minX);
+        THROW InvalidArgument("Spatial messaging max x bound must be greater than min bound, %f !> %f.", x, reinterpret_cast<Data *>(message)->minX);
     }
     if (!isnan(reinterpret_cast<Data *>(message)->minY) &&
         y <= reinterpret_cast<Data *>(message)->minY) {
-        THROW InvalidArgument("Spatial messaging max y bound must be greater than min bound, %f !> %f", y, reinterpret_cast<Data *>(message)->minY);
+        THROW InvalidArgument("Spatial messaging max y bound must be greater than min bound, %f !> %f.", y, reinterpret_cast<Data *>(message)->minY);
     }
     reinterpret_cast<Data *>(message)->maxX = x;
     reinterpret_cast<Data *>(message)->maxY = y;

--- a/src/flamegpu/util/compute_capability.cu
+++ b/src/flamegpu/util/compute_capability.cu
@@ -7,7 +7,7 @@ int util::compute_capability::getComputeCapability(int deviceIndex) {
 
     // Throw an exception if the deviceIndex is negative.
     if (deviceIndex < 0) {
-        throw InvalidCUDAdevice();
+        THROW InvalidCUDAdevice();
     }
 
     // Ensure deviceIndex is valid.
@@ -15,7 +15,7 @@ int util::compute_capability::getComputeCapability(int deviceIndex) {
     gpuErrchk(cudaGetDeviceCount(&deviceCount));
     if (deviceIndex >= deviceCount) {
         // Throw an excpetion if the device index is bad.
-        throw InvalidCUDAdevice();
+        THROW InvalidCUDAdevice();
     }
     // Load device attributes
     gpuErrchk(cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, deviceIndex));


### PR DESCRIPTION
Fixed a few cases where throw was being used instead of THROW (this causes the reported location to be wrong if a prior exception has been thrown.

Removed all cases I could find where exception message ends '\n'.

Changed the debug exception printf to end with \n, this makes testing output more readable.

Now when `throw` is used instead of `THROW`, it will never print the file/line number (unless someone has called the set location function manually without creating an `FGPUException` derived class).