### PR TITLE
Add Github Actions workflows for CI and ensure GCC version supported

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -1,0 +1,22 @@
+# Just build documentation using Doxygen - no CUDA required
+name: Docs
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  doxygen:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install doxygen
+      run: sudo apt -y install doxygen graphviz
+
+    - name: Configure cmake
+      run: cmake . -B build -DBUILD_API_DOCUMENTATION=ON
+
+    - name: Docs
+      run: cmake --build . --target docs --verbose -j `nproc`
+      working-directory: build

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -1,0 +1,50 @@
+# Lint the project using cpplint
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  cpplint:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-18.04
+            cuda: "10.2"
+    env:
+      build_dir: "build"
+      build_tests: "ON"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Linting currently requires cuda to be installed. Ljnux is faster than windows.
+    - name: Install CUDA
+      env:
+        cuda: ${{ matrix.cuda }}
+      run: |
+        source ./scripts/actions/install_cuda_ubuntu.sh
+        if [[ $? -eq 0 ]]; then
+          # Set paths for subsequent steps, using ${CUDA_PATH}
+          echo "Adding CUDA to CUDA_PATH, PATH and LD_LIBRARY_PATH"
+          echo "::set-env name=CUDA_PATH::${CUDA_PATH}"
+          echo "::add-path::${CUDA_PATH}/bin"
+          echo "::set-env name=LD_LIBRARY_PATH::${CUDA_PATH}/lib:${LD_LIBRARY_PATH}"
+        fi
+      shell: bash
+
+    # Also install the linter.
+    - name: Install cpplint
+      run: pip3 install cpplint && echo "::add-path::$HOME/.local/bin"
+
+    # Configure cmake, including tests to make sure they are linted.
+    - name: Configure cmake
+      run: cmake . -B ${{ env.build_dir }} -DBUILD_TESTS=${{ env.build_tests }} 
+
+    # Run the linter.
+    - name: Lint
+      run: cmake --build . --target all_lint --verbose -j `nproc` 
+      working-directory: ${{ env.build_dir }}

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -1,0 +1,86 @@
+# Compile project on Ubuntu
+name: Ubuntu
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      # explicit include-based build matrix, of known valid options
+      matrix:
+        include:
+          # 18.04 supports CUDA 10.1+ (gxx <= 8)
+          - os: ubuntu-18.04
+            cuda: "10.2"
+            gcc: 8
+          # - os: ubuntu-18.04
+          #   cuda: "10.1"
+          #   gcc: 8
+
+          # 16.04 supports CUDA 8+, we require 9.2+ due to gcc 7+ dependency (gtest+nvcc combo)
+          # - os: ubuntu-16.04
+          #   cuda: "10.0"
+          #   gcc: 7
+          # - os: ubuntu-16.04
+          #   cuda: "9.2"
+          #   gcc: 7
+          
+          # CUDA 9.1 and below cannot build tests, but should build the library
+          # - os: ubuntu-16.04
+          #   cuda: "9.1"
+          #   gcc: 6
+          # - os: ubuntu-16.04
+          #   cuda: "9.0"
+          #   gcc: 6
+    env:
+      cuda_arch: "35;75"
+      build_dir: "build"
+      config: "Release"
+      build_tests: "ON"
+      Werror: "ON"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install CUDA
+      env:
+        cuda: ${{ matrix.cuda }}
+      run: |
+        source ./scripts/actions/install_cuda_ubuntu.sh
+        if [[ $? -eq 0 ]]; then
+          # Set paths for subsequent steps, using ${CUDA_PATH}
+          echo "Adding CUDA to CUDA_PATH, PATH and LD_LIBRARY_PATH"
+          echo "::set-env name=CUDA_PATH::${CUDA_PATH}"
+          echo "::add-path::${CUDA_PATH}/bin"
+          echo "::set-env name=LD_LIBRARY_PATH::${CUDA_PATH}/lib:${LD_LIBRARY_PATH}"
+        fi
+      shell: bash
+
+    # Specify the correct host compilers
+    - name: Install/Select gcc and g++ 
+      run: |
+        sudo apt-get install -y gcc-${{ matrix.gcc }} g++-${{ matrix.gcc }}
+        echo "::set-env name=CC::/usr/bin/gcc-${{ matrix.gcc }}"
+        echo "::set-env name=CXX::/usr/bin/g++-${{ matrix.gcc }}"
+        echo "::set-env name=CUDAHOSTCXX::/usr/bin/g++-${{ matrix.gcc }}"
+
+    - name: Configure cmake
+      run: cmake . -B ${{ env.build_dir }} -DCMAKE_BUILD_TYPE=${{ env.config }} -DBUILD_TESTS=${{ env.build_tests }} -DWARNINGS_AS_ERRORS=${{ env.Werror }} -DCUDA_ARCH="${{ env.cuda_arch }}"
+
+    - name: Build flamegpu2
+      run: cmake --build . --target flamegpu2 --verbose -j `nproc`
+      working-directory: ${{ env.build_dir }}
+
+    - name: Build tests
+      if: env.build_tests == 'ON' && matrix.gcc > 6
+      run: cmake --build . --target tests --verbose -j `nproc`
+      working-directory: ${{ env.build_dir }}
+
+    - name: Build everything else
+      run: cmake --build . --target all --verbose -j `nproc`
+      working-directory: ${{ env.build_dir }}
+

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -1,0 +1,77 @@
+# Windows builds.
+name: Windows
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      # explicit include-based build matrix, of known valid options
+      matrix:
+        include:
+          # Windows2019 & VS 2019 supports 10.1+
+          - os: windows-2019
+            cuda: "10.2.89"
+            visual_studio: "Visual Studio 16 2019"
+          # - os: windows-2019
+          #   cuda: "10.1.243"
+          #   visual_studio: "Visual Studio 16 2019"
+
+          # Windows2016 & VS 2017 supports 10.0+
+          # - os: windows-2016
+          #   cuda: "10.2.89"
+          #   visual_studio: "Visual Studio 15 2017"
+          # - os: windows-2016
+          #   cuda: "10.1.243"
+          #   visual_studio: "Visual Studio 15 2017"
+          # - os: windows-2016
+          #   cuda: "10.0.130"
+          #   visual_studio: "Visual Studio 15 2017"
+
+    env:
+      cuda_arch: "35"
+      build_dir: "build"
+      config: "Release"
+      build_tests: "OFF"
+      Werror: "ON"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install CUDA
+      env: 
+        cuda: ${{ matrix.cuda }}
+        visual_studio: ${{ matrix.visual_studio }}
+      run: |
+        # Install CUDA via a powershell script
+        .\scripts\actions\install_cuda_windows.ps1
+        if ($?) {
+          # Set paths for subsequent steps, using $env:CUDA_PATH
+          echo "Adding CUDA to CUDA_PATH, CUDA_PATH_X_Y and PATH"
+          echo "::set-env name=CUDA_PATH::$env:CUDA_PATH"
+          echo "::set-env name=$env:CUDA_PATH_VX_Y::$env:CUDA_PATH"
+          echo "::add-path::$env:CUDA_PATH/bin"
+        }
+      shell: powershell
+
+    - name: Configure CMake
+      id: configure
+      run: cmake . -B ${{ env.build_dir }} -G "${{ matrix.visual_studio }}" -A x64 -DBUILD_TESTS=${{ env.build_tests }} -DWARNINGS_AS_ERRORS=${{ env.werror }} -DCUDA_ARCH="${{ env.cuda_arch }}"
+      shell: bash
+
+    - name: Build flamegpu2
+      run: cmake --build . --config ${{ env.config }} --target flamegpu2 --verbose
+      working-directory: ${{ env.build_dir }}
+
+    - name: Build tests
+      if: env.build_tests == 'ON'
+      run: cmake --build . --config ${{ env.config }} --target tests --verbose
+      working-directory: ${{ env.build_dir }}
+
+    - name: Build everything else
+      run: cmake --build . --config ${{ env.config }} --target ALL_BUILD --verbose
+      working-directory: ${{ env.build_dir }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,22 @@ option(USE_NVTX "Build with NVTX markers enabled" OFF)
 # Control target CUDA_ARCH to compile for
 SET(CUDA_ARCH "${CUDA_ARCH}" CACHE STRING "List of CUDA Architectures to target. E.g. 61;70" FORCE)
 
+# Enable the CXX compiler required for feature detection.
+enable_language(CXX)
+
+# If the CXX compiler is GNU, it needs to be >= 6 to build the library and >= 7 to build the tests. This will block certain cuda compilers.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # g++-6 is required - 5.5 is a broken compiler, lowever versions untested.
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6)        
+        message(FATAL_ERROR "g++ version >= 6 is required")
+    elseif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7)
+        if (BUILD_TESTS)
+            message(WARNING "  g++ < 7 is incompatible with googletest when using CUDA.\n  Setting BUILD_TESTS OFF.")
+            set(BUILD_TESTS OFF)
+        endif()
+    endif()
+endif()
+
 # Define a function to add a lint target.
 find_file(CPPLINT NAMES cpplint cpplint.exe)
 if(CPPLINT)

