### PR TITLE
Make simulation() duration programatically accessible

### DIFF
--- a/include/flamegpu/gpu/CUDAAgentModel.h
+++ b/include/flamegpu/gpu/CUDAAgentModel.h
@@ -135,19 +135,24 @@ class CUDAAgentModel : public Simulation {
     // TODO
     void RTCSetEnvironmentVariable(const char* variable_name, const void* src, size_t count, size_t offset = 0) const;
 
+    /**
+     * Get the duration of the last call to simulate() in milliseconds. 
+     * With a resolution of around 0.5 microseconds (cudaEventElapsedtime)
+     */
+    float getSimulationElapsedTime() const;
 
  protected:
-     /**
-      * Called by Simulation::applyConfig() to trigger any runner specific configs
-      * @see CUDAAgentModel::CUDAConfig()
-      */
+    /**
+     * Called by Simulation::applyConfig() to trigger any runner specific configs
+     * @see CUDAAgentModel::CUDAConfig()
+     */
     void applyConfig_derived() override;
-     /**
-      * Called by Simulation::checkArgs() to trigger any runner specific argument checking
-      * This only handles arg 0 before returning
-      * @return True if the argument was handled successfully
-      * @see Simulation::checkArgs()
-      */
+    /**
+     * Called by Simulation::checkArgs() to trigger any runner specific argument checking
+     * This only handles arg 0 before returning
+     * @return True if the argument was handled successfully
+     * @see Simulation::checkArgs()
+     */
     bool checkArgs_derived(int argc, const char** argv, int &i) override;
     /**
      * Called by Simulation::printHelp() to print help for runner specific runtime args
@@ -165,6 +170,10 @@ class CUDAAgentModel : public Simulation {
      * Number of times step() has been called since sim was last reset/init
      */
     unsigned int step_count;
+    /**
+     * Duration of the last call to simulate() in milliseconds, with a resolution of around 0.5 microseconds (cudaEventElapsedtime)
+     */
+    float simulation_elapsed_time;
     /**
      * Update the step counter for host and device.
      */

--- a/tests/test_cases/gpu/test_cuda_agent_model.cu
+++ b/tests/test_cases/gpu/test_cuda_agent_model.cu
@@ -324,4 +324,31 @@ TEST(TestCUDAAgentModel, AgentDeath) {
     }
 }
 
+// test the programatically accessible simulation time elapsed.
+TEST(TestCUDAAgentModel, getSimulationElapsedTime) {
+    // Define a simple model - doesn't need to do anything other than take some time.
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    AgentPopulation pop(a, static_cast<unsigned int>(AGENT_COUNT));
+    m.addStepFunction(IncrementCounter);
+
+    CUDAAgentModel c(m);
+    c.setPopulationData(pop);
+
+    // Try getting the timer before running simulate, which should return 0
+    EXPECT_EQ(c.getSimulationElapsedTime(), 0.0f);
+    // Call simulate to run 1 steps, which should take some length of time
+    c.SimulationConfig().steps = 1;
+    c.simulate();
+    EXPECT_GT(c.getSimulationElapsedTime(), 0.0f);
+
+    // Then run 10 steps, which should be longer / not the same.
+    float simulate1StepDuration = c.getSimulationElapsedTime();
+    c.SimulationConfig().steps = 10;
+    c.simulate();
+    float simulate10StepDuration = c.getSimulationElapsedTime();
+    EXPECT_GT(simulate10StepDuration, 0.0f);
+    EXPECT_NE(simulate1StepDuration, simulate10StepDuration);
+}
+
 }  // namespace test_cuda_agent_model


### PR DESCRIPTION
This will allow us to support performance regression testing.

In the future adding additional timing information will be useful (per layer for step detection, but probably want that to be opt-in) 