### PR TITLE
NVTX Improvements (nvtx3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,4 @@ before_script:
   - CUDA_ARCH="35;75"
 
 # Build steps
-script: "mkdir build && cd build && ${CMAKE_CMD} .. -DBUILD_TESTS=ON -DWARNINGS_AS_ERRORS=ON -DSMS=${CUDA_ARCH} && make -j`nproc` all_lint all docs "
+script: "mkdir build && cd build && ${CMAKE_CMD} .. -DBUILD_TESTS=ON -DWARNINGS_AS_ERRORS=ON -DSMS=${CUDA_ARCH} -DUSE_NVTX=ON && make -j`nproc` all_lint all docs "

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ option(VISUALISATION "Enable visualisation support" OFF)
 option(BUILD_TESTS "Enable building tests" OFF)
 
 # Option to enable/disable NVTX markers for improved profiling
-option(NVTX "Enable NVTX markers for improved profiling (if available). Implied by profile builds" OFF)
+option(USE_NVTX "Build with NVTX markers enabled" OFF)
 
 # Define a function to add a lint target.
 find_file(CPPLINT NAMES cpplint cpplint.exe)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ before_build:
     mkdir build
     cd build
     cmake --version
-    cmake .. -A x64 -DWARNINGS_AS_ERRORS=ON -DSMS=35,60
+    cmake .. -A x64 -DWARNINGS_AS_ERRORS=ON -DSMS=35,60 -DUSE_NVTX=ON 
 
 # The build
 build:

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -87,22 +87,24 @@ endif()
 
 
 # If NVTX is enabled, find the library and update variables accordingly.
-if(NVTX)
+if(USE_NVTX)
     # Find the nvtx library using custom cmake module
-    find_package(NVTX QUIET)
+    find_package(NVTX)
     # If it was found, use it.
     if(NVTX_FOUND)
-        set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -DNVTX")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNVTX")
+        set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -DUSE_NVTX=${NVTX_VERSION}")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_NVTX=${NVTX_VERSION}")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_NVTX=${NVTX_VERSION}")
         set(FLAMEGPU_DEPENDENCY_INCLUDE_DIRECTORIES ${FLAMEGPU_DEPENDENCY_INCLUDE_DIRECTORIES} ${NVTX_INCLUDE_DIRS})
-        set(FLAMEGPU_DEPENDENCY_LINK_LIBRARIES ${FLAMEGPU_DEPENDENCY_LINK_LIBRARIES} ${NVTX_LIBRARIES})
-        message("-- Found NVTX: ${NVTX_INCLUDE_DIRS}")
+        if(NVTX_VERSION VERSION_LESS "3")
+            set(FLAMEGPU_DEPENDENCY_LINK_LIBRARIES ${FLAMEGPU_DEPENDENCY_LINK_LIBRARIES} ${NVTX_LIBRARIES})
+        endif()
     else()
         # If not found, disable.
-        message("NVTX Not found, Setting NVTX=OFF")
-        SET(NVTX "OFF")    
+        message("-- NVTX not available")
+        SET(USE_NVTX "OFF" PARENT_SCOPE)    
     endif()
-endif(NVTX)
+endif(USE_NVTX)
 
 # Logging for jitify compilation
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -DJITIFY_PRINT_LOG")

--- a/cmake/modules/FindNVTX.cmake
+++ b/cmake/modules/FindNVTX.cmake
@@ -40,16 +40,17 @@ if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "10.0")
             nvtx3
         )
 
