### PR TITLE
Revert "Fix header order issues newly detected by cpplint 1.5.0"

### DIFF
--- a/include/flamegpu/gpu/CUDAErrorChecking.h
+++ b/include/flamegpu/gpu/CUDAErrorChecking.h
@@ -10,13 +10,14 @@
  * @warning
  */
 
-#include <string>
-// #include <stdexcept>
+
 
 // #include <device_launch_parameters.h>
 // #include <cuda_runtime.h>
 #include <cuda.h>
 
+#include <string>
+// #include <stdexcept>
 #include "flamegpu/exception/FGPUException.h"
 
 /* Error check function for safe CUDA API calling */

--- a/include/flamegpu/runtime/flamegpu_host_api.h
+++ b/include/flamegpu/runtime/flamegpu_host_api.h
@@ -1,14 +1,13 @@
 #ifndef INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_HOST_API_H_
 #define INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_HOST_API_H_
 
+#include <cuda_runtime_api.h>
 #include <cassert>
 #include <string>
 #include <utility>
 #include <functional>
 #include <unordered_map>
 #include <vector>
-
-#include <cuda_runtime_api.h>
 
 #include "flamegpu/gpu/CUDAErrorChecking.h"
 #include "flamegpu/runtime/utility/HostRandom.cuh"

--- a/include/flamegpu/runtime/messaging/BruteForce.h
+++ b/include/flamegpu/runtime/messaging/BruteForce.h
@@ -2,13 +2,13 @@
 #define INCLUDE_FLAMEGPU_RUNTIME_MESSAGING_BRUTEFORCE_H_
 
 #ifndef __CUDACC_RTC__
+// TODO: This should *not* be required in a .h file. Need to separate concerns between c++ and CUDA.
+#include <device_launch_parameters.h>
+
 #include <typeindex>
 #include <memory>
 #include <unordered_map>
 #include <string>
-
-// TODO: This should *not* be required in a .h file. Need to separate concerns between c++ and CUDA.
-#include <device_launch_parameters.h>
 
 #include "flamegpu/model/Variable.h"
 #include "flamegpu/gpu/CUDAErrorChecking.h"

--- a/include/flamegpu/runtime/utility/AgentRandom.cuh
+++ b/include/flamegpu/runtime/utility/AgentRandom.cuh
@@ -1,9 +1,8 @@
 #ifndef INCLUDE_FLAMEGPU_RUNTIME_UTILITY_AGENTRANDOM_CUH_
 #define INCLUDE_FLAMEGPU_RUNTIME_UTILITY_AGENTRANDOM_CUH_
 
-#include <cassert>
-
 #include <curand_kernel.h>
+#include <cassert>
 
 #include "flamegpu/exception/FGPUStaticAssert.h"
 

--- a/include/flamegpu/runtime/utility/DeviceEnvironment.cuh
+++ b/include/flamegpu/runtime/utility/DeviceEnvironment.cuh
@@ -1,11 +1,10 @@
 #ifndef INCLUDE_FLAMEGPU_RUNTIME_UTILITY_DEVICEENVIRONMENT_CUH_
 #define INCLUDE_FLAMEGPU_RUNTIME_UTILITY_DEVICEENVIRONMENT_CUH_
 
+// #include <cuda_runtime.h>
 #include <stdint.h>
 #include <string>
 #include <cassert>
-
-// #include <cuda_runtime.h>
 
 
 // #include "flamegpu/runtime/utility/HostEnvironment.cuh"

--- a/include/flamegpu/runtime/utility/EnvironmentManager.cuh
+++ b/include/flamegpu/runtime/utility/EnvironmentManager.cuh
@@ -3,6 +3,8 @@
 #ifndef INCLUDE_FLAMEGPU_RUNTIME_UTILITY_ENVIRONMENTMANAGER_CUH_
 #define INCLUDE_FLAMEGPU_RUNTIME_UTILITY_ENVIRONMENTMANAGER_CUH_
 
+#include <cuda_runtime.h>
+
 #include <cstddef>
 #include <unordered_map>
 #include <array>
@@ -12,8 +14,6 @@
 #include <utility>
 #include <typeindex>
 #include <set>
-
-#include <cuda_runtime.h>
 
 #include "flamegpu/exception/FGPUException.h"
 #include "flamegpu/gpu/CUDAErrorChecking.h"