--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ The Code is currently under active development and should **not be used** until 
 
 ### Continuous Integration
 
-Continuous integration is provided by Travis (Linux) and windows (AppVeyor). This performs only build tests and the virtual machines do not support executing the unit tests. Each build has a script which is required to install the CUDA toolkit on the VM worker node. See the scripts folder for more details.
+Continuous Integration (CI) is provided by Github Actions, Travis (Linux only) and AppVeyor (Windows only).
+CI jobs *only* include compilation, as the CI workers do not include CUDA GPUs.
 
-#### Current Master Branch Build Status
+| Provider           | Status |
+|--------------------|--------|
+| Github Actions     | [![Ubuntu](https://github.com/ptheywood/FLAMEGPU2_dev/workflows/Ubuntu/badge.svg?branch=master)](https://github.com/ptheywood/FLAMEGPU2_dev/actions?query=workflow%3AUbuntu+branch%3Amaster) [![Windows](https://github.com/ptheywood/FLAMEGPU2_dev/workflows/Windows/badge.svg?branch=master)](https://github.com/ptheywood/FLAMEGPU2_dev/actions?query=workflow%3AWindows+branch%3Amaster) [![Lint](https://github.com/ptheywood/FLAMEGPU2_dev/workflows/Lint/badge.svg?branch=master)](https://github.com/ptheywood/FLAMEGPU2_dev/actions?query=workflow%3ALint+branch%3Amaster) [![Docs](https://github.com/ptheywood/FLAMEGPU2_dev/workflows/Docs/badge.svg?branch=master)](https://github.com/ptheywood/FLAMEGPU2_dev/actions?query=workflow%3ADocs+branch%3Amaster) |
+| Travis (Ubuntu)     | [![Build Status](https://travis-ci.org/FLAMEGPU/FLAMEGPU2_dev.svg?branch=master)](https://travis-ci.org/FLAMEGPU/FLAMEGPU2_dev)|
+| Appveyor (Windows) | [![Build status](https://ci.appveyor.com/api/projects/status/4p58gnu8tyj7y3a7/branch/master?svg=true)](https://ci.appveyor.com/project/mondus/flamegpu2-dev/branch/master) |
 
-[![Build status](https://ci.appveyor.com/api/projects/status/4p58gnu8tyj7y3a7/branch/master?svg=true)](https://ci.appveyor.com/project/mondus/flamegpu2-dev/branch/master)
-
-[![Build Status](https://travis-ci.org/FLAMEGPU/FLAMEGPU2_dev.svg?branch=master)](https://travis-ci.org/FLAMEGPU/FLAMEGPU2_dev)
 
 ### Dependencies
 
@@ -26,7 +28,8 @@ Only documentation can be built without the required dependencies (however Doxyg
 * [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit) >= 9.0
 * *Linux:*
   * [make](https://www.gnu.org/software/make/)
-  * gcc (version requirements [here](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#system-requirements))
+  * gcc/g++ >= 6 (version requirements [here](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#system-requirements))
+      * gcc/g++ >= 7 required for the test suite 
 * *Windows:*
   * Visual Studio 2015 or higher
 
@@ -168,21 +171,21 @@ doxygen Doxyfile.docs
 
 ##### Device Architectures
 
-CUDA device architectures can be specified via `-DSMS` when generating make files, using a semi colon, space or comma separated list of compute capability numbers. I.e to build for just SM_61 and SM_70:
+CUDA device architectures can be specified via `-DCUDA_ARCH` when generating make files, using a semi colon, space or comma separated list of compute capability numbers. I.e to build for just SM_61 and SM_70:
 
 ```
 mkdir -p build && cd build
-cmake .. -DSMS="61;70"
+cmake .. -DCUDA_ARCH="61;70"
 make -j8
 ```
 
-Pass `-DSMS=` to reset to the default.
+Pass `-DCUDA_ARCH=` to reset to the default.
 
 ##### NVTX Markers
 
-[NVTX markers](https://docs.nvidia.com/cuda/profiler-users-guide/index.html#nvtx) can be enabled to improve the profiling experience, using the `NVTX` Cmake option. 
+[NVTX markers](https://docs.nvidia.com/cuda/profiler-users-guide/index.html#nvtx) can be enabled to improve the profiling experience, using the `USE_NVTX` Cmake option. 
 
-I.e. `-DNVTX=ON` will enable NVTX markers and allow custom markers to be included. This is implied by the `Profile` build configuration. 
+I.e. `-DUSE_NVTX=ON` will enable NVTX markers and allow custom markers to be included. This is implied by the `Profile` build configuration. 
 See `include/util/nvtx.h` and the associated documentation for how to apply custom markers.
 
 ### Running FLAME GPU 2

--- a/scripts/actions/install_cuda_ubuntu.sh
+++ b/scripts/actions/install_cuda_ubuntu.sh
@@ -1,0 +1,144 @@
+# @todo - better / more robust parsing of inputs from env vars.
+## -------------------
+## Constants
+## -------------------
+
+# @todo - apt repos/known supported versions?
+
+# @todo - GCC support matrix?
+
+# List of packages to install.
+CUDA_PACKAGES_IN=(
+    "command-line-tools"
+    "curand-dev"
+    "nvrtc-dev"
+)
+
+## -------------------
+## Bash functions
+## -------------------
+# returns 0 (true) if a >= b
+function version_ge() {
+    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [ "$(printf '%s\n' "$@" | sort -V | head -n 1)" == "$2" ]
+}
+# returns 0 (true) if a > b
+function version_gt() {
+    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [ "$1" = "$2" ] && return 1 || version_ge $1 $2
+}
+# returns 0 (true) if a <= b
+function version_le() {
+    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [ "$(printf '%s\n' "$@" | sort -V | head -n 1)" == "$1" ]
+}
+# returns 0 (true) if a < b
+function version_lt() {
+    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [ "$1" = "$2" ] && return 1 || version_le $1 $2
+}
+
+## -------------------
+## Select CUDA version
+## -------------------
+
+# Get the cuda version from the environment as $cuda.
+CUDA_VERSION_MAJOR_MINOR=${cuda}
+
+# Split the version.
+# We (might/probably) don't know PATCH at this point - it depends which version gets installed.
+CUDA_MAJOR=$(echo "${CUDA_VERSION_MAJOR_MINOR}" | cut -d. -f1)
+CUDA_MINOR=$(echo "${CUDA_VERSION_MAJOR_MINOR}" | cut -d. -f2)
+CUDA_PATCH=$(echo "${CUDA_VERSION_MAJOR_MINOR}" | cut -d. -f3)
+# use lsb_release to find the OS.
+UBUNTU_VERSION=$(lsb_release -sr)
+UBUNTU_VERSION="${UBUNTU_VERSION//.}"
+
+echo "CUDA_MAJOR: ${CUDA_MAJOR}"
+echo "CUDA_MINOR: ${CUDA_MINOR}"
+echo "CUDA_PATCH: ${CUDA_PATCH}"
+echo "UBUNTU_VERSION: ${UBUNTU_VERSION}"
+
+# If we don't know the CUDA_MAJOR or MINOR, error.
+if [ -z "${CUDA_MAJOR}" ] ; then
+    echo "Error: Unknown CUDA Major version. Aborting."
+    exit 1
+fi
+if [ -z "${CUDA_MINOR}" ] ; then
+    echo "Error: Unknown CUDA Minor version. Aborting."
+    exit 1
+fi
+# If we don't know the Ubuntu version, error.
+if [ -z ${UBUNTU_VERSION} ]; then
+    echo "Error: Unknown Ubuntu version. Aborting."
+    exit 1
+fi
+
+
+## ---------------------------
+## GCC studio support check?
+## ---------------------------
+
+# @todo
+
+## -------------------------------
+## Select CUDA packages to install
+## -------------------------------
+CUDA_PACKAGES=""
+for package in "${CUDA_PACKAGES_IN[@]}"
+do : 
+    # @todo This is not perfect. Should probably provide a separate list for diff versions
+    # cuda-compiler-X-Y if CUDA >= 9.1 else cuda-nvcc-X-Y
+    if [[ "${package}" == "nvcc" ]] && version_ge "$CUDA_VERSION_MAJOR_MINOR" "9.1" ; then
+        package="compiler"
+    elif [[ "${package}" == "compiler" ]] && version_lt "$CUDA_VERSION_MAJOR_MINOR" "9.1" ; then
+        package="nvcc"
+    fi
+    # Build the full package name and append to the string.
+    CUDA_PACKAGES+=" cuda-${package}-${CUDA_MAJOR}-${CUDA_MINOR}"
+done
+echo "CUDA_PACKAGES ${CUDA_PACKAGES}"
+
+## -----------------
+## Prepare to install
+## -----------------
+
+PIN_FILENAME="cuda-ubuntu${UBUNTU_VERSION}.pin"
+PIN_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/${PIN_FILENAME}"
+APT_KEY_URL="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/7fa2af80.pub"
+REPO_URL="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/"
+
+echo "PIN_FILENAME ${PIN_FILENAME}"
+echo "PIN_URL ${PIN_URL}"
+echo "APT_KEY_URL ${APT_KEY_URL}"
+
+## -----------------
+## Install
+## -----------------
+echo "Adding CUDA Repository"
+wget ${PIN_URL}
+sudo mv ${PIN_FILENAME} /etc/apt/preferences.d/cuda-repository-pin-600
+sudo apt-key adv --fetch-keys ${APT_KEY_URL}
+sudo add-apt-repository "deb ${REPO_URL} /"
+sudo apt-get update
+
+echo "Installing CUDA packages ${CUDA_PACKAGES}"
+sudo apt-get -y install ${CUDA_PACKAGES}
+
+if [[ $? -ne 0 ]]; then
+    echo "CUDA Installation Error."
+    exit 1
+fi
+## -----------------
+## Set environment vars / vars to be propagated
+## -----------------
+
+CUDA_PATH=/usr/local/cuda-${CUDA_MAJOR}.${CUDA_MINOR}
+echo "CUDA_PATH=${CUDA_PATH}"
+export CUDA_PATH=${CUDA_PATH}
+
+
+# Quick test. @temp
+export PATH="$CUDA_PATH/bin:$PATH"
+export LD_LIBRARY_PATH="$CUDA_PATH/lib:$LD_LIBRARY_PATH"
+nvcc -V

--- a/scripts/actions/install_cuda_windows.ps1
+++ b/scripts/actions/install_cuda_windows.ps1
@@ -1,0 +1,137 @@
+## -------------------
+## Constants
+## -------------------
+
+# Dictionary of known cuda versions and thier download URLS, which do not follow a consistent pattern :(
+$CUDA_KNOWN_URLS = @{
+    "8.0.44" = "http://developer.nvidia.com/compute/cuda/8.0/Prod/network_installers/cuda_8.0.44_win10_network-exe";
+    "8.0.61" = "http://developer.nvidia.com/compute/cuda/8.0/Prod2/network_installers/cuda_8.0.61_win10_network-exe";
+    "9.0.176" = "http://developer.nvidia.com/compute/cuda/9.0/Prod/network_installers/cuda_9.0.176_win10_network-exe";
+    "9.1.85" = "http://developer.nvidia.com/compute/cuda/9.1/Prod/network_installers/cuda_9.1.85_win10_network";
+    "9.2.148" = "http://developer.nvidia.com/compute/cuda/9.2/Prod2/network_installers2/cuda_9.2.148_win10_network";
+    "10.0.130" = "http://developer.nvidia.com/compute/cuda/10.0/Prod/network_installers/cuda_10.0.130_win10_network";
+    "10.1.105" = "http://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.105_win10_network.exe";
+    "10.1.168" = "http://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.168_win10_network.exe";
+    "10.1.243" = "http://developer.download.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.243_win10_network.exe";
+    "10.2.89" = "http://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe";
+}
+
+# @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead?
+$VISUAL_STUDIO_MIN_CUDA = @{
+    "2019" = "10.1";
+    "2017" = "10.0"; # Depends on which version of 2017! 9.0 to 10.0 depending on  version
+    "2015" = "8.0"; # might support older, unsure.
+}
+
+$CUDA_PACKAGES_IN = @(
+    "nvcc";
+    "visual_studio_integration";
+    "curand_dev";
+    "nvrtc_dev";
+)
+
+
+## -------------------
+## Select CUDA version
+## -------------------
+
+# Get the cuda version from the environment as env:cuda.
+$CUDA_VERSION_FULL = $env:cuda
+# Make sure CUDA_VERSION_FULL is set and valid, otherwise error.
+
+# Validate CUDA version, extracting components via regex
+$cuda_ver_matched = $CUDA_VERSION_FULL -match "^(?<major>[1-9][0-9]*)\.(?<minor>[0-9]+)\.(?<patch>[0-9]+)$"
+if(-not $cuda_ver_matched){
+    Write-Output "Invalid CUDA version specified, <major>.<minor>.<patch> required. '$CUDA_VERSION_FULL'."
+    exit 1
+}
+$CUDA_MAJOR=$Matches.major
+$CUDA_MINOR=$Matches.minor
+$CUDA_PATCH=$Matches.patch
+
+## ---------------------------
+## Visual studio support check
+## ---------------------------
+# Exit if visual studio is too new for the cuda version.
+$VISUAL_STUDIO = $env:visual_studio.trim()
+if ($VISUAL_STUDIO.length -ge 4) {
+$VISUAL_STUDIO_YEAR = $VISUAL_STUDIO.Substring($VISUAL_STUDIO.Length-4)
+    if ($VISUAL_STUDIO_YEAR.length -eq 4 -and $VISUAL_STUDIO_MIN_CUDA.containsKey($VISUAL_STUDIO_YEAR)){
+        $MINIMUM_CUDA_VERSION = $VISUAL_STUDIO_MIN_CUDA[$VISUAL_STUDIO_YEAR]
+        if ([version]$CUDA_VERSION_FULL -lt [version]$MINIMUM_CUDA_VERSION) {
+            Write-Output "Error: Visual Studio $($VISUAL_STUDIO_YEAR) requires CUDA >= $($MINIMUM_CUDA_VERSION)"
+            exit 1
+        }
+    }
+} else {
+    Write-Output "Warning: Unknown Visual Studio Version. CUDA version may be insufficient."
+}
+
+## ------------------------------------------------
+## Select CUDA packages to install from environment
+## ------------------------------------------------
+
+$CUDA_PACKAGES = ""
+Foreach ($package in $CUDA_PACKAGES_IN) {
+    # Make sure the correct package name is used for nvcc.
+    if($package -eq "nvcc" -and [version]$CUDA_VERSION_FULL -lt [version]"9.1"){
+        $package="compiler"
+    } elseif($package -eq "compiler" -and [version]$CUDA_VERSION_FULL -ge [version]"9.1") {
+        $package="nvcc"
+    }
+    $CUDA_PACKAGES += " $($package)_$($CUDA_MAJOR).$($CUDA_MINOR)"
+
+}
+echo "$($CUDA_PACKAGES)"
+## -----------------
+## Prepare download
+## -----------------
+
+# Select the download link if known, otherwise have a guess.
+$CUDA_REPO_PKG_REMOTE=""
+if($CUDA_KNOWN_URLS.containsKey($CUDA_VERSION_FULL)){
+    $CUDA_REPO_PKG_REMOTE=$CUDA_KNOWN_URLS[$CUDA_VERSION_FULL]
+} else{
+    # Guess what the url is given the most recent pattern (at the time of writing, 10.1)
+    Write-Output "note: URL for CUDA ${$CUDA_VERSION_FULL} not known, estimating."
+    $CUDA_REPO_PKG_REMOTE="http://developer.download.nvidia.com/compute/cuda/$($CUDA_MAJOR).$($CUDA_MINOR)/Prod/network_installers/cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
+}
+$CUDA_REPO_PKG_LOCAL="cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
+
+
+## ------------
+## Install CUDA
+## ------------
+
+# Get CUDA network installer
+Write-Output "Downloading CUDA Network Installer for $($CUDA_VERSION_FULL) from: $($CUDA_REPO_PKG_REMOTE)"
+Invoke-WebRequest $CUDA_REPO_PKG_REMOTE -OutFile $CUDA_REPO_PKG_LOCAL | Out-Null
+if(Test-Path -Path $CUDA_REPO_PKG_LOCAL){
+    Write-Output "Downloading Complete"
+} else {
+    Write-Output "Error: Failed to download $($CUDA_REPO_PKG_LOCAL) from $($CUDA_REPO_PKG_REMOTE)"
+    exit 1
+}
+
+# Invoke silent install of CUDA (via network installer)
+Write-Output "Installing CUDA $($CUDA_VERSION_FULL). Subpackages $($CUDA_PACKAGES)"
+Start-Process -Wait -FilePath .\"$($CUDA_REPO_PKG_LOCAL)" -ArgumentList "-s $($CUDA_PACKAGES)"
+
+# Check the return status of the CUDA installer.
+if (!$?) {
+    Write-Output "Error: CUDA installer reported error. $($LASTEXITCODE)"
+    exit 1 
+}
+
+# Store the CUDA_PATH in the environment for the current session, to be forwarded in the action.
+$CUDA_PATH = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$($CUDA_MAJOR).$($CUDA_MINOR)"
+$CUDA_PATH_VX_Y = "CUDA_PATH_V$($CUDA_MAJOR)_$($CUDA_MINOR)" 
+# Set environmental variables in this session
+$env:CUDA_PATH = "$($CUDA_PATH)"
+$env:CUDA_PATH_VX_Y = "$($CUDA_PATH_VX_Y)"
+Write-Output "CUDA_PATH $($CUDA_PATH)"
+Write-Output "CUDA_PATH_VX_Y $($CUDA_PATH_VX_Y)"
+
+# PATH needs updating elsewhere, anything in here won't persist.
+# Append $CUDA_PATH/bin to path.
+# Set CUDA_PATH as an environmental variable

--- a/src/flamegpu/gpu/CUDAAgent.cu
+++ b/src/flamegpu/gpu/CUDAAgent.cu
@@ -656,7 +656,7 @@ void CUDAAgent::addInstantitateRTCFunction(const AgentFunctionData& func, bool f
             rtc_func_map.insert(CUDARTCFuncMap::value_type(func_name, std::unique_ptr<jitify::KernelInstantiation>(new jitify::KernelInstantiation(kernel, { func_impl.c_str()}))));
         }
     }
-    catch (std::runtime_error e) {
+    catch (std::runtime_error const&) {
         // jitify does not have a method for getting compile logs so rely on JITIFY_PRINT_LOG defined in cmake
         THROW InvalidAgentFunc("Error compiling runtime agent function (or function condition) ('%s'): function had compilation errors (see std::cout), "
             "in CUDAAgent::addInstantitateRTCFunction().",

--- a/tests/test_cases/runtime/test_agent_random.cu
+++ b/tests/test_cases/runtime/test_agent_random.cu
@@ -86,7 +86,7 @@ TEST(AgentRandomTest, AgentRandomCheck) {
             a1 = instance.getVariable<float>("a");
             b1 = instance.getVariable<float>("b");
             c1 = instance.getVariable<float>("c");
-            results1.push_back({a1, b1, c1});
+            results1.push_back(std::make_tuple(a1, b1, c1));
             if (i != 0) {
                 // Different agents get different random numbers
                 EXPECT_TRUE(a1 != a2);
@@ -115,11 +115,10 @@ TEST(AgentRandomTest, AgentRandomCheck) {
 
         for (unsigned int i = 0; i < population.getCurrentListSize(); i++) {
             AgentInstance instance = population.getInstanceAt(i);
-            results2.push_back({
+            results2.push_back(std::make_tuple(
                 instance.getVariable<float>("a"),
                 instance.getVariable<float>("b"),
-                instance.getVariable<float>("c")
-            });
+                instance.getVariable<float>("c")));
         }
         EXPECT_TRUE(results2.size() == AGENT_COUNT);
 
@@ -144,11 +143,10 @@ TEST(AgentRandomTest, AgentRandomCheck) {
 
         for (unsigned int i = 0; i < population.getCurrentListSize(); i++) {
             AgentInstance instance = population.getInstanceAt(i);
-            results2.push_back({
+            results2.push_back(std::make_tuple(
                 instance.getVariable<float>("a"),
                 instance.getVariable<float>("b"),
-                instance.getVariable<float>("c")
-            });
+                instance.getVariable<float>("c")));
         }
         EXPECT_EQ(results2.size(), AGENT_COUNT);
 


### PR DESCRIPTION
4 Workflows on github actions for windows builds, linux builds, docs builds and linting.

Ensure a suitable GCC compiler is used. GCC 6+ to build the library, and GCC 7+ to build the test suite.

Updates readme.md with new CI details, GCC restrictions and some other improvements


This does not apply path based filtering for actions.

If merged before #291, #291 should be rebased and the workflows ammended to include swig cmake options (Ubuntu: `sudo apt-get install -f swig`, Ubuntu+Windows: `-DBUILD_SWIG_PYTHON=ON -DBUILD_SWIG_PYTHON_VIRTUALENV=ON` within the configure steps.

Closes #290 
Closes #299 