### PR TITLE
Swig appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ before_build:
     mkdir build
     cd build
     cmake --version
-    cmake .. -A x64 -DWARNINGS_AS_ERRORS=ON -DSMS=35,60
+    cmake .. -A x64 -DWARNINGS_AS_ERRORS=ON -DSMS=35,60 -DBUILD_SWIG_PYTHON=ON -DBUILD_SWIG_PYTHON_VIRTUALENV=ON -DPYTHON_INCLUDE_DIR=C:\Python38-x64\include -DPYTHON_LIBRARY=C:\Python38-x64\libs\python38.lib
 
 # The build
 build:

--- a/cmake/swig/CMakeLists.txt.in
+++ b/cmake/swig/CMakeLists.txt.in
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 2.8.2)
+
+include(ExternalProject)
+
+project(swig-download NONE)
+ExternalProject_Add(swig
+    URL               "http://prdownloads.sourceforge.net/swig/swigwin-4.0.1.zip"
+    SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/swig"
+    BINARY_DIR        ""
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND     ""
+    INSTALL_COMMAND   ""
+    TEST_COMMAND      ""
+    )

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -8,6 +8,38 @@ if(POLICY CMP0086)
   cmake_policy(SET CMP0086 NEW)
 endif()
 
+# Pull in swig (on Windows)
+MACRO (download_swig)
+    configure_file(../cmake/swig/CMakeLists.txt.in ${CMAKE_CURRENT_BINARY_DIR}/swig-download/CMakeLists.txt)
+    # Run CMake generate
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+        RESULT_VARIABLE result
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/swig-download
+        )
+    if (result)
+        message(WARNING
+                "CMake step for swig failed: ${result}\n")
+    endif ()
+    # Run CMake build (this only downloads and extracts)
+    execute_process(
+    COMMAND ${CMAKE_COMMAND} --build .
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/swig-download
+    )
+    if (result)
+        message(WARNING
+                "Download step for swig failed: ${result}\n"
+                "Attempting to continue\n")
+    endif ()
+    # Set Swig path variable
+    message(STATUS ${CMAKE_CURRENT_BINARY_DIR}/swig/swig.exe)
+    set(SWIG_EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/swig/swig.exe CACHE FILEPATH "Path to SWIG executable")
+ENDMACRO()
+# If on windows, and SWIG_EXECUTABLE not specified, auto download Swig 4.0.1
+if(WIN32 AND NOT SWIG_EXECUTABLE)  
+    download_swig()
+endif()
 # Set up swig
 set(CMAKE_SWIG_FLAGS)
 find_package(SWIG REQUIRED)

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -56,9 +56,9 @@ find_package(PythonLibs REQUIRED)
 #include_directories(${PYTHON_INCLUDE_PATH})
 
 # Find Python
-find_package(Python REQUIRED COMPONENTS Interpreter Development)
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 
-message(STATUS "Python found at " ${Python_EXECUTABLE})
+message(STATUS "Python found at " ${Python3_EXECUTABLE})
 
 if(Python_VERSION VERSION_GREATER_EQUAL 3)
   list(APPEND CMAKE_SWIG_FLAGS "-py3")

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -43,7 +43,7 @@ target_include_directories(${PYTHON_MODULE_NAME}
   PRIVATE
   ../../include
   ../../externals
-  ${Python_INCLUDE_DIRS}
+  ${Python3_INCLUDE_DIRS}
   )
   
 # link with the static flamegpu and cuda libraries
@@ -53,7 +53,7 @@ target_link_libraries(${PYTHON_MODULE_NAME} PRIVATE flamegpu2 cuda)
 # i.e. we can't use: $<$<PLATFORM_ID:Windows>:${PYTHON_LIBRARIES}>
 # see: https://cmake.org/cmake/help/git-stage/command/target_link_libraries.html#command:target_link_libraries
 if(MSVC)
-  target_link_libraries(${PYTHON_MODULE_NAME} PRIVATE ${Python_LIBRARIES} flamegpu2 cuda)
+  target_link_libraries(${PYTHON_MODULE_NAME} PRIVATE ${Python3_LIBRARIES} flamegpu2 cuda)
 endif()
 
 