-    # Get the NVTX version from the headerfile, by reading it and regex matching
-    file(READ "${NVTX_INCLUDE_DIRS}/nvToolsExt.h" nvtx_header_text)
-    string(REGEX MATCH "define NVTX_VERSION ([0-9]+)" NVTX_VERSION_DEFINE ${nvtx_header_text})
-    set(NVTX_VERSION "${CMAKE_MATCH_1}")
-
-    # Apply standard cmake find package rules / variables. I.e. QUIET, NVTX_FOUND etc.
-    find_package_handle_standard_args(NVTX
-        REQUIRED_VARS NVTX_INCLUDE_DIRS
-        VERSION_VAR NVTX_VERSION
-    )
+    if(NVTX_INCLUDE_DIRS)
+        # Get the NVTX version from the headerfile, by reading it and regex matching
+        file(READ "${NVTX_INCLUDE_DIRS}/nvToolsExt.h" nvtx_header_text)
+        string(REGEX MATCH "define NVTX_VERSION ([0-9]+)" NVTX_VERSION_DEFINE ${nvtx_header_text})
+        set(NVTX_VERSION "${CMAKE_MATCH_1}")
+        # Apply standard cmake find package rules / variables. I.e. QUIET, NVTX_FOUND etc.
+        find_package_handle_standard_args(NVTX
+            REQUIRED_VARS NVTX_INCLUDE_DIRS
+            VERSION_VAR NVTX_VERSION
+        )
+    endif()
 endif()
 
 # If not yet aware of NVTX, or we found V1/2 while looking for V3, make sure we find the actual V1/2
@@ -79,16 +80,17 @@ if(NOT NVTX_FOUND OR NVTX_VERSION VERSION_LESS 3)
             lib64
             lib/x64
     )
-    # Get the NVTX version from the headerfile, by reading it and regex matching
-    file(READ "${NVTX_INCLUDE_DIRS}/nvToolsExt.h" nvtx_header_text)
-    string(REGEX MATCH "define NVTX_VERSION ([0-9]+)" NVTX_VERSION_DEFINE ${nvtx_header_text})
-    set(NVTX_VERSION "${CMAKE_MATCH_1}")
-
-    # Apply standard cmake find package rules / variables. I.e. QUIET, NVTX_FOUND etc.
-    find_package_handle_standard_args(NVTX
-        REQUIRED_VARS NVTX_INCLUDE_DIRS
-        VERSION_VAR NVTX_VERSION
-    )
+    if(NVTX_INCLUDE_DIRS)
+        # Get the NVTX version from the headerfile, by reading it and regex matching
+        file(READ "${NVTX_INCLUDE_DIRS}/nvToolsExt.h" nvtx_header_text)
+        string(REGEX MATCH "define NVTX_VERSION ([0-9]+)" NVTX_VERSION_DEFINE ${nvtx_header_text})
+        set(NVTX_VERSION "${CMAKE_MATCH_1}")
+        # Apply standard cmake find package rules / variables. I.e. QUIET, NVTX_FOUND etc.
+        find_package_handle_standard_args(NVTX
+            REQUIRED_VARS NVTX_INCLUDE_DIRS
+            VERSION_VAR NVTX_VERSION
+        )
+    endif()
 endif()
 
 # Set returned values as advanced?

--- a/cmake/modules/FindNVTX.cmake
+++ b/cmake/modules/FindNVTX.cmake
@@ -1,5 +1,8 @@
 # CMake module to find NVTX headers/library
-# This is currently quite simple, could be expanded to support user-provided hinting?
+# Finds NVTX 3 for CUDA >= 10.0, which is header only
+# Finds NVTX 1 for CUDA <  10.0, which is header + library. 
+#
+#
 # Usage:
 #    find_package( NVTX )
 #    if(NVTX_FOUND)
@@ -11,6 +14,7 @@
 #    NVTX_FOUND
 #    NVTX_INCLUDE_DIRS
 #    NVTX_LIBRARIES
+#    NVTX_VERSION
 #
 # Manually specify NVRTC paths via -DNVTX_ROOT=/path/to/cuda/install/location
 
@@ -19,41 +23,73 @@
 
 # Search Path heirarchy order is <PackageName>_ROOT >  NVRTC_INCLUDE_DIRS / NVRTC_LIBRARIES > cmake environment variables > HINTS > system environment variables > platform files for current system > PATHS
 
