### PR TITLE
Fixes swig venv install on linux

### DIFF
--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -137,7 +137,7 @@ if(BUILD_SWIG_PYTHON_VIRTUALENV)
 
 		# Must not call it in a folder containing the setup.py otherwise pip call it
 		# (i.e. "python setup.py bdist") while we want to consume the wheel package
-		COMMAND ${VENV_PIP} install --force-reinstall --find-links=dist ${PYTHON_MODULE_NAME}
+		COMMAND ${VENV_PIP} install --force-reinstall --find-links=dist --no-index -U ${PYTHON_MODULE_NAME}
 		# install pytest
 		COMMAND ${VENV_PIP} install pytest
 		BYPRODUCTS ${VENV_DIR}


### PR DESCRIPTION
`-U` tells it to upgrade flamegpu, which as a side effect installs it within the venv instead of using the version outside the venv, but in the working directory.

`--no-index` stops it search pypy for flamegpu

```
Collecting pyflamegpu
Exception:
Traceback (most recent call last):                                                                             
  File "/home/ptheywood/code/flamegpu/flamegpu2_dev/build/lib/linux-x64/python/venv/lib/python3.6/site-packages/pip/basecommand.py", line 215, in main                                                                        
    status = self.run(options, args)                                                                           
  File "/home/ptheywood/code/flamegpu/flamegpu2_dev/build/lib/linux-x64/python/venv/lib/python3.6/site-packages/pip/commands/install.py", line 353, in run                                                                    
    wb.build(autobuilding=True)                                                                                
  File "/home/ptheywood/code/flamegpu/flamegpu2_dev/build/lib/linux-x64/python/venv/lib/python3.6/site-packages/pip/wheel.py", line 749, in build                                                                             
    self.requirement_set.prepare_files(self.finder)                                                            
  File "/home/ptheywood/code/flamegpu/flamegpu2_dev/build/lib/linux-x64/python/venv/lib/python3.6/site-packages/pip/req/req_set.py", line 380, in prepare_files                                                               
    ignore_dependencies=self.ignore_dependencies))                                                             
  File "/home/ptheywood/code/flamegpu/flamegpu2_dev/build/lib/linux-x64/python/venv/lib/python3.6/site-packages/pip/req/req_set.py", line 554, in _prepare_file                                                               
    require_hashes                                                                                             
  File "/home/ptheywood/code/flamegpu/flamegpu2_dev/build/lib/linux-x64/python/venv/lib/python3.6/site-packages/pip/req/req_install.py", line 278, in populate_link                                                           
    self.link = finder.find_requirement(self, upgrade)                                                         
  File "/home/ptheywood/code/flamegpu/flamegpu2_dev/build/lib/linux-x64/python/venv/lib/python3.6/site-packages/pip/index.py", line 465, in find_requirement                                                                  
    all_candidates = self.find_all_candidates(req.name)                                                        
  File "/home/ptheywood/code/flamegpu/flamegpu2_dev/build/lib/linux-x64/python/venv/lib/python3.6/site-packages/pip/index.py", line 423, in find_all_candidates                                                               
    for page in self._get_pages(url_locations, project_name):                                                  
  File "/home/ptheywood/code/flamegpu/flamegpu2_dev/build/lib/linux-x64/python/venv/lib/python3.6/site-packages/pip/index.py", line 568, in _get_pages                                                                        
    page = self._get_page(location)                                                                            
  File "/home/ptheywood/code/flamegpu/flamegpu2_dev/build/lib/linux-x64/python/venv/lib/python3.6/site-packages/pip/index.py", line 683, in _get_page                                                                         
    return HTMLPage.get_page(link, session=self.session)                                                       
  File "/home/ptheywood/code/flamegpu/flamegpu2_dev/build/lib/linux-x64/python/venv/lib/python3.6/site-packages/pip/index.py", line 795, in get_page                                                                          
    resp.raise_for_status()                                                                                    
  File "/home/ptheywood/code/flamegpu/flamegpu2_dev/build/lib/linux-x64/python/venv/share/python-wheels/requests-2.18.4-py2.py3-none-any.whl/requests/models.py", line 935, in raise_for_status                               
    raise HTTPError(http_error_msg, response=self)                                                             
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://pypi.org/simple/pyflamegpu/    
```