@@ -79,18 +79,18 @@ file(GENERATE
 # Function to find if python module MODULE_NAME is available, if not then install it to the Python user install directory.
 function(search_python_module MODULE_NAME)
   execute_process(
-    COMMAND ${Python_EXECUTABLE} -c "import ${MODULE_NAME}; print(${MODULE_NAME}.__version__)"
+    COMMAND ${Python3_EXECUTABLE} -c "import ${MODULE_NAME}; print(${MODULE_NAME}.__version__) if hasattr(${MODULE_NAME}, '__version__') else print('Unknown');"
     RESULT_VARIABLE _RESULT
     OUTPUT_VARIABLE MODULE_VERSION
     ERROR_QUIET
     OUTPUT_STRIP_TRAILING_WHITESPACE
     )
   if(${_RESULT} STREQUAL "0")
-    message(STATUS "Found python module: ${MODULE_NAME} (found version \"${MODULE_VERSION}\")")
+    message(STATUS "Found python module: ${MODULE_NAME} (version \"${MODULE_VERSION}\")")
   else()
     message(WARNING "Can't find python module \"${MODULE_NAME}\", user install it using pip...")
     execute_process(
-      COMMAND ${Python_EXECUTABLE} -m pip install --upgrade --user ${MODULE_NAME}
+      COMMAND ${Python3_EXECUTABLE} -m pip install --upgrade --user ${MODULE_NAME}
       OUTPUT_STRIP_TRAILING_WHITESPACE
       )
   endif()
@@ -107,7 +107,7 @@ add_custom_command(TARGET ${PYTHON_MODULE_NAME} POST_BUILD
 	COMMAND ${CMAKE_COMMAND} -E copy ${PYTHON_LIB_TEMP_DIRECTORY}/${PYTHON_MODULE_NAME}/${PYTHON_MODULE_NAME}.py ${PYTHON_MODULE_NAME}
 	# copy the compiled pyd file to library output location
 	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${PYTHON_MODULE_NAME}> ${PYTHON_MODULE_NAME}
-	COMMAND ${Python_EXECUTABLE} setup.py bdist_wheel
+	COMMAND ${Python3_EXECUTABLE} setup.py bdist_wheel
 	# by products of the packaging
 	BYPRODUCTS
 		${PYTHON_MODULE_NAME}
@@ -121,9 +121,9 @@ add_custom_command(TARGET ${PYTHON_MODULE_NAME} POST_BUILD
 # Build Virtual Environment for python testing and install the packaged wheel
 if(BUILD_SWIG_PYTHON_VIRTUALENV)
 	# Look for python module virtualenv
-	search_python_module(virtualenv)
+	search_python_module(venv)
 	# Testing using a virtual environment
-	set(VENV_EXECUTABLE ${Python_EXECUTABLE} -m virtualenv)
+	set(VENV_EXECUTABLE ${Python3_EXECUTABLE} -m venv)
 	set(VENV_DIR ${PYTHON_LIB_OUTPUT_DIRECTORY}/venv)
 	if(WIN32)
 		set(VENV_Python_EXECUTABLE "${VENV_DIR}\\Scripts\\python.exe")
@@ -132,7 +132,7 @@ if(BUILD_SWIG_PYTHON_VIRTUALENV)
 	endif()
 	# make a virtualenv to install our python package in it
 	add_custom_command(TARGET ${PYTHON_MODULE_NAME} POST_BUILD
-		COMMAND ${VENV_EXECUTABLE} -p ${Python_EXECUTABLE} ${VENV_DIR}
+		COMMAND ${VENV_EXECUTABLE} ${VENV_DIR}
 		# Must not call it in a folder containing the setup.py otherwise pip call it
 		# (i.e. "python setup.py bdist") while we want to consume the wheel package
 		COMMAND ${VENV_Python_EXECUTABLE} -m pip install --force-reinstall --find-links=dist ${PYTHON_MODULE_NAME}

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -36,7 +36,8 @@ set_source_files_properties(${PYTHON_LIB_TEMP_DIRECTORY}/${PYTHON_MODULE_NAME}/$
 set_property(TARGET ${PYTHON_MODULE_NAME} PROPERTY SWIG_USE_TARGET_INCLUDE_DIRECTORIES ON)
 # needs to have RDC enable for the project
 set_property(TARGET ${PYTHON_MODULE_NAME} PROPERTY CUDA_SEPARABLE_COMPILATION ON)
-
+# Suppress warnings during compilation of SWIG generated PYTHON_wrap.cxx
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcudafe --diag_suppress=\"declared_but_not_referenced\"")
 # set include directories for module build
 target_include_directories(${PYTHON_MODULE_NAME}
   PRIVATE


### PR DESCRIPTION
* Automatically download SWIG on windows if `SWIG_EXECUTABLE` is not set within cmake
* Make Appveyor build SWIG targets
* Suppress warnings in compilation of SWIG generated file ..._wrap.cxx
* Switches to requiring Python 3
    * Switches from `virtualenv` module to python3 internal `venv`