### PR TITLE
CUDA 11.0RC 

### DIFF
--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -15,6 +15,9 @@ jobs:
         include:
           # 18.04 supports CUDA 10.1+ (gxx <= 8)
           - os: ubuntu-18.04
+            cuda: "11.0"
+            gcc: 8
+          - os: ubuntu-18.04
             cuda: "10.2"
             gcc: 8
           # - os: ubuntu-18.04
@@ -22,6 +25,9 @@ jobs:
           #   gcc: 8
 
           # 16.04 supports CUDA 8+, we require 9.2+ due to gcc 7+ dependency (gtest+nvcc combo)
+          # - os: ubuntu-16.04
+          #   cuda: "11.0"
+          #   gcc: 7
           # - os: ubuntu-16.04
           #   cuda: "10.0"
           #   gcc: 7

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -15,6 +15,9 @@ jobs:
         include:
           # Windows2019 & VS 2019 supports 10.1+
           - os: windows-2019
+            cuda: "11.0.167"
+            visual_studio: "Visual Studio 16 2019"
+          - os: windows-2019
             cuda: "10.2.89"
             visual_studio: "Visual Studio 16 2019"
           # - os: windows-2019
@@ -22,6 +25,9 @@ jobs:
           #   visual_studio: "Visual Studio 16 2019"
 
           # Windows2016 & VS 2017 supports 10.0+
+          # - os: windows-2016
+          #   cuda: "11.0.167"
+          #   visual_studio: "Visual Studio 15 2017"
           # - os: windows-2016
           #   cuda: "10.2.89"
           #   visual_studio: "Visual Studio 15 2017"

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,4 @@ before_script:
   - CUDA_ARCH="35;75"
 
 # Build steps
-script: "mkdir build && cd build && ${CMAKE_CMD} .. -DBUILD_TESTS=ON -DWARNINGS_AS_ERRORS=ON -DSMS=${CUDA_ARCH} -DUSE_NVTX=ON && make -j`nproc` all_lint all docs "
+script: "mkdir build && cd build && ${CMAKE_CMD} .. -DBUILD_TESTS=ON -DWARNINGS_AS_ERRORS=ON -DCUDA_ARCH=${CUDA_ARCH} -DUSE_NVTX=ON && make -j`nproc` all_lint all docs "

--- a/externals/jitify/jitify.hpp
+++ b/externals/jitify/jitify.hpp
@@ -116,6 +116,25 @@
 #endif
 #include <nvrtc.h>
 
+// For use by get_current_executable_path().
+#ifdef __linux__
+#include <linux/limits.h>  // For PATH_MAX
+
+#include <cstdlib>  // For realpath
+#define JITIFY_PATH_MAX PATH_MAX
+#elif defined(_WIN32) || defined(_WIN64)
+#include <windows.h>
+#define JITIFY_PATH_MAX MAX_PATH
+#else
+#error "Unsupported platform"
+#endif
+
+#ifdef _MSC_VER       // MSVC compiler
+#include <dbghelp.h>  // For UnDecorateSymbolName
+#else
+#include <cxxabi.h>  // For abi::__cxa_demangle
+#endif
+
 #if defined(_WIN32) || defined(_WIN64)
 // WAR for strtok_r being called strtok_s on Windows
 #pragma push_macro("strtok_r")
@@ -128,9 +147,9 @@
 #undef max
 #endif
 
-//#ifndef JITIFY_PRINT_LOG
-//#define JITIFY_PRINT_LOG 1
-//#endif
+#ifndef JITIFY_PRINT_LOG
+#define JITIFY_PRINT_LOG 1
+#endif
 
 #if JITIFY_PRINT_ALL
 #define JITIFY_PRINT_INSTANTIATION 1