-
-# Attempt to find nvToolsExt.h containing directory
-find_path(NVTX_INCLUDE_DIRS
-    NAMES
-        nvToolsExt.h
-        nvtx3/nvToolsExt.h
-    HINTS
-        ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
-    PATHS
-        ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
-    PATH_SUFFIXES
-        include
-        include/nvtx3
-    )
-
-# Find the directory containing the dynamic library
-find_library(NVTX_LIBRARIES
-    NAMES 
-        libnvToolsExt.so
-        nvToolsExt64_1
-        nvToolsExt32_1 
-    HINTS
-        ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}
-    PATHS 
-        ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}
-    PATH_SUFFIXES
-        lib
-        lib64
-        lib/Win32
-        lib/x64
-)
-
-# Apply standard cmake find package rules / variables. I.e. QUIET, NVTX_FOUND etc.
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(NVTX DEFAULT_MSG NVTX_INCLUDE_DIRS NVTX_LIBRARIES)
+
+# Search for the nvtx3 header if CUDA >= 10.0
+if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "10.0")
+    # Find the nvtx header, specifically searching for the v3 header only (in the nvtx3 subdir). There are edge cases where its possible that the v2 header would be found instead.
+    find_path(NVTX_INCLUDE_DIRS
+        NAMES
+            nvToolsExt.h
+        HINTS
+            ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
+        PATHS
+            ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
+        PATH_SUFFIXES
+            include/nvtx3
+            nvtx3
+        )
+
+    # Get the NVTX version from the headerfile, by reading it and regex matching
+    file(READ "${NVTX_INCLUDE_DIRS}/nvToolsExt.h" nvtx_header_text)
+    string(REGEX MATCH "define NVTX_VERSION ([0-9]+)" NVTX_VERSION_DEFINE ${nvtx_header_text})
+    set(NVTX_VERSION "${CMAKE_MATCH_1}")
+
+    # Apply standard cmake find package rules / variables. I.e. QUIET, NVTX_FOUND etc.
+    find_package_handle_standard_args(NVTX
+        REQUIRED_VARS NVTX_INCLUDE_DIRS
+        VERSION_VAR NVTX_VERSION
+    )
+endif()
+
+# If not yet aware of NVTX, or we found V1/2 while looking for V3, make sure we find the actual V1/2
+if(NOT NVTX_FOUND OR NVTX_VERSION VERSION_LESS 3)
+    # Find the header file
+    find_path(NVTX_INCLUDE_DIRS
+        NAMES
+            nvToolsExt.h
+        HINTS
+            ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
+        PATHS
+            ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
+        PATH_SUFFIXES
+            include
+        )
+    # Find the appropraite dynamic library - but only 64 bit.
+    find_library(NVTX_LIBRARIES
+        NAMES
+            libnvToolsExt.so
+            nvToolsExt64_1
+        HINTS
+            ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}
+        PATHS
+            ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}
+        PATH_SUFFIXES
+            lib
+            lib64
+            lib/x64
+    )
+    # Get the NVTX version from the headerfile, by reading it and regex matching
+    file(READ "${NVTX_INCLUDE_DIRS}/nvToolsExt.h" nvtx_header_text)
+    string(REGEX MATCH "define NVTX_VERSION ([0-9]+)" NVTX_VERSION_DEFINE ${nvtx_header_text})
+    set(NVTX_VERSION "${CMAKE_MATCH_1}")
+
+    # Apply standard cmake find package rules / variables. I.e. QUIET, NVTX_FOUND etc.
+    find_package_handle_standard_args(NVTX
+        REQUIRED_VARS NVTX_INCLUDE_DIRS
+        VERSION_VAR NVTX_VERSION
+    )
+endif()
 
 # Set returned values as advanced?
-mark_as_advanced(NVTX_INCLUDE_DIRS NVTX_LIBRARIES)
+mark_as_advanced(NVTX_INCLUDE_DIRS NVTX_LIBRARIES NVTX_VERSION)

