### PR TITLE
set CMAKE_CUDA_ARCHITECTURES to OFF for CMake 3.18+

### DIFF
--- a/cmake/cuda_arch.cmake
+++ b/cmake/cuda_arch.cmake
@@ -3,6 +3,11 @@
 
 # @todo - split setting of values out of the project so it's onyl done once before include_directory?
 
+# CMAKE > 3.18 introduces CUDA_ARCHITECTURES as a cmake-native way of generating gencodes (Policy CMP0104). Set the value to OFF to prevent errors for it being not provided.
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.18")
+    set(CMAKE_CUDA_ARCHITECTURES "OFF")
+endif()
+
 # Check if any have been provided by the users
 string(LENGTH "${CUDA_ARCH}" CUDA_ARCH_LENGTH)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,13 @@ cmake_minimum_required(VERSION VERSION 3.12 FATAL_ERROR)
 # Tests require GTest
 #enable_testing()
 
+# Apply the CUDA_ARCH target before gtest is included to resolve cmake 3.18+ warnings?
+# Set the location of the ROOT flame gpu project relative to this CMakeList.txt
+get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/.. REALPATH)
+
+# Include common rules.
+include(${FLAMEGPU_ROOT}/cmake/common.cmake)
+
 # START Download & Build GoogleTest
 MACRO (download_gtest)
     configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
@@ -60,12 +67,6 @@ add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
 
 # Name the project and set languages
 project(tests CUDA CXX)
-
-# Set the location of the ROOT flame gpu project relative to this CMakeList.txt
-get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/.. REALPATH)
-
-# Include common rules.
-include(${FLAMEGPU_ROOT}/cmake/common.cmake)
 
 # Define output location of binary files
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)


### PR DESCRIPTION
Disabled developer warnings which are genertated for each target otherwise.

Don't want to use the new property, as would restrict us to Cmake 3.18+, and it's not clearly documented what --gencodes it generates.

Also would not support CUDA 11 LTO (which may or may not help performance)

closes #313 