@@ -424,27 +443,34 @@ inline bool extract_include_info_from_compile_error(std::string log,
                                                     std::string& name,
                                                     std::string& parent,
                                                     int& line_num) {
-  static const std::string pattern = "cannot open source file \"";
-  size_t beg = log.find(pattern);
-  if (beg == std::string::npos) {
-    return false;
-  }
-  beg += pattern.size();
-  size_t end = log.find("\"", beg);
-  name = log.substr(beg, end - beg);
+  static const std::vector<std::string> pattern = {
+      "could not open source file \"", "cannot open source file \""};
 
-  size_t line_beg = log.rfind("\n", beg);
-  if (line_beg == std::string::npos) {
-    line_beg = 0;
-  } else {
-    line_beg += 1;
+  for (auto& p : pattern) {
+    size_t beg = log.find(p);
+    if (beg != std::string::npos) {
+      beg += p.size();
+      size_t end = log.find("\"", beg);
+      name = log.substr(beg, end - beg);
+
+      size_t line_beg = log.rfind("\n", beg);
+      if (line_beg == std::string::npos) {
+        line_beg = 0;
+      } else {
+        line_beg += 1;
+      }
+
+      size_t split = log.find("(", line_beg);
+      parent = log.substr(line_beg, split - line_beg);
+      line_num =
+          atoi(log.substr(split + 1, log.find(")", split + 1) - (split + 1))
+                   .c_str());
+
+      return true;
+    }
   }
 
-  size_t split = log.find("(", line_beg);
-  parent = log.substr(line_beg, split - line_beg);
-  line_num = atoi(
-      log.substr(split + 1, log.find(")", split + 1) - (split + 1)).c_str());
-  return true;
+  return false;
 }
 
 inline bool is_include_directive_with_quotes(const std::string& source,
@@ -549,9 +575,8 @@ inline bool load_source(
   if (!source_stream) {
     std::string fullpath = path_join(current_dir, filename);
     // Try loading from callback
-    // double brackets prevent assignment in conditional warning
     if (!file_callback ||
-        !((source_stream = file_callback(fullpath, string_stream)) != 0 )) {
+        !((source_stream = file_callback(fullpath, string_stream)) != 0)) {
 #if JITIFY_ENABLE_EMBEDDED_FILES
       // Try loading as embedded file
       EmbeddedData embedded;
@@ -745,29 +770,50 @@ inline std::string value_string<bool>(const bool& x) {
   return x ? "true" : "false";
 }
 
+// Removes all tokens that start with double underscores.
+inline void strip_double_underscore_tokens(char* s) {
+  using jitify::detail::is_tokenchar;
+  char* w = s;
+  do {
+    if (*s == '_' && *(s + 1) == '_') {
+      while (is_tokenchar(*++s))
+        ;
+    }
+  } while ((*w++ = *s++));
+}
+
 //#if CUDA_VERSION < 8000
 #ifdef _MSC_VER  // MSVC compiler
-inline std::string demangle(const char* verbose_name) {
-  // Strips annotations from the verbose name returned by typeid(X).name()
-  std::string result = verbose_name;
-  result = jitify::detail::replace_token(result, "__ptr64", "");
-  result = jitify::detail::replace_token(result, "__cdecl", "");
-  result = jitify::detail::replace_token(result, "class", "");
-  result = jitify::detail::replace_token(result, "struct", "");
-  return result;
+inline std::string demangle_cuda_symbol(const char* mangled_name) {
+  // We don't have a way to demangle CUDA symbol names under MSVC.
+  return mangled_name;
 }
-#else  // not MSVC
-#include <cxxabi.h>
-inline std::string demangle(const char* mangled_name) {
-  size_t bufsize = 1024;
-  auto buf = std::unique_ptr<char, decltype(free)*>(
-      reinterpret_cast<char*>(malloc(bufsize)), free);
+inline std::string demangle_native_type(const std::type_info& typeinfo) {
+  // Get the decorated name and skip over the leading '.'.
+  const char* decorated_name = typeinfo.raw_name() + 1;
+  char undecorated_name[4096];
+  if (UnDecorateSymbolName(
+          decorated_name, undecorated_name,
+          sizeof(undecorated_name) / sizeof(*undecorated_name),
+          UNDNAME_NO_ARGUMENTS |          // Treat input as a type name
+              UNDNAME_NAME_ONLY           // No "class" and "struct" prefixes
+          /*UNDNAME_NO_MS_KEYWORDS*/)) {  // No "__cdecl", "__ptr64" etc.
+    // WAR for UNDNAME_NO_MS_KEYWORDS messing up function types.
+    strip_double_underscore_tokens(undecorated_name);
+    return undecorated_name;
+  }
+  throw std::runtime_error("UnDecorateSymbolName failed");
+}
+#else   // not MSVC
+inline std::string demangle_cuda_symbol(const char* mangled_name) {
+  size_t bufsize = 0;
+  char* buf = nullptr;
   std::string demangled_name;
   int status;
-  char* demangled_ptr =
-      abi::__cxa_demangle(mangled_name, buf.get(), &bufsize, &status);
+  auto demangled_ptr = std::unique_ptr<char, decltype(free)*>(
+      abi::__cxa_demangle(mangled_name, buf, &bufsize, &status), free);
   if (status == 0) {
-    demangled_name = demangled_ptr;  // all worked as expected
+    demangled_name = demangled_ptr.get();  // all worked as expected
   } else if (status == -2) {
     demangled_name = mangled_name;  // we interpret this as plain C name
   } else if (status == -1) {
@@ -778,29 +824,34 @@ inline std::string demangle(const char* mangled_name) {
   }
   return demangled_name;
 }
+inline std::string demangle_native_type(const std::type_info& typeinfo) {
+  return demangle_cuda_symbol(typeinfo.name());
+}
 #endif  // not MSVC
 //#endif // CUDA_VERSION < 8000
+
+template <typename>
+class JitifyTypeNameWrapper_ {};
 
 template <typename T>
 struct type_reflection {
   inline static std::string name() {
     //#if CUDA_VERSION < 8000
+    // TODO: Use nvrtcGetTypeName once it has the same behavior as this.
     // WAR for typeid discarding cv qualifiers on value-types
-    // We use a pointer type to maintain cv qualifiers, then strip out the '*'
-    std::string no_cv_name = demangle(typeid(T).name());
-    std::string ptr_name = demangle(typeid(T*).name());
-    // Find the right '*' by diffing the type name and ptr name
-    // Note that the '*' will also be prefixed with the cv qualifiers
-    size_t diff_begin =
-        std::mismatch(no_cv_name.begin(), no_cv_name.end(), ptr_name.begin())
-            .first -
-        no_cv_name.begin();
-    size_t star_begin = ptr_name.find("*", diff_begin);
-    if (star_begin == std::string::npos) {
-      throw std::runtime_error("Type reflection failed: " + ptr_name);
+    // Wrap type in dummy template class to preserve cv-qualifiers, then strip
+    // off the wrapper from the resulting string.
+    std::string wrapped_name =
+        demangle_native_type(typeid(JitifyTypeNameWrapper_<T>));
+    // Note: The reflected name of this class also has namespace prefixes.
+    const std::string wrapper_class_name = "JitifyTypeNameWrapper_<";
+    size_t start = wrapped_name.find(wrapper_class_name);
+    if (start == std::string::npos) {
+      throw std::runtime_error("Type reflection failed: " + wrapped_name);
     }
+    start += wrapper_class_name.size();
     std::string name =
-        ptr_name.substr(0, star_begin) + ptr_name.substr(star_begin + 1);
+        wrapped_name.substr(start, wrapped_name.size() - (start + 1));
     return name;
     //#else
     //         std::string ret;
@@ -907,7 +958,7 @@ inline std::string reflect(jitify::reflection::Type<T>) {
  */
 template <typename T>
 inline std::string reflect(jitify::reflection::Instance<T>& value) {
-  return detail::demangle(typeid(value.value).name());
+  return detail::demangle_native_type(typeid(value.value));
 }
 
 // Type from value
@@ -996,6 +1047,19 @@ inline std::string demangle_ptx_variable_name(const char* name) {
   return ss.str();
 }
 
+static const char* get_current_executable_path() {
+  static const char* path = []() -> const char* {
+    static char buffer[JITIFY_PATH_MAX] = {};
+#ifdef __linux__
+    if (!::realpath("/proc/self/exe", buffer)) return nullptr;
+#elif defined(_WIN32) || defined(_WIN64)
+    if (!GetModuleFileNameA(nullptr, buffer, JITIFY_PATH_MAX)) return nullptr;
+#endif
+    return buffer;
+  }();
+  return path;
+}
+
 inline bool endswith(const std::string& str, const std::string& suffix) {
   return str.size() >= suffix.size() &&
          str.substr(str.size() - suffix.size()) == suffix;
@@ -1077,7 +1141,15 @@ class CUDAKernel {
                                    "jitified_source.ptx", 0, 0, 0));
       for (int i = 0; i < (int)link_files.size(); ++i) {
         std::string link_file = link_files[i];
-        CUjitInputType jit_input_type = get_cuda_jit_input_type(&link_file);
+        CUjitInputType jit_input_type;
+        if (link_file == ".") {
+          // Special case for linking to current executable.
+          link_file = get_current_executable_path();
+          jit_input_type = CU_JIT_INPUT_OBJECT;
+        } else {
+          // Infer based on filename.
+          jit_input_type = get_cuda_jit_input_type(&link_file);
+        }
         CUresult result = cuLinkAddFile(_link_state, jit_input_type,
                                         link_file.c_str(), 0, 0, 0);
         int path_num = 0;
@@ -1109,8 +1181,8 @@ class CUDAKernel {
 #ifdef JITIFY_PRINT_LINKER_LOG
     std::cout << "---------------------------------------" << std::endl;
     std::cout << "--- Linker for "
-              << reflection::detail::demangle(_func_name.c_str()) << " ---"
-              << std::endl;
+              << reflection::detail::demangle_cuda_symbol(_func_name.c_str())
+              << " ---" << std::endl;
     std::cout << "---------------------------------------" << std::endl;
     std::cout << _info_log << std::endl;
     std::cout << std::endl;
@@ -1144,7 +1216,8 @@ class CUDAKernel {
       pos = std::min(_ptx.find(".const .align", pos),
                      _ptx.find(".global .align", pos));
       if (pos == std::string::npos) break;
-      size_t end = _ptx.find(";", pos);
+      size_t end = _ptx.find_first_of(";=", pos);
+      if (_ptx[end] == '=') --end;
       std::string line = _ptx.substr(pos, end - pos);
       pos = end;
       size_t symbol_start = line.find_last_of(" ") + 1;
@@ -1224,16 +1297,54 @@ class CUDAKernel {
                           block.z, smem, stream, arg_ptrs.data(), NULL);
   }
 
-  inline CUdeviceptr get_global_ptr(const char* name) const {
+  inline void safe_launch(dim3 grid, dim3 block, unsigned int smem,
+                          CUstream stream, std::vector<void*> arg_ptrs) const {
+    return cuda_safe_call(cuLaunchKernel(_kernel, grid.x, grid.y, grid.z,
+                                         block.x, block.y, block.z, smem,
+                                         stream, arg_ptrs.data(), NULL));
+  }
+
+  inline CUdeviceptr get_global_ptr(const char* name,
+                                    size_t* size = nullptr) const {
     CUdeviceptr global_ptr = 0;
     auto global = _global_map.find(name);
     if (global != _global_map.end()) {
-      cuda_safe_call(
-          cuModuleGetGlobal(&global_ptr, 0, _module, global->second.c_str()));
+      cuda_safe_call(cuModuleGetGlobal(&global_ptr, size, _module,
+                                       global->second.c_str()));
     } else {
       throw std::runtime_error(std::string("failed to look up global ") + name);
     }
     return global_ptr;
+  }
+
+  template <typename T>
+  inline CUresult get_global_data(const char* name, T* data, size_t count,
+                                  CUstream stream = 0) const {
+    size_t size_bytes;
+    CUdeviceptr ptr = get_global_ptr(name, &size_bytes);
+    size_t given_size_bytes = count * sizeof(T);
+    if (given_size_bytes != size_bytes) {
+      throw std::runtime_error(
+          std::string("Value for global variable ") + name +
+          " has wrong size: got " + std::to_string(given_size_bytes) +
+          " bytes, expected " + std::to_string(size_bytes));
+    }
+    return cuMemcpyDtoH(data, ptr, size_bytes);
+  }
+
+  template <typename T>
+  inline CUresult set_global_data(const char* name, const T* data, size_t count,
+                                  CUstream stream = 0) const {
+    size_t size_bytes;
+    CUdeviceptr ptr = get_global_ptr(name, &size_bytes);
+    size_t given_size_bytes = count * sizeof(T);
+    if (given_size_bytes != size_bytes) {
+      throw std::runtime_error(
+          std::string("Value for global variable ") + name +
+          " has wrong size: got " + std::to_string(given_size_bytes) +
+          " bytes, expected " + std::to_string(size_bytes));
+    }
+    return cuMemcpyHtoD(ptr, data, size_bytes);
   }
 
   const std::string& function_name() const { return _func_name; }
@@ -1266,200 +1377,280 @@ static const char* jitsafe_header_preinclude_h = R"(
 #define catch(...)
 )";
 
-static const char* jitsafe_header_float_h =
-    "#pragma once\n"
-    "\n"
-    "inline __host__ __device__ float  jitify_int_as_float(int i)             "
-    "{ union FloatInt { float f; int i; } fi; fi.i = i; return fi.f; }\n"
-    "inline __host__ __device__ double jitify_longlong_as_double(long long i) "
-    "{ union DoubleLongLong { double f; long long i; } fi; fi.i = i; return "
-    "fi.f; }\n"
-    "#define FLT_RADIX       2\n"
-    "#define FLT_MANT_DIG    24\n"
-    "#define DBL_MANT_DIG    53\n"
-    "#define FLT_DIG         6\n"
-    "#define DBL_DIG         15\n"
-    "#define FLT_MIN_EXP     -125\n"
-    "#define DBL_MIN_EXP     -1021\n"
-    "#define FLT_MIN_10_EXP  -37\n"
-    "#define DBL_MIN_10_EXP  -307\n"
-    "#define FLT_MAX_EXP     128\n"
-    "#define DBL_MAX_EXP     1024\n"
-    "#define FLT_MAX_10_EXP  38\n"
-    "#define DBL_MAX_10_EXP  308\n"
-    "#define FLT_MAX         jitify_int_as_float(2139095039)\n"
-    "#define DBL_MAX         jitify_longlong_as_double(9218868437227405311)\n"
-    "#define FLT_EPSILON     jitify_int_as_float(872415232)\n"
-    "#define DBL_EPSILON     jitify_longlong_as_double(4372995238176751616)\n"
-    "#define FLT_MIN         jitify_int_as_float(8388608)\n"
-    "#define DBL_MIN         jitify_longlong_as_double(4503599627370496)\n"
-    "#define FLT_ROUNDS      1\n"
-    "#if defined __cplusplus && __cplusplus >= 201103L\n"
-    "#define FLT_EVAL_METHOD 0\n"
-    "#define DECIMAL_DIG     21\n"
-    "#endif\n";
+static const char* jitsafe_header_float_h = R"(
+#pragma once
 
-static const char* jitsafe_header_limits_h =
-    "#pragma once\n"
-    "\n"
-    "#if defined _WIN32 || defined _WIN64\n"
-    " #define __WORDSIZE 32\n"
-    "#else\n"
-    " #if defined __x86_64__ && !defined __ILP32__\n"
-    "  #define __WORDSIZE 64\n"
-    " #else\n"
-    "  #define __WORDSIZE 32\n"
-    " #endif\n"
-    "#endif\n"
-    "#define MB_LEN_MAX  16\n"
-    "#define CHAR_BIT    8\n"
-    "#define SCHAR_MIN   (-128)\n"
-    "#define SCHAR_MAX   127\n"
-    "#define UCHAR_MAX   255\n"
-    "#ifdef __CHAR_UNSIGNED__\n"
-    " #define CHAR_MIN   0\n"
-    " #define CHAR_MAX   UCHAR_MAX\n"
-    "#else\n"
-    " #define CHAR_MIN   SCHAR_MIN\n"
-    " #define CHAR_MAX   SCHAR_MAX\n"
-    "#endif\n"
-    "#define SHRT_MIN    (-32768)\n"
-    "#define SHRT_MAX    32767\n"
-    "#define USHRT_MAX   65535\n"
-    "#define INT_MIN     (-INT_MAX - 1)\n"
-    "#define INT_MAX     2147483647\n"
-    "#define UINT_MAX    4294967295U\n"
-    "#if __WORDSIZE == 64\n"
-    " # define LONG_MAX  9223372036854775807L\n"
-    "#else\n"
-    " # define LONG_MAX  2147483647L\n"
-    "#endif\n"
-    "#define LONG_MIN    (-LONG_MAX - 1L)\n"
-    "#if __WORDSIZE == 64\n"
-    " #define ULONG_MAX  18446744073709551615UL\n"
-    "#else\n"
-    " #define ULONG_MAX  4294967295UL\n"
-    "#endif\n"
-    "#define LLONG_MAX  9223372036854775807LL\n"
-    "#define LLONG_MIN  (-LLONG_MAX - 1LL)\n"
-    "#define ULLONG_MAX 18446744073709551615ULL\n";
+#define FLT_RADIX       2
+#define FLT_MANT_DIG    24
+#define DBL_MANT_DIG    53
+#define FLT_DIG         6
+#define DBL_DIG         15
+#define FLT_MIN_EXP     -125
+#define DBL_MIN_EXP     -1021
+#define FLT_MIN_10_EXP  -37
+#define DBL_MIN_10_EXP  -307
+#define FLT_MAX_EXP     128
+#define DBL_MAX_EXP     1024
+#define FLT_MAX_10_EXP  38
+#define DBL_MAX_10_EXP  308
+#define FLT_MAX         3.4028234e38f 
+#define DBL_MAX         1.7976931348623157e308 
+#define FLT_EPSILON     1.19209289e-7f 
+#define DBL_EPSILON     2.220440492503130e-16 
+#define FLT_MIN         1.1754943e-38f; 
+#define DBL_MIN         2.2250738585072013e-308 
+#define FLT_ROUNDS      1
+#if defined __cplusplus && __cplusplus >= 201103L
+#define FLT_EVAL_METHOD 0
+#define DECIMAL_DIG     21
+#endif
+)";
 
-static const char* jitsafe_header_iterator =
-    "#pragma once\n"
-    "\n"
-    "namespace __jitify_iterator_ns {\n"
-    "struct output_iterator_tag {};\n"
-    "struct input_iterator_tag {};\n"
-    "struct forward_iterator_tag {};\n"
-    "struct bidirectional_iterator_tag {};\n"
-    "struct random_access_iterator_tag {};\n"
-    "template<class Iterator>\n"
-    "struct iterator_traits {\n"
-    "  typedef typename Iterator::iterator_category iterator_category;\n"
-    "  typedef typename Iterator::value_type        value_type;\n"
-    "  typedef typename Iterator::difference_type   difference_type;\n"
-    "  typedef typename Iterator::pointer           pointer;\n"
-    "  typedef typename Iterator::reference         reference;\n"
-    "};\n"
-    "template<class T>\n"
-    "struct iterator_traits<T*> {\n"
-    "  typedef random_access_iterator_tag iterator_category;\n"
-    "  typedef T                          value_type;\n"
-    "  typedef ptrdiff_t                  difference_type;\n"
-    "  typedef T*                         pointer;\n"
-    "  typedef T&                         reference;\n"
-    "};\n"
-    "template<class T>\n"
-    "struct iterator_traits<T const*> {\n"
-    "  typedef random_access_iterator_tag iterator_category;\n"
-    "  typedef T                          value_type;\n"
-    "  typedef ptrdiff_t                  difference_type;\n"
-    "  typedef T const*                   pointer;\n"
-    "  typedef T const&                   reference;\n"
-    "};\n"
-    "} // namespace __jitify_iterator_ns\n"
-    "namespace std { using namespace __jitify_iterator_ns; }\n"
-    "using namespace __jitify_iterator_ns;\n";
+static const char* jitsafe_header_limits_h = R"(
+#pragma once
+
+#if defined _WIN32 || defined _WIN64
+ #define __WORDSIZE 32
+#else
+ #if defined __x86_64__ && !defined __ILP32__
+  #define __WORDSIZE 64
+ #else
+  #define __WORDSIZE 32
+ #endif
+#endif
+#define MB_LEN_MAX  16
+#define CHAR_BIT    8
+#define SCHAR_MIN   (-128)
+#define SCHAR_MAX   127
+#define UCHAR_MAX   255
+enum {
+  _JITIFY_CHAR_IS_UNSIGNED = (char)-1 >= 0,
+  CHAR_MIN = _JITIFY_CHAR_IS_UNSIGNED ? 0 : SCHAR_MIN,
+  CHAR_MAX = _JITIFY_CHAR_IS_UNSIGNED ? UCHAR_MAX : SCHAR_MAX,
+};
+#define SHRT_MIN    (-32768)
+#define SHRT_MAX    32767
+#define USHRT_MAX   65535
+#define INT_MIN     (-INT_MAX - 1)
+#define INT_MAX     2147483647
+#define UINT_MAX    4294967295U
+#if __WORDSIZE == 64
+ # define LONG_MAX  9223372036854775807L
+#else
+ # define LONG_MAX  2147483647L
+#endif
+#define LONG_MIN    (-LONG_MAX - 1L)
+#if __WORDSIZE == 64
+ #define ULONG_MAX  18446744073709551615UL
+#else
+ #define ULONG_MAX  4294967295UL
+#endif
+#define LLONG_MAX  9223372036854775807LL
+#define LLONG_MIN  (-LLONG_MAX - 1LL)
+#define ULLONG_MAX 18446744073709551615ULL
+)";
+
+static const char* jitsafe_header_iterator = R"(
+#pragma once
+
+namespace std {
+struct output_iterator_tag {};
+struct input_iterator_tag {};
+struct forward_iterator_tag {};
+struct bidirectional_iterator_tag {};
+struct random_access_iterator_tag {};
+template<class Iterator>
+struct iterator_traits {
+  typedef typename Iterator::iterator_category iterator_category;
+  typedef typename Iterator::value_type        value_type;
+  typedef typename Iterator::difference_type   difference_type;
+  typedef typename Iterator::pointer           pointer;
+  typedef typename Iterator::reference         reference;
+};
+template<class T>
+struct iterator_traits<T*> {
+  typedef random_access_iterator_tag iterator_category;
+  typedef T                          value_type;
+  typedef ptrdiff_t                  difference_type;
+  typedef T*                         pointer;
+  typedef T&                         reference;
+};
+template<class T>
+struct iterator_traits<T const*> {
+  typedef random_access_iterator_tag iterator_category;
+  typedef T                          value_type;
+  typedef ptrdiff_t                  difference_type;
+  typedef T const*                   pointer;
+  typedef T const&                   reference;
+};
+}  // namespace std
+)";
 
 // TODO: This is incomplete; need floating point limits
-static const char* jitsafe_header_limits =
-    "#pragma once\n"
-    "#include <climits>\n"
-    "\n"
-    "namespace std {\n"
-    "// TODO: Floating-point limits\n"
-    "namespace __jitify_detail {\n"
-    "template<class T, T Min, T Max, int Digits=-1>\n"
-    "struct IntegerLimits {\n"
-    "	static inline __host__ __device__ T min() { return Min; }\n"
-    "	static inline __host__ __device__ T max() { return Max; }\n"
-    "#if __cplusplus >= 201103L\n"
-    "	static constexpr inline __host__ __device__ T lowest() noexcept {\n"
-    "		return Min;\n"
-    "	}\n"
-    "#endif  // __cplusplus >= 201103L\n"
-    "	enum {\n"
-    "       is_specialized = true,\n"
-    "		digits     = (Digits == -1) ? (int)(sizeof(T)*8 - (Min != 0)) "
-    ": Digits,\n"
-    "		digits10   = (digits * 30103) / 100000,\n"
-    "		is_signed  = ((T)(-1)<0),\n"
-    "		is_integer = true,\n"
-    "		is_exact   = true,\n"
-    "		radix      = 2,\n"
-    "		is_bounded = true,\n"
-    "		is_modulo  = false\n"
-    "	};\n"
-    "};\n"
-    "} // namespace detail\n"
-    "template<typename T> struct numeric_limits {\n"
-    "    enum { is_specialized = false };\n"
-    "};\n"
-    "template<> struct numeric_limits<bool>               : public "
-    "__jitify_detail::IntegerLimits<bool,              false,    true,1> {};\n"
-    "template<> struct numeric_limits<char>               : public "
-    "__jitify_detail::IntegerLimits<char,              CHAR_MIN, CHAR_MAX> "
-    "{};\n"
-    "template<> struct numeric_limits<signed char>        : public "
-    "__jitify_detail::IntegerLimits<signed char,       SCHAR_MIN,SCHAR_MAX> "
-    "{};\n"
-    "template<> struct numeric_limits<unsigned char>      : public "
-    "__jitify_detail::IntegerLimits<unsigned char,     0,        UCHAR_MAX> "
-    "{};\n"
-    "template<> struct numeric_limits<wchar_t>            : public "
-    "__jitify_detail::IntegerLimits<wchar_t,           INT_MIN,  INT_MAX> {};\n"
-    "template<> struct numeric_limits<short>              : public "
-    "__jitify_detail::IntegerLimits<short,             SHRT_MIN, SHRT_MAX> "
-    "{};\n"
-    "template<> struct numeric_limits<unsigned short>     : public "
-    "__jitify_detail::IntegerLimits<unsigned short,    0,        USHRT_MAX> "
-    "{};\n"
-    "template<> struct numeric_limits<int>                : public "
-    "__jitify_detail::IntegerLimits<int,               INT_MIN,  INT_MAX> {};\n"
-    "template<> struct numeric_limits<unsigned int>       : public "
-    "__jitify_detail::IntegerLimits<unsigned int,      0,        UINT_MAX> "
-    "{};\n"
-    "template<> struct numeric_limits<long>               : public "
-    "__jitify_detail::IntegerLimits<long,              LONG_MIN, LONG_MAX> "
-    "{};\n"
-    "template<> struct numeric_limits<unsigned long>      : public "
-    "__jitify_detail::IntegerLimits<unsigned long,     0,        ULONG_MAX> "
-    "{};\n"
-    "template<> struct numeric_limits<long long>          : public "
-    "__jitify_detail::IntegerLimits<long long,         LLONG_MIN,LLONG_MAX> "
-    "{};\n"
-    "template<> struct numeric_limits<unsigned long long> : public "
-    "__jitify_detail::IntegerLimits<unsigned long long,0,        ULLONG_MAX> "
-    "{};\n"
-    "//template<typename T> struct numeric_limits { static const bool "
-    "is_signed = ((T)(-1)<0); };\n"
-    "} // namespace std\n";
+//   Joe Eaton: added IEEE float and double types, none of the smaller types
+//              using type specific structs since we can't template on floats.
+static const char* jitsafe_header_limits = R"(
+#pragma once
+#include <cfloat>
+#include <climits>
+// TODO: epsilon(), infinity(), etc
+namespace __jitify_detail {
+#if __cplusplus >= 201103L
+#define JITIFY_CXX11_CONSTEXPR constexpr
+#define JITIFY_CXX11_NOEXCEPT noexcept
+#else
+#define JITIFY_CXX11_CONSTEXPR
+#define JITIFY_CXX11_NOEXCEPT
+#endif
+
+struct FloatLimits {
+#if __cplusplus >= 201103L
+   static JITIFY_CXX11_CONSTEXPR inline __host__ __device__ 
+          float lowest() JITIFY_CXX11_NOEXCEPT {   return -FLT_MAX;}
+   static JITIFY_CXX11_CONSTEXPR inline __host__ __device__ 
+          float min() JITIFY_CXX11_NOEXCEPT {      return FLT_MIN; }
+   static JITIFY_CXX11_CONSTEXPR inline __host__ __device__ 
+          float max() JITIFY_CXX11_NOEXCEPT {      return FLT_MAX; }
+#endif  // __cplusplus >= 201103L
+   enum {
+   is_specialized    = true,
+   is_signed         = true,
+   is_integer        = false,
+   is_exact          = false,
+   has_infinity      = true,
+   has_quiet_NaN     = true,
+   has_signaling_NaN = true,
+   has_denorm        = 1,
+   has_denorm_loss   = true,
+   round_style       = 1,
+   is_iec559         = true,
+   is_bounded        = true,
+   is_modulo         = false,
+   digits            = 24,
+   digits10          = 6,
+   max_digits10      = 9,
+   radix             = 2,
+   min_exponent      = -125,
+   min_exponent10    = -37,
+   max_exponent      = 128,
+   max_exponent10    = 38,
+   tinyness_before   = false,
+   traps             = false
+   };
+};
+struct DoubleLimits {
+#if __cplusplus >= 201103L
+   static JITIFY_CXX11_CONSTEXPR inline __host__ __device__ 
+          double lowest() noexcept { return -DBL_MAX; }
+   static JITIFY_CXX11_CONSTEXPR inline __host__ __device__ 
+          double min() noexcept { return DBL_MIN; }
+   static JITIFY_CXX11_CONSTEXPR inline __host__ __device__ 
+          double max() noexcept { return DBL_MAX; }
+#endif  // __cplusplus >= 201103L
+   enum {
+   is_specialized    = true,
+   is_signed         = true,
+   is_integer        = false,
+   is_exact          = false,
+   has_infinity      = true,
+   has_quiet_NaN     = true,
+   has_signaling_NaN = true,
+   has_denorm        = 1,
+   has_denorm_loss   = true,
+   round_style       = 1,
+   is_iec559         = true,
+   is_bounded        = true,
+   is_modulo         = false,
+   digits            = 53,
+   digits10          = 15,
+   max_digits10      = 17,
+   radix             = 2,
+   min_exponent      = -1021,
+   min_exponent10    = -307,
+   max_exponent      = 1024,
+   max_exponent10    = 308,
+   tinyness_before   = false,
+   traps             = false
+   };
+};
+template<class T, T Min, T Max, int Digits=-1>
+struct IntegerLimits {
+	static inline __host__ __device__ T min() { return Min; }
+	static inline __host__ __device__ T max() { return Max; }
+#if __cplusplus >= 201103L
+	static constexpr inline __host__ __device__ T lowest() noexcept {
+		return Min;
+	}
+#endif  // __cplusplus >= 201103L
+	enum {
+       is_specialized = true,
+       digits = (Digits == -1) ? (int)(sizeof(T)*8 - (Min != 0)) : Digits,
+       digits10   = (digits * 30103) / 100000,
+       is_signed  = ((T)(-1)<0),
+       is_integer = true,
+       is_exact   = true,
+       radix      = 2,
+       is_bounded = true,
+       is_modulo  = false
+	};
+};
+} // namespace __jitify_detail
+namespace std {
+template<typename T> struct numeric_limits {
+    enum { is_specialized = false };
+};
+template<> struct numeric_limits<bool>               : public 
+__jitify_detail::IntegerLimits<bool,              false,    true,1> {};
+template<> struct numeric_limits<char>               : public 
+__jitify_detail::IntegerLimits<char,              CHAR_MIN, CHAR_MAX> 
+{};
+template<> struct numeric_limits<signed char>        : public 
+__jitify_detail::IntegerLimits<signed char,       SCHAR_MIN,SCHAR_MAX> 
+{};
+template<> struct numeric_limits<unsigned char>      : public 
+__jitify_detail::IntegerLimits<unsigned char,     0,        UCHAR_MAX> 
+{};
+template<> struct numeric_limits<wchar_t>            : public 
+__jitify_detail::IntegerLimits<wchar_t,           INT_MIN,  INT_MAX> {};
+template<> struct numeric_limits<short>              : public 
+__jitify_detail::IntegerLimits<short,             SHRT_MIN, SHRT_MAX> 
+{};
+template<> struct numeric_limits<unsigned short>     : public 
+__jitify_detail::IntegerLimits<unsigned short,    0,        USHRT_MAX> 
+{};
+template<> struct numeric_limits<int>                : public 
+__jitify_detail::IntegerLimits<int,               INT_MIN,  INT_MAX> {};
+template<> struct numeric_limits<unsigned int>       : public 
+__jitify_detail::IntegerLimits<unsigned int,      0,        UINT_MAX> 
+{};
+template<> struct numeric_limits<long>               : public 
+__jitify_detail::IntegerLimits<long,              LONG_MIN, LONG_MAX> 
+{};
+template<> struct numeric_limits<unsigned long>      : public 
+__jitify_detail::IntegerLimits<unsigned long,     0,        ULONG_MAX> 
+{};
+template<> struct numeric_limits<long long>          : public 
+__jitify_detail::IntegerLimits<long long,         LLONG_MIN,LLONG_MAX> 
+{};
+template<> struct numeric_limits<unsigned long long> : public 
+__jitify_detail::IntegerLimits<unsigned long long,0,        ULLONG_MAX> 
+{};
+//template<typename T> struct numeric_limits { static const bool 
+//is_signed = ((T)(-1)<0); };
+template<> struct numeric_limits<float>              : public 
+__jitify_detail::FloatLimits 
+{};
+template<> struct numeric_limits<double>             : public 
+__jitify_detail::DoubleLimits 
+{};
+}  // namespace std
+)";
 
 // TODO: This is highly incomplete
 static const char* jitsafe_header_type_traits = R"(
     #pragma once
     #if __cplusplus >= 201103L
-    namespace __jitify_type_traits_ns {
+    namespace std {
 
     template<bool B, class T = void> struct enable_if {};
     template<class T>                struct enable_if<true, T> { typedef T type; };
@@ -1567,7 +1758,7 @@ static const char* jitsafe_header_type_traits = R"(
     template< class T > struct add_pointer<T, true> { using type = T; };
     template< class T, class... Args > struct add_pointer<T(Args...), true> { using type = T(*)(Args...); };
     template< class T, class... Args > struct add_pointer<T(Args..., ...), true> { using type = T(*)(Args..., ...); };
-    }
+    }  // namespace __jitify_detail
     template< class T > struct add_pointer : __jitify_detail::add_pointer<T, is_function<T>::value> {};
     #if __cplusplus >= 201402L
     template< class T > using add_pointer_t = typename add_pointer<T>::type;
@@ -1585,9 +1776,7 @@ static const char* jitsafe_header_type_traits = R"(
     template< class T > using decay_t = typename decay<T>::type;
     #endif
 
-    } // namespace __jtiify_type_traits_ns
-    namespace std { using namespace __jitify_type_traits_ns; }
-    using namespace __jitify_type_traits_ns;
+    }  // namespace std
     #endif // c++11
 )";
 
@@ -1718,7 +1907,7 @@ static const char* jitsafe_header_iostream =
 static const char* jitsafe_header_ostream =
     "#pragma once\n"
     "\n"
-    "namespace __jitify_ostream_ns {\n"
+    "namespace std {\n"
     "template<class CharT,class Traits=void>\n"  // = std::char_traits<CharT>
                                                  // >\n"
     "struct basic_ostream {\n"
@@ -1734,22 +1923,18 @@ static const char* jitsafe_header_ostream =
     "template< class CharT, class Traits, class T > basic_ostream<CharT, "
     "Traits>& operator<<( basic_ostream<CharT,Traits>&& os, const T& value );\n"
     "#endif  // __cplusplus >= 201103L\n"
-    "} // namespace __jitify_ostream_ns\n"
-    "namespace std { using namespace __jitify_ostream_ns; }\n"
-    "using namespace __jitify_ostream_ns;\n";
+    "}  // namespace std\n";
 
 static const char* jitsafe_header_istream =
     "#pragma once\n"
     "\n"
-    "namespace __jitify_istream_ns {\n"
+    "namespace std {\n"
     "template<class CharT,class Traits=void>\n"  // = std::char_traits<CharT>
                                                  // >\n"
     "struct basic_istream {\n"
     "};\n"
     "typedef basic_istream<char> istream;\n"
-    "} // namespace __jitify_istream_ns\n"
-    "namespace std { using namespace __jitify_istream_ns; }\n"
-    "using namespace __jitify_istream_ns;\n";
+    "}  // namespace std\n";
 
 static const char* jitsafe_header_sstream =
     "#pragma once\n"
@@ -1758,7 +1943,7 @@ static const char* jitsafe_header_sstream =
 
 static const char* jitsafe_header_utility =
     "#pragma once\n"
-    "namespace __jitify_utility_ns {\n"
+    "namespace std {\n"
     "template<class T1, class T2>\n"
     "struct pair {\n"
     "	T1 first;\n"
@@ -1773,25 +1958,21 @@ static const char* jitsafe_header_utility =
     "pair<T1,T2> make_pair(T1 const& first, T2 const& second) {\n"
     "	return pair<T1,T2>(first, second);\n"
     "}\n"
-    "} // namespace __jitify_utility_ns\n"
-    "namespace std { using namespace __jitify_utility_ns; }\n"
-    "using namespace __jitify_utility_ns;\n";
+    "}  // namespace std\n";
 
 // TODO: incomplete
 static const char* jitsafe_header_vector =
     "#pragma once\n"
-    "namespace __jitify_vector_ns {\n"
+    "namespace std {\n"
     "template<class T, class Allocator=void>\n"  // = std::allocator> \n"
     "struct vector {\n"
     "};\n"
-    "} // namespace __jitify_vector_ns\n"
-    "namespace std { using namespace __jitify_vector_ns; }\n"
-    "using namespace __jitify_vector_ns;\n";
+    "}  // namespace std\n";
 
 // TODO: incomplete
 static const char* jitsafe_header_string =
     "#pragma once\n"
-    "namespace __jitify_string_ns {\n"
+    "namespace std {\n"
     "template<class CharT,class Traits=void,class Allocator=void>\n"
     "struct basic_string {\n"
     "basic_string();\n"
@@ -1803,27 +1984,23 @@ static const char* jitsafe_header_string =
     "void operator+=(const basic_string &);\n"
     "};\n"
     "typedef basic_string<char> string;\n"
-    "} // namespace __jitify_string_ns\n"
-    "namespace std { using namespace __jitify_string_ns; }\n"
-    "using namespace __jitify_string_ns;\n";
+    "}  // namespace std\n";
 
 // TODO: incomplete
 static const char* jitsafe_header_stdexcept =
     "#pragma once\n"
-    "namespace __jitify_stdexcept_ns {\n"
+    "namespace std {\n"
     "struct runtime_error {\n"
     "explicit runtime_error( const std::string& what_arg );"
     "explicit runtime_error( const char* what_arg );"
     "virtual const char* what() const;\n"
     "};\n"
-    "} // namespace __jitify_stdexcept_ns\n"
-    "namespace std { using namespace __jitify_stdexcept_ns; }\n"
-    "using namespace __jitify_stdexcept_ns;\n";
+    "}  // namespace std\n";
 
 // TODO: incomplete
 static const char* jitsafe_header_complex =
     "#pragma once\n"
-    "namespace __jitify_complex_ns {\n"
+    "namespace std {\n"
     "template<typename T>\n"
     "class complex {\n"
     "	T _real;\n"
@@ -1853,13 +2030,11 @@ static const char* jitsafe_header_complex =
     "template<typename T>\n"
     "complex<T> operator*(const T& lhs, const complex<T>& rhs)\n"
     "  { return complexs<T>(rhs.real()*lhs,rhs.imag()*lhs); }\n"
-    "} // namespace __jitify_complex_ns\n"
-    "namespace std { using namespace __jitify_complex_ns; }\n"
-    "using namespace __jitify_complex_ns;\n";
+    "}  // namespace std\n";
 
 // TODO: This is incomplete (missing binary and integer funcs, macros,
 // constants, types)
-static const char* jitsafe_header_math =
+static const char* jitsafe_header_math_h =
     "#pragma once\n"
     "namespace __jitify_math_ns {\n"
     "#if __cplusplus >= 201103L\n"
@@ -1950,23 +2125,21 @@ static const char* jitsafe_header_memory_h = R"(
 static const char* jitsafe_header_mutex = R"(
     #pragma once
     #if __cplusplus >= 201103L
-    namespace __jitify_mutex_ns {
+    namespace std {
     class mutex {
     public:
     void lock();
     bool try_lock();
     void unlock();
     };
-    } // namespace __jitify_mutex_ns
-    namespace std { using namespace __jitify_mutex_ns; }
-    using namespace __jitify_mutex_ns;
+    }  // namespace std
     #endif
  )";
 
 static const char* jitsafe_header_algorithm = R"(
     #pragma once
     #if __cplusplus >= 201103L
-    namespace __jitify_algorithm_ns {
+    namespace std {
 
     #if __cplusplus == 201103L
     #define JITIFY_CXX14_CONSTEXPR
@@ -1983,10 +2156,7 @@ static const char* jitsafe_header_algorithm = R"(
       return (b < a) ? b : a;
     }
 
-    #endif
-    } // namespace __jitify_algorithm_ns
-    namespace std { using namespace __jitify_algorithm_ns; }
-    using namespace __jitify_algorithm_ns;
+    }  // namespace std
     #endif
  )";
 
@@ -2066,8 +2236,8 @@ static const std::map<std::string, std::string>& get_jitsafe_headers_map() {
       {"limits", jitsafe_header_limits},
       {"type_traits", jitsafe_header_type_traits},
       {"utility", jitsafe_header_utility},
-      {"math.h", jitsafe_header_math},
-      {"cmath", jitsafe_header_math},
+      {"math.h", jitsafe_header_math_h},
+      {"cmath", jitsafe_header_math_h},
       {"memory.h", jitsafe_header_memory_h},
       {"complex", jitsafe_header_complex},
       {"iostream", jitsafe_header_iostream},
@@ -2725,6 +2895,13 @@ class KernelLauncher_impl {
   inline CUresult launch(
       jitify::detail::vector<void*> arg_ptrs,
       jitify::detail::vector<std::string> arg_types = 0) const;
+  inline void safe_launch(
+      jitify::detail::vector<void*> arg_ptrs,
+      jitify::detail::vector<std::string> arg_types = 0) const;
+
+ private:
+  inline void pre_launch(
+      jitify::detail::vector<std::string> arg_types = 0) const;
 };
 
 /*! An object representing a configured and instantiated kernel ready
@@ -2754,6 +2931,17 @@ class KernelLauncher {
       jitify::detail::vector<std::string> arg_types = 0) const {
     return _impl->launch(arg_ptrs, arg_types);
   }
+
+  /*! Launch the kernel and check for cuda errors.
+   *
+   *  \see launch
+   */
+  inline void safe_launch(
+      std::vector<void*> arg_ptrs = std::vector<void*>(),
+      jitify::detail::vector<std::string> arg_types = 0) const {
+    _impl->safe_launch(arg_ptrs, arg_types);
+  }
+
   // Regular function call syntax
   /*! Launch the kernel.
    *
@@ -2771,6 +2959,15 @@ class KernelLauncher {
   inline CUresult launch(ArgTypes... args) const {
     return this->launch(std::vector<void*>({(void*)&args...}),
                         {reflection::reflect<ArgTypes>()...});
+  }
+  /*! Launch the kernel and check for cuda errors.
+   *
+   *  \param args Function arguments for the kernel.
+   */
+  template <typename... ArgTypes>
+  inline void safe_launch(ArgTypes... args) const {
+    this->safe_launch(std::vector<void*>({(void*)&args...}),
+                      {reflection::reflect<ArgTypes>()...});
   }
 };
 
@@ -2837,16 +3034,59 @@ class KernelInstantiation {
   /*
    * \deprecated Use \p get_global_ptr instead.
    */
-  inline CUdeviceptr get_constant_ptr(const char* name) const {
-    return get_global_ptr(name);
+  inline CUdeviceptr get_constant_ptr(const char* name,
+                                      size_t* size = nullptr) const {
+    return get_global_ptr(name, size);
   }
 
   /*
    * Get a device pointer to a global __constant__ or __device__ variable using
+   * its un-mangled name. If provided, *size is set to the size of the variable
+   * in bytes.
+   */
+  inline CUdeviceptr get_global_ptr(const char* name,
+                                    size_t* size = nullptr) const {
+    return _impl->cuda_kernel().get_global_ptr(name, size);
+  }
+
+  /*
+   * Copy data from a global __constant__ or __device__ array to the host using
    * its un-mangled name.
    */
-  inline CUdeviceptr get_global_ptr(const char* name) const {
-    return _impl->cuda_kernel().get_global_ptr(name);
+  template <typename T>
+  inline CUresult get_global_array(const char* name, T* data, size_t count,
+                                   CUstream stream = 0) const {
+    return _impl->cuda_kernel().get_global_data(name, data, count, stream);
+  }
+
+  /*
+   * Copy a value from a global __constant__ or __device__ variable to the host
+   * using its un-mangled name.
+   */
+  template <typename T>
+  inline CUresult get_global_value(const char* name, T* value,
+                                   CUstream stream = 0) const {
+    return get_global_array(name, value, 1, stream);
+  }
+
+  /*
+   * Copy data from the host to a global __constant__ or __device__ array using
+   * its un-mangled name.
+   */
+  template <typename T>
+  inline CUresult set_global_array(const char* name, const T* data,
+                                   size_t count, CUstream stream = 0) const {
+    return _impl->cuda_kernel().set_global_data(name, data, count, stream);
+  }
+
+  /*
+   * Copy a value from the host to a global __constant__ or __device__ variable
+   * using its un-mangled name.
+   */
+  template <typename T>
+  inline CUresult set_global_value(const char* name, const T& value,
+                                   CUstream stream = 0) const {
+    return set_global_array(name, &value, 1, stream);
   }
 
   const std::string& mangled_name() const {
@@ -3052,8 +3292,7 @@ inline std::ostream& operator<<(std::ostream& stream, dim3 d) {
   return stream;
 }
 
-inline CUresult KernelLauncher_impl::launch(
-    jitify::detail::vector<void*> arg_ptrs,
+inline void KernelLauncher_impl::pre_launch(
     jitify::detail::vector<std::string> arg_types) const {
 #if JITIFY_PRINT_LAUNCH
   Kernel_impl const& kernel = _kernel_inst._kernel;
@@ -3068,8 +3307,22 @@ inline CUresult KernelLauncher_impl::launch(
     throw std::runtime_error(
         "Kernel pointer is NULL; you may need to define JITIFY_THREAD_SAFE 1");
   }
+}
+
+inline CUresult KernelLauncher_impl::launch(
+    jitify::detail::vector<void*> arg_ptrs,
+    jitify::detail::vector<std::string> arg_types) const {
+  pre_launch(arg_types);
   return _kernel_inst._cuda_kernel->launch(_grid, _block, _smem, _stream,
                                            arg_ptrs);
+}
+
+inline void KernelLauncher_impl::safe_launch(
+    jitify::detail::vector<void*> arg_ptrs,
+    jitify::detail::vector<std::string> arg_types) const {
+  pre_launch(arg_types);
+  _kernel_inst._cuda_kernel->safe_launch(_grid, _block, _smem, _stream,
+                                         arg_ptrs);
 }
 
 inline KernelInstantiation_impl::KernelInstantiation_impl(
@@ -3784,16 +4037,57 @@ class KernelInstantiation {
   /*
    * \deprecated Use \p get_global_ptr instead.
    */
-  CUdeviceptr get_constant_ptr(const char* name) const {
-    return get_global_ptr(name);
+  CUdeviceptr get_constant_ptr(const char* name, size_t* size = nullptr) const {
+    return get_global_ptr(name, size);
   }
 
   /*
    * Get a device pointer to a global __constant__ or __device__ variable using
+   * its un-mangled name. If provided, *size is set to the size of the variable
+   * in bytes.
+   */
+  CUdeviceptr get_global_ptr(const char* name, size_t* size = nullptr) const {
+    return _cuda_kernel->get_global_ptr(name, size);
+  }
+
+  /*
+   * Copy data from a global __constant__ or __device__ array to the host using
    * its un-mangled name.
    */
-  CUdeviceptr get_global_ptr(const char* name) const {
-    return _cuda_kernel->get_global_ptr(name);
+  template <typename T>
+  CUresult get_global_array(const char* name, T* data, size_t count,
+                            CUstream stream = 0) const {
+    return _cuda_kernel->get_global_data(name, data, count, stream);
+  }
+
+  /*
+   * Copy a value from a global __constant__ or __device__ variable to the host
+   * using its un-mangled name.
+   */
+  template <typename T>
+  CUresult get_global_value(const char* name, T* value,
+                            CUstream stream = 0) const {
+    return get_global_array(name, value, 1, stream);
+  }
+
+  /*
+   * Copy data from the host to a global __constant__ or __device__ array using
+   * its un-mangled name.
+   */
+  template <typename T>
+  CUresult set_global_array(const char* name, const T* data, size_t count,
+                            CUstream stream = 0) const {
+    return _cuda_kernel->set_global_data(name, data, count, stream);
+  }
+
+  /*
+   * Copy a value from the host to a global __constant__ or __device__ variable
+   * using its un-mangled name.
+   */
+  template <typename T>
+  CUresult set_global_value(const char* name, const T& value,
+                            CUstream stream = 0) const {
+    return set_global_array(name, &value, 1, stream);
   }
 
   const std::string& mangled_name() const {
@@ -3818,6 +4112,18 @@ class KernelLauncher {
   unsigned int _smem;
   cudaStream_t _stream;
 
+ private:
+  void pre_launch(std::vector<std::string> arg_types = {}) const {
+#if JITIFY_PRINT_LAUNCH
+    std::string arg_types_string =
+        (arg_types.empty() ? "..." : reflection::reflect_list(arg_types));
+    std::cout << "Launching " << _kernel_inst->_cuda_kernel->function_name()
+              << "<<<" << _grid << "," << _block << "," << _smem << ","
+              << _stream << ">>>"
+              << "(" << arg_types_string << ")" << std::endl;
+#endif
+  }
+
  public:
   KernelLauncher(KernelInstantiation const* kernel_inst, dim3 grid, dim3 block,
                  unsigned int smem = 0, cudaStream_t stream = 0)
@@ -3840,16 +4146,16 @@ class KernelLauncher {
    */
   CUresult launch(std::vector<void*> arg_ptrs = {},
                   std::vector<std::string> arg_types = {}) const {
-#if JITIFY_PRINT_LAUNCH
-    std::string arg_types_string =
-        (arg_types.empty() ? "..." : reflection::reflect_list(arg_types));
-    std::cout << "Launching " << _kernel_inst->_cuda_kernel->function_name()
-              << "<<<" << _grid << "," << _block << "," << _smem << ","
-              << _stream << ">>>"
-              << "(" << arg_types_string << ")" << std::endl;
-#endif
+    pre_launch(arg_types);
     return _kernel_inst->_cuda_kernel->launch(_grid, _block, _smem, _stream,
                                               arg_ptrs);
+  }
+
+  void safe_launch(std::vector<void*> arg_ptrs = {},
+                   std::vector<std::string> arg_types = {}) const {
+    pre_launch(arg_types);
+    _kernel_inst->_cuda_kernel->safe_launch(_grid, _block, _smem, _stream,
+                                            arg_ptrs);
   }
 
   /*! Launch the kernel.
@@ -3860,6 +4166,16 @@ class KernelLauncher {
   CUresult launch(ArgTypes... args) const {
     return this->launch(std::vector<void*>({(void*)&args...}),
                         {reflection::reflect<ArgTypes>()...});
+  }
+
+  /*! Launch the kernel and check for cuda errors.
+   *
+   *  \param args Function arguments for the kernel.
+   */
+  template <typename... ArgTypes>
+  void safe_launch(ArgTypes... args) const {
+    return this->safe_launch(std::vector<void*>({(void*)&args...}),
+                             {reflection::reflect<ArgTypes>()...});
   }
 };
 

--- a/scripts/actions/install_cuda_ubuntu.sh
+++ b/scripts/actions/install_cuda_ubuntu.sh
@@ -7,11 +7,14 @@
 
 # @todo - GCC support matrix?
 
-# List of packages to install.
+# List of sub-packages to install.
+# @todo - pass this in from outside the script? 
+# @todo - check the specified subpackages exist via apt pre-install?  apt-rdepends cuda-9-0 | grep "^cuda-"?
+
+# Ideally choose from the list of meta-packages to minimise variance between cuda versions (although it does change too)
 CUDA_PACKAGES_IN=(
     "command-line-tools"
-    "curand-dev"
-    "nvrtc-dev"
+    "libraries-dev"
 )
 
 ## -------------------
@@ -57,6 +60,7 @@ UBUNTU_VERSION="${UBUNTU_VERSION//.}"
 echo "CUDA_MAJOR: ${CUDA_MAJOR}"
 echo "CUDA_MINOR: ${CUDA_MINOR}"
 echo "CUDA_PATCH: ${CUDA_PATCH}"
+# echo "UBUNTU_NAME: ${UBUNTU_NAME}"
 echo "UBUNTU_VERSION: ${UBUNTU_VERSION}"
 
 # If we don't know the CUDA_MAJOR or MINOR, error.

--- a/scripts/actions/install_cuda_windows.ps1
+++ b/scripts/actions/install_cuda_windows.ps1
@@ -14,6 +14,7 @@ $CUDA_KNOWN_URLS = @{
     "10.1.168" = "http://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.168_win10_network.exe";
     "10.1.243" = "http://developer.download.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.243_win10_network.exe";
     "10.2.89" = "http://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe";
+    "11.0.167" = "http://developer.download.nvidia.com/compute/cuda/11.0.1/network_installers/cuda_11.0.1_win10_network.exe"
 }
 
 # @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead?
@@ -23,11 +24,14 @@ $VISUAL_STUDIO_MIN_CUDA = @{
     "2015" = "8.0"; # might support older, unsure.
 }
 
+# cuda_runtime.h is in nvcc <= 10.2, but cudart >= 11.0
+# @todo - make this easier to vary per CUDA version.
 $CUDA_PACKAGES_IN = @(
     "nvcc";
     "visual_studio_integration";
     "curand_dev";
     "nvrtc_dev";
+    "cudart";
 )
 
 

--- a/src/flamegpu/runtime/cuRVE/curve_rtc.cpp
+++ b/src/flamegpu/runtime/cuRVE/curve_rtc.cpp
@@ -408,7 +408,7 @@ std::string CurveRTCHost::getEnvVariableSymbolName(const char* variableName, uns
 }
 
 std::string CurveRTCHost::demangle(const char* verbose_name) {
-    std::string s = jitify::reflection::detail::demangle(verbose_name);
+    std::string s = jitify::reflection::detail::demangle_cuda_symbol(verbose_name);
     // Lambda function for trimming whitesapce as jitify demangle does not remove this
     s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) {
         return !std::isspace(ch);
@@ -417,7 +417,7 @@ std::string CurveRTCHost::demangle(const char* verbose_name) {
 }
 
 std::string CurveRTCHost::demangle(const std::type_index& type) {
-    std::string s = jitify::reflection::detail::demangle(type.name());
+    std::string s = jitify::reflection::detail::demangle_cuda_symbol(type.name());
     // Lambda function for trimming whitesapce as jitify demangle does not remove this
     s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) {
         return !std::isspace(ch);

--- a/src/flamegpu/runtime/cuRVE/curve_rtc.cpp
+++ b/src/flamegpu/runtime/cuRVE/curve_rtc.cpp
@@ -408,7 +408,25 @@ std::string CurveRTCHost::getEnvVariableSymbolName(const char* variableName, uns
 }
 
 std::string CurveRTCHost::demangle(const char* verbose_name) {
+#ifndef _MSC_VER
     std::string s = jitify::reflection::detail::demangle_cuda_symbol(verbose_name);
+#else
+    // Jitify removed the required demangle function, this is a basic clone of what was being done in earlier version
+    // It's possible jitify::reflection::detail::demangle_native_type() would work, however that requires type_info, not type_index
+    size_t index = 0;
+    std::string s = verbose_name;
+    while (true) {
+        /* Locate the substring to replace. */
+        index = s.find("class", index);
+        if (index == std::string::npos) break;
+
+        /* Make the replacement. */
+        s.replace(index, 5, "     ");
+
+        /* Advance index forward so the next iteration doesn't pick it up as well. */
+        index += 5;
+    }
+#endif
     // Lambda function for trimming whitesapce as jitify demangle does not remove this
     s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) {
         return !std::isspace(ch);
@@ -417,10 +435,5 @@ std::string CurveRTCHost::demangle(const char* verbose_name) {
 }
 
 std::string CurveRTCHost::demangle(const std::type_index& type) {
-    std::string s = jitify::reflection::detail::demangle_cuda_symbol(type.name());
-    // Lambda function for trimming whitesapce as jitify demangle does not remove this
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) {
-        return !std::isspace(ch);
-        }));
-    return s;
+    return demangle(type.name());
 }

--- a/tests/test_cases/pop/test_agent_instance.cu
+++ b/tests/test_cases/pop/test_agent_instance.cu
@@ -149,7 +149,7 @@ TEST(AgentInstanceTest, SetViaAgentInstance) {
         AgentInstance instance = population.getInstanceAt(i);
         EXPECT_EQ(instance.getVariable<float>("x"), 12.0f);
         auto output_array = instance.getVariable<int, 4>("array_var");
-        auto test_array = std::array<int, 4>({ 2, 4, 8, 16 });
+        std::array<int, 4> test_array = { 2, 4, 8, 16 };
         EXPECT_EQ(output_array, test_array);
         EXPECT_EQ(instance.getVariable<float>("y"), 14.0f);
     }
@@ -189,7 +189,7 @@ TEST(AgentInstanceTest, SetViaAgentInstance2) {
     for (unsigned int i = 0; i < population.getCurrentListSize(); i++) {
         AgentInstance instance = population.getInstanceAt(i);
         EXPECT_EQ(instance.getVariable<float>("x"), 12.0f);
-        auto test_array = std::array<int, 4>({ 2, 4, 8, 16 });
+        std::array<int, 4> test_array = { 2, 4, 8, 16 };
         auto output_val = instance.getVariable<int>("array_var", 0);
         EXPECT_EQ(output_val, test_array[0]);
         output_val = instance.getVariable<int>("array_var", 1);


### PR DESCRIPTION
Closes #302

+ Fixes the test suite for CUDA 11.0.167 under linux
+ Upgrades jitify to the latest version (commit 2a015bb) which works with CUDA 11.0 RC
+ Adds CUDA 11.0RC to the Ubuntu and Windows github action worflows as build matrix options.

Tested generated executables locally under linux. 
Windows executables untested (will likely wait until a non RC to install CUDA 11.0 on windows locally).