--- a/include/flamegpu/util/nvtx.h
+++ b/include/flamegpu/util/nvtx.h
@@ -4,17 +4,25 @@
 /**
  * Utility namespace for handling of NVTX profiling markers/ranges, wrapped in macros to avoid performance impact if not enabled.
  * 
- * Macro `NVTX` must be defined to be enabled.
- * Use NVTX_ macros to use. 
+ * Macro `USE_NVTX` must be defined to be enabled.
+ * Use NVTX_PUSH, NVTX_POP, NVTX_RANGE macros to use.
  */
 
 // If NVTX is enabled, include header, defined namespace / class and macros.
-#if defined(NVTX)
-// Include the header if enabled
-#include "nvToolsExt.h"
+#if defined(USE_NVTX)
+    // Include the appropriate header if enabled
+    #if USE_NVTX >= 3
+        #include "nvtx3/nvToolsExt.h"
+    #else
+        #include "nvToolsExt.h"
+    #endif
 #endif
 
-// #if defined(NVTX)
+/* @todo - Make these macros testable.
+   If USE_NVTX is enabled, store static counts of push/pop/range's
+   Make accessors to enable testing the number of counts is as expected
+   Could also include this in a device shutdown method, to report if there is a mismatch of push/pop and therefore an NVTX error.
+*/
 
 namespace util {
 namespace nvtx {
@@ -36,7 +44,7 @@ const uint32_t colourCount = sizeof(palette) / sizeof(uint32_t);
  * @note The number of pushes must match the number of pops.
  * @see NVTX_PUSH to use with minimal performance impact
  */
-#if defined(NVTX)
+#if defined(USE_NVTX)
 inline void push(const char * label) {
     // Static variable to track the next colour to be used with auto rotation.
     static uint32_t nextColourIdx = 0;
@@ -73,7 +81,7 @@ inline void push(const char *) {
  * @see NVTX_POP to use with minimal performance impact
  */
 inline void pop() {
-    #if defined(NVTX)
+    #if defined(USE_NVTX)
         nvtxRangePop();
     #endif
 }
@@ -102,8 +110,8 @@ class NVTXRange {
 };  // namespace nvtx
 };  // namespace util
 
-// If NVTX is enabled, provide macros which actually use NVTX
-#if defined(NVTX)
+// If USE_NVTX is enabled, provide macros which actually use NVTX
+#if defined(USE_NVTX)
 /**
  * Macro which creates a scope-based NVTX range, with auto-popping of the marker.
  * If NVTX is defined, this constructs an util::nvtx::NVTXRange object with the specified label.

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -31,7 +31,7 @@ apt-key add 7fa2af80.pub
 apt-get -qq update
 
 # Install CUDA packages
-apt-get install -y --no-install-recommends cuda-compiler-${CUDA_PACKAGE_VERSION} cuda-cudart-dev-${CUDA_PACKAGE_VERSION} cuda-curand-dev-${CUDA_PACKAGE_VERSION} cuda-nvrtc-dev-${CUDA_PACKAGE_VERSION}
+apt-get install -y --no-install-recommends cuda-compiler-${CUDA_PACKAGE_VERSION} cuda-cudart-dev-${CUDA_PACKAGE_VERSION} cuda-curand-dev-${CUDA_PACKAGE_VERSION} cuda-nvrtc-dev-${CUDA_PACKAGE_VERSION} cuda-nvtx-${CUDA_PACKAGE_VERSION}
 
 # Install cpplint (optional, not currently used at CI time)
 pip3 install cpplint #--user

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,10 +117,10 @@ SET(SRC_INCLUDE
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/utility/EnvironmentManager.cuh
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/utility/HostEnvironment.cuh
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/utility/HostRandom.cuh
-    ${FLAMEGPU_ROOT}/include/flamegpu/runtime/utility/RandomManager.cuh    
-    ${FLAMEGPU_ROOT}/include/flamegpu/util/nvtx.h    
-    ${FLAMEGPU_ROOT}/include/flamegpu/util/compute_capability.cuh    
-    ${FLAMEGPU_ROOT}/include/flamegpu/util/SignalHandlers.h    
+    ${FLAMEGPU_ROOT}/include/flamegpu/runtime/utility/RandomManager.cuh
+    ${FLAMEGPU_ROOT}/include/flamegpu/util/nvtx.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/util/compute_capability.cuh
+    ${FLAMEGPU_ROOT}/include/flamegpu/util/SignalHandlers.h
 )
 SET(SRC_FLAMEGPU2
     ${FLAMEGPU_ROOT}/src/flamegpu/exception/FGPUException.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -126,7 +126,8 @@ SET(TEST_CASE_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_array_3d.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_append_truncate.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/util/test_compute_capability.cu
-	${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_rtc_device_api.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/util/test_nvtx.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_rtc_device_api.cu
 )
 SET(DEV_TEST_CASE_SRC
 

--- a/tests/test_cases/util/test_nvtx.cu
+++ b/tests/test_cases/util/test_nvtx.cu
@@ -1,0 +1,31 @@
+#include "gtest/gtest.h"
+#include "flamegpu/util/nvtx.h"
+#include "flamegpu/gpu/CUDAErrorChecking.h"
+
+// Test nvtx versions, and whether or not use causes any potential issues.
+TEST(TestUtilNVTX, nvtx) {
+    // NVTX PUSH, POP and RANGE have no measurable side effects whether USE_NVTX is enabled or not, so use alone shouldn't cause any issues. This is effectively a compile time/linker test. This should probably be resolved (but has a cost).
+
+    // Push a marker
+    NVTX_PUSH("Test_RANGE");
+    // Pop the marker
+    NVTX_POP();
+    // Make a scoped range (push, pop)
+    {
+        NVTX_RANGE("Test_NVTX_RANGE");
+    }
+
+    // If NVTX is enabled, we can check macros to determine which version was loaded.
+    #if defined(USE_NVTX) && defined(__CUDACC_VER_MAJOR__) && defined(NVTX_VERSION)
+        int cuda_major = __CUDACC_VER_MAJOR__;
+        int nvtx_version = NVTX_VERSION;
+        if (cuda_major >= 10) {
+            // CUDA >= 10.0 should be using NVTX3 or newer
+            EXPECT_GE(nvtx_version, 3);
+        } else {
+            // If CUDA is < 10.0, should be using nvtx 1 or 2
+            EXPECT_GE(nvtx_version, 0);
+            EXPECT_LT(nvtx_version, 3);
+        }
+    #endif
+}


### PR DESCRIPTION
Closes #276 

+ [x] Changes `-DNVTX` to `-DUSE_NVTX`, default is `OFF`
+ [x] Finds NVTX3 for CUDA >= 10.0
+ [x] Finds NVTX1/2 for CUDA < 10.0, or if NVTX3 was missing for some reason.
+ [x] Passes the NVTX version to compilers as `USE_NVTX=<VERSION>`
+ [x] Uses the correct header for NVTX3 if `USE_NVTX >= 3`
+ [x] Test to check the correct/expected version of NVTX is used for the CUDA version used. Also includes use of the macros, although their effects are not measurable (more of a compilation test)
+ [x] Tested on linux:
    + [x] CUDA 10.2 `-- Found NVTX: /usr/local/cuda-10.2/targets/x86_64-linux/include/nvtx3 (found version "3")`
    + [x] CUDA 9.2 `-- Found NVTX: /usr/local/cuda-9.2/targets/x86_64-linux/include (found version "2")`
+ [x] Tested on Windows:
    + [x] CUDA 10
    + ~CUDA 9 - Hard to test locally + CUDA 9 is generally unhappy on windows currently~
+ [x] Enabled on CI