--- a/include/flamegpu/runtime/utility/HostEnvironment.cuh
+++ b/include/flamegpu/runtime/utility/HostEnvironment.cuh
@@ -1,13 +1,13 @@
 #ifndef INCLUDE_FLAMEGPU_RUNTIME_UTILITY_HOSTENVIRONMENT_CUH_
 #define INCLUDE_FLAMEGPU_RUNTIME_UTILITY_HOSTENVIRONMENT_CUH_
 
+#include <cuda_runtime.h>
+
 #include <unordered_map>
 #include <array>
 #include <string>
 #include <utility>
 #include <set>
-
-#include <cuda_runtime.h>
 
 #include "flamegpu/gpu/CUDAErrorChecking.h"
 #include "flamegpu/runtime/utility/EnvironmentManager.cuh"

--- a/include/flamegpu/runtime/utility/RandomManager.cuh
+++ b/include/flamegpu/runtime/utility/RandomManager.cuh
@@ -1,11 +1,10 @@
 #ifndef INCLUDE_FLAMEGPU_RUNTIME_UTILITY_RANDOMMANAGER_CUH_
 #define INCLUDE_FLAMEGPU_RUNTIME_UTILITY_RANDOMMANAGER_CUH_
 
+#include <curand_kernel.h>
 #include <cstdint>
 #include <random>
 #include <string>
-
-#include <curand_kernel.h>
 
 #include "flamegpu/runtime/utility/AgentRandom.cuh"
 

--- a/src/flamegpu/gpu/CUDAScatter.cu
+++ b/src/flamegpu/gpu/CUDAScatter.cu
@@ -1,9 +1,12 @@
 #include "flamegpu/gpu/CUDAScatter.h"
 
+#include <cuda_runtime.h>
 #include <vector>
 #include <cassert>
 
-#include <cuda_runtime.h>
+#include "flamegpu/gpu/CUDAErrorChecking.h"
+#include "flamegpu/gpu/CUDAScanCompaction.h"
+#include "flamegpu/runtime/flamegpu_host_new_agent_api.h"
 
 #ifdef _MSC_VER
 #pragma warning(push, 3)
@@ -12,11 +15,6 @@
 #else
 #include <cub/cub.cuh>
 #endif
-
-#include "flamegpu/gpu/CUDAErrorChecking.h"
-#include "flamegpu/gpu/CUDAScanCompaction.h"
-#include "flamegpu/runtime/flamegpu_host_new_agent_api.h"
-
 
 unsigned int CUDAScatter::simulationInstances = 0;
 

--- a/src/flamegpu/model/AgentFunctionDescription.cpp
+++ b/src/flamegpu/model/AgentFunctionDescription.cpp
@@ -1,11 +1,11 @@
-#include "flamegpu/model/AgentFunctionDescription.h"
-
+#include <nvrtc.h>
+#include <cuda.h>
 #include <iostream>
 #include <string>
 #include <regex>
 
-#include <nvrtc.h>
-#include <cuda.h>
+#include "flamegpu/model/AgentFunctionDescription.h"
+
 
 /**
  * Constructors

--- a/src/flamegpu/runtime/utility/RandomManager.cu
+++ b/src/flamegpu/runtime/utility/RandomManager.cu
@@ -1,13 +1,14 @@
 #include "flamegpu/runtime/utility/RandomManager.cuh"
 
-#include <ctime>
-#include <cassert>
-#include <cstdio>
-#include <algorithm>
-
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
 #include <device_launch_parameters.h>
+
+#include<ctime>
+
+#include <cassert>
+#include <cstdio>
+#include <algorithm>
 
 #include "flamegpu/gpu/CUDAErrorChecking.h"
 #include "flamegpu/gpu/CUDAAgentModel.h"

--- a/tests/helpers/main.cu
+++ b/tests/helpers/main.cu
@@ -1,5 +1,5 @@
-#include <cstdio>
 #include <cuda_runtime.h>
+#include <cstdio>
 #include "gtest/gtest.h"
 #include "helpers/device_initialisation.h"
 


### PR DESCRIPTION
This reverts commit 02d26d1f38cb269ed282f3fc72366d1ea0faba48.

cpplint 1.5.1 once gain breaks linting due to order of includes. Reverting to the previous configuration seems to be the simple solution, as `<cuda.h>` is once again correctly detected as a c system header, and expected to be before c++ system headers such as `<string>`.