### PR TITLE
CUDAScanCompaction/CUDAScatter are nolonger singletons

### DIFF
--- a/include/flamegpu/gpu/CUDAAgentModel.h
+++ b/include/flamegpu/gpu/CUDAAgentModel.h
@@ -246,12 +246,12 @@ class CUDAAgentModel : public Simulation {
       /**
        * Held here for tracking when to release cuda memory
        */
-      CUDAScatter &scatter;
+      CUDAScatter scatter;
       /**
        * Held here for tracking when to release cuda memory
        */
       EnvironmentManager &environment;
-      Singletons(Curve &curve, CUDAScatter &scatter, EnvironmentManager &environment) : curve(curve), scatter(scatter), environment(environment) {}
+      Singletons(Curve &curve, EnvironmentManager &environment) : curve(curve), environment(environment) { }
     } * singletons;
     /**
      * Flag indicating that the model has been initialsed
@@ -279,9 +279,10 @@ class CUDAAgentModel : public Simulation {
     /**
      * Adds any agents stored in agentData to the device
      * Clears agent storage in agentData
+     * @param streamId Stream index to perform scatter on
      * @note called at the end of step() and after all init/hostLayer functions and exit conditions have finished
      */
-    void processHostAgentCreation();
+    void processHostAgentCreation(const unsigned int &streamId);
     /**
      * Runs a specific agent function
      * @param func_des the agent function to execute

--- a/include/flamegpu/gpu/CUDAAgentStateList.h
+++ b/include/flamegpu/gpu/CUDAAgentStateList.h
@@ -18,6 +18,7 @@
 #include "flamegpu/gpu/CUDAFatAgentStateList.h"
 #include "flamegpu/pop/AgentStateMemory.h"
 
+class CUDAScatter;
 struct VarOffsetStruct;
 class CUDAAgent;
 
@@ -71,8 +72,10 @@ class CUDAAgentStateList {
     /**
      * Store agent data from agent state memory into state list
      * @data data Source for agent data
+     * @param scatter Scatter instance and scan arrays to be used
+     * @param streamId This is required for scan compaction arrays and async
      */
-    void setAgentData(const AgentStateMemory &data);
+    void setAgentData(const AgentStateMemory &data, CUDAScatter &scatter, const unsigned int &streamId);
     /**
      * Retrieve agent data from the agent state list into agent state memory
      * @data data Destination for agent data
@@ -85,24 +88,29 @@ class CUDAAgentStateList {
      * @param newSize The number of new agents to initialise
      * @param d_inBuff device pointer to buffer of agent init data
      * @param offsets Offset data explaining the layout of d_inBuff
+     * @param scatter Scatter instance and scan arrays to be used
+     * @param streamId This is required for scan compaction arrays and async
      */
-    void scatterHostCreation(const unsigned int &newSize, char *const d_inBuff, const VarOffsetStruct &offsets);
+    void scatterHostCreation(const unsigned int &newSize, char *const d_inBuff, const VarOffsetStruct &offsets, CUDAScatter &scatter, const unsigned int &streamId);
     /**
      * Scatters agents from the currently assigned device agent birth buffer (see member variable newBuffs)
      * The device buffer must be packed in the same format as CUDAAgent::mapNewRuntimeVariables(const AgentFunctionData&, const unsigned int &, const unsigned int &)
      * @param d_newBuff The buffer holding the new agent data
      * @param newSize The maximum number of new agents (this will be the size of the agent state executing func)
+     * @param scatter Scatter instance and scan arrays to be used
      * @param streamId This is required for scan compaction arrays and async
      */
-    void scatterNew(void * d_newBuff, const unsigned int &newSize, const unsigned int &streamId);
+    void scatterNew(void * d_newBuff, const unsigned int &newSize, CUDAScatter &scatter, const unsigned int &streamId);
     /**
      * Returns true if the state list is not the primary statelist (and is mapped to a master agent state)
      */
     bool getIsSubStatelist();
     /**
      * Returns any unmapped variables (for alive agents) to their default value
+     * @param scatter Scatter instance and scan arrays to be used
+     * @param streamId This is required for scan compaction arrays and async
      */
-    void initUnmappedVars();
+    void initUnmappedVars(CUDAScatter &scatter, const unsigned int &streamId);
     /**
      * Returns the statelist to an empty state
      * This resets the size to 0.

--- a/include/flamegpu/gpu/CUDAFatAgent.h
+++ b/include/flamegpu/gpu/CUDAFatAgent.h
@@ -87,25 +87,28 @@ class CUDAFatAgent {
      * This updates the alive agent count
      * @param agent_fat_id The index of the CUDAAgent within this CUDAFatAgent
      * @param state_name The name of the state attached to the named fat agent index
+     * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
      * @param streamId Index of the stream used for scan compaction flags (and async cuda ops)
      */
-    void processDeath(const unsigned int &agent_fat_id, const std::string &state_name, const unsigned int &streamId);
+    void processDeath(const unsigned int &agent_fat_id, const std::string &state_name, CUDAScatter &scatter, const unsigned int &streamId);
     /**
      * Transitions all active agents from the source state to the destination state
      * @param agent_fat_id The index of the CUDAAgent within this CUDAFatAgent
      * @param _src The name of the source state attached to the named fat agent index
      * @param _dest The name of the destination state attached to the named fat agent index
+     * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
      * @param streamId Index of the stream used for scan compaction flags (and async cuda ops)
      */
-    void transitionState(const unsigned int &agent_fat_id, const std::string &_src, const std::string &_dest, const unsigned int &streamId);
+    void transitionState(const unsigned int &agent_fat_id, const std::string &_src, const std::string &_dest, CUDAScatter &scatter, const unsigned int &streamId);
     /**
      * Reads the flags set by an agent function condition in order to sort agents according to whether they passed or failed
      * Failed agents are sorted to the front and marked as disabled, passing agents are then sorted to the back
      * @param agent_fat_id The index of the CUDAAgent within this CUDAFatAgent
      * @param state_name The name of the state attached to the named fat agent index
+     * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
      * @param streamId Index of the stream used for scan compaction flags (and async cuda ops)
      */
-    void processFunctionCondition(const unsigned int &agent_fat_id, const std::string &state_name, const unsigned int &streamId);
+    void processFunctionCondition(const unsigned int &agent_fat_id, const std::string &state_name, CUDAScatter &scatter, const unsigned int &streamId);
     /**
      * Marks the specified number of agents within the specified statelist as disabled
      * @param agent_fat_id The index of the CUDAAgent within this CUDAFatAgent

--- a/include/flamegpu/gpu/CUDAFatAgentStateList.h
+++ b/include/flamegpu/gpu/CUDAFatAgentStateList.h
@@ -11,6 +11,8 @@
 #include "flamegpu/model/AgentData.h"
 #include "flamegpu/model/SubAgentData.h"
 
+class CUDAScatter;
+
 /**
  * This is used to identify a variable that belongs to specific agent
  * This agent's unsigned int is assigned by the parent CUDAFatAgent
@@ -189,38 +191,41 @@ class CUDAFatAgentStateList {
     void setAgentCount(const unsigned int &newCount, const bool &resetDisabled = false);
     /**
      * Scatters all living agents (including disabled, according to the provided stream's death flag)
+     * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
      * @param streamId The stream in which the corresponding agent function has executed
      * @return The number of agents that are still alive (this includes temporarily disabled agents due to agent function condition)
      */
-    unsigned int scatterDeath(const unsigned int &streamId);
+    unsigned int scatterDeath(CUDAScatter &scatter, const unsigned int &streamId);
     /**
      * Scatters all living agents which failed the agent function condition into the swap buffer (there should be no disabled at this time)
      * This does not swap buffers or update disabledAgent)
+     * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
      * @param streamId The stream in which the corresponding agent function has executed
      * @return The number of agents that were scattered (the number of agents which failed the condition)
      * @see scatterAgentFunctionConditionTrue(const unsigned int &, const unsigned int &)
      */
-    unsigned int scatterAgentFunctionConditionFalse(const unsigned int &streamId);
+    unsigned int scatterAgentFunctionConditionFalse(CUDAScatter &scatter, const unsigned int &streamId);
     /**
      * Scatters all living agents which passed the agent function condition into the swap buffer (there should be no disabled at this time)
      * Also swaps the buffers and sets the number of disabled agents
-     * @param streamId The stream in which the corresponding agent function has executed
      * @param conditionFailCount The number of agents which failed the condition (they should already have been scattered to swap)
+     * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+     * @param streamId The stream in which the corresponding agent function has executed
      * @return The number of agents that were scattered (the number of agents which passed the condition)
      * @see scatterAgentFunctionConditionFalse(const unsigned int &)
      * @see setConditionState(const unsigned int &)
      */
-    unsigned int scatterAgentFunctionConditionTrue(const unsigned int &conditionFailCount, const unsigned int &streamId);
+    unsigned int scatterAgentFunctionConditionTrue(const unsigned int &conditionFailCount, CUDAScatter &scatter, const unsigned int &streamId);
     /**
      * Set the number of disabled agents within the state list
      * Updates member var disabledAgents and data_condition for every item inside variables_unique
      * @param numberOfDisabled The new number of disabled agents (this can increase of decrease)
      */
-    void setDisabledAgents(const unsigned int numberOfDisabled);
+    void setDisabledAgents(const unsigned int &numberOfDisabled);
     /**
      * Resets the value of all variables not present in exclusionSet to their defaults
      */
-    void initVariables(std::set<std::shared_ptr<VariableBuffer>> &exclusionSet, const unsigned int initCount, const unsigned initOffset, const unsigned int &streamId);
+    void initVariables(std::set<std::shared_ptr<VariableBuffer>> &exclusionSet, const unsigned int initCount, const unsigned initOffset, CUDAScatter &scatter, const unsigned int &streamId);
     /**
      * Returns the collection of unique variable buffers held by this CUDAFatAgentStateList
      */

--- a/include/flamegpu/gpu/CUDAMessage.h
+++ b/include/flamegpu/gpu/CUDAMessage.h
@@ -21,6 +21,7 @@
 
 // forward declare classes from other modules
 
+class CUDAScatter;
 struct AgentFunctionData;
 struct MessageData;
 class AgentPopulation;
@@ -63,8 +64,10 @@ class CUDAMessage {
     /**
      * Updates message_count to equal newSize, internally reallocates buffer space if more space is required
      * @param newSize The number of messages that the buffer should be capable of storing
+     * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+     * @param streamId Index of stream specific structures used
      */
-    void resize(unsigned int newSize, const unsigned int &streamId);
+    void resize(unsigned int newSize, CUDAScatter &scatter, const unsigned int &streamId);
     /**
      * Uses the cuRVE runtime to map the variables used by the agent function to the cuRVE library so that can be accessed by name within a n agent function
      * The read runtime variables are to be used when reading messages
@@ -92,9 +95,10 @@ class CUDAMessage {
      * Swaps the two internal maps within message_list
      * @param isOptional If optional newMsgCount will be reduced based on scan_flag[streamId]
      * @param newMsgCount The number of output messages (including optional messages which were not output)
+     * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
      * @param streamId Index of stream specific structures used
      */
-    virtual void swap(bool isOptional, const unsigned int &newMsgCount, const unsigned int &streamId);
+    virtual void swap(bool isOptional, const unsigned int &newMsgCount, CUDAScatter &scatter, const unsigned int &streamId);
     /**
      * Basic list swap with no additional actions
      */
@@ -105,7 +109,12 @@ class CUDAMessage {
     bool getPBMConstructionRequiredFlag() const  { return pbm_construction_required; }
     void setPBMConstructionRequiredFlag() { pbm_construction_required = true; }
     void clearPBMConstructionRequiredFlag() { pbm_construction_required = false; }
-    void buildIndex();
+    /**
+     * Builds index, required to read messages (some messaging types won't require an implementation)
+     * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+     * @param streamId Index of stream specific structures used
+     */
+    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId);
     const void *getMetaDataDevicePtr() const;
 
  protected:

--- a/include/flamegpu/gpu/CUDAMessageList.h
+++ b/include/flamegpu/gpu/CUDAMessageList.h
@@ -14,8 +14,8 @@
 #include <map>
 #include <utility>
 
+class CUDAScatter;
 class CUDAMessage;
-// class AgentStateMemory;
 
 // #define UNIFIED_GPU_MEMORY
 
@@ -31,7 +31,7 @@ class CUDAMessageList {
      /**
       * Initially allocates message lists based on cuda_message.getMaximumListSize()
       */
-    explicit CUDAMessageList(CUDAMessage& cuda_message);
+    explicit CUDAMessageList(CUDAMessage& cuda_message, CUDAScatter &scatter, const unsigned int &streamId);
     /**
      * Frees all message list memory
      */
@@ -65,17 +65,19 @@ class CUDAMessageList {
     /**
      * Perform a compaction using d_msg_scan_flag and d_msg_position
      * @param newCount Number of new messages to be scattered
+     * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
      * @return Total number of messages now in list (includes old + new counts if appending)
      */
-    virtual unsigned int scatter(const unsigned int &newCount, const unsigned int &streamId, const bool &append);
+    virtual unsigned int scatter(const unsigned int &newCount, CUDAScatter &scatter, const unsigned int &streamId, const bool &append);
     /**
      * Copy all message data from d_swap_list to d_list
      * This ALWAYS performs and append to the existing message list count
      * Used by swap() when appending messagelists
      * @param newCount Number of new messages to be scattered
+     * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
      * @return Total number of messages now in list (includes old + new counts)
      */
-    virtual unsigned int scatterAll(const unsigned int &newCount, const unsigned int &streamId);
+    virtual unsigned int scatterAll(const unsigned int &newCount, CUDAScatter &scatter, const unsigned int &streamId);
     const CUDAMsgMap &getReadList() { return d_list; }
     const CUDAMsgMap &getWriteList() { return d_swap_list; }
 

--- a/include/flamegpu/runtime/messaging/Array.h
+++ b/include/flamegpu/runtime/messaging/Array.h
@@ -337,11 +337,11 @@ class MsgArray {
          * Initialises member variables
          * @param agentfn_hash Added to msg_hash to produce combined_hash
          * @param msg_hash Added to agentfn_hash to produce combined_hash
-         * @param _streamId Stream index, used for optional message output flag array
+         * @param scan_flag_messageOutput Scan flag array for optional message output
          */
-        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *, unsigned int _streamId)
+        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *, unsigned int *scan_flag_messageOutput)
             : combined_hash(agentfn_hash + msg_hash)
-            , streamId(_streamId)
+            , scan_flag(scan_flag_messageOutput)
         { }
         /**
          * Sets the array index to store the message in
@@ -364,9 +364,9 @@ class MsgArray {
          */
         Curve::NamespaceHash combined_hash;
         /**
-         * Stream index used for setting optional message output flag
+         * Scan flag array for optional message output
          */
-        unsigned int streamId;
+        unsigned int *scan_flag;
     };
 
 #ifndef __CUDACC_RTC__
@@ -390,8 +390,10 @@ class MsgArray {
         /**
          * Sort messages according to index
          * Detect and report any duplicate indicies/gaps
+         * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+         * @param streamId Index of stream specific structures used
          */
-        void buildIndex() override;
+        void buildIndex(CUDAScatter &scatter, const unsigned int &streamId) override;
         /**
          * Allocates memory for the constructed index.
          * The memory allocation is checked by build index.

--- a/include/flamegpu/runtime/messaging/Array2D.h
+++ b/include/flamegpu/runtime/messaging/Array2D.h
@@ -368,11 +368,11 @@ class MsgArray2D {
          * Initialises member variables
          * @param agentfn_hash Added to msg_hash to produce combined_hash
          * @param msg_hash Added to agentfn_hash to produce combined_hash
-         * @param _streamId Stream index, used for optional message output flag array
+         * @param scan_flag_messageOutput Scan flag array for optional message output
          */
-        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *_metadata, unsigned int _streamId)
+        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *_metadata, unsigned int *scan_flag_messageOutput)
             : combined_hash(agentfn_hash + msg_hash)
-            , streamId(_streamId)
+            , scan_flag(scan_flag_messageOutput)
             , metadata(reinterpret_cast<const MetaData*>(_metadata))
         { }
         /**
@@ -396,9 +396,9 @@ class MsgArray2D {
          */
         Curve::NamespaceHash combined_hash;
         /**
-         * Stream index used for setting optional message output flag
+         * Scan flag array for optional message output
          */
-        unsigned int streamId;
+        unsigned int *scan_flag;
         /**
          * Metadata struct for accessing messages
          */
@@ -426,8 +426,10 @@ class MsgArray2D {
         /**
          * Sort messages according to index
          * Detect and report any duplicate indicies/gaps
+         * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+         * @param streamId Index of stream specific structures used
          */
-        void buildIndex() override;
+        void buildIndex(CUDAScatter &scatter, const unsigned int &streamId) override;
         /**
          * Allocates memory for the constructed index.
          * The memory allocation is checked by build index.

--- a/include/flamegpu/runtime/messaging/Array3D.h
+++ b/include/flamegpu/runtime/messaging/Array3D.h
@@ -385,11 +385,11 @@ class MsgArray3D {
          * Initialises member variables
          * @param agentfn_hash Added to msg_hash to produce combined_hash
          * @param msg_hash Added to agentfn_hash to produce combined_hash
-         * @param _streamId Stream index, used for optional message output flag array
+         * @param scan_flag_messageOutput Scan flag array for optional message output
          */
-        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *_metadata, unsigned int _streamId)
+        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *_metadata, unsigned int *scan_flag_messageOutput)
             : combined_hash(agentfn_hash + msg_hash)
-            , streamId(_streamId)
+            , scan_flag(scan_flag_messageOutput)
             , metadata(reinterpret_cast<const MetaData*>(_metadata))
         { }
         /**
@@ -413,9 +413,9 @@ class MsgArray3D {
          */
         Curve::NamespaceHash combined_hash;
         /**
-         * Stream index used for setting optional message output flag
+         * Scan flag array for optional message output
          */
-        unsigned int streamId;
+        unsigned int *scan_flag;
         /**
          * Metadata struct for accessing messages
          */
@@ -442,8 +442,10 @@ class MsgArray3D {
         /**
          * Sort messages according to index
          * Detect and report any duplicate indicies/gaps
+         * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+         * @param streamId Index of stream specific structures used
          */
-        void buildIndex() override;
+        void buildIndex(CUDAScatter &scatter, const unsigned int &streamId) override;
         /**
          * Allocates memory for the constructed index.
          * The memory allocation is checked by build index.

--- a/include/flamegpu/runtime/messaging/BruteForce.h
+++ b/include/flamegpu/runtime/messaging/BruteForce.h
@@ -203,11 +203,11 @@ class MsgBruteForce {
          * Initialises member variables
          * @param agentfn_hash Added to msg_hash to produce combined_hash
          * @param msg_hash Added to agentfn_hash to produce combined_hash
-         * @param _streamId Stream index, used for optional message output flag array
+         * @param scan_flag_messageOutput Scan flag array for optional message output
          */
-        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *, unsigned int _streamId)
+        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *, unsigned int *scan_flag_messageOutput)
             : combined_hash(agentfn_hash + msg_hash)
-            , streamId(_streamId)
+            , scan_flag(scan_flag_messageOutput)
         { }
         /**
          * Sets the specified variable for this agents message
@@ -226,9 +226,9 @@ class MsgBruteForce {
          */
         Curve::NamespaceHash combined_hash;
         /**
-         * Stream index used for setting optional message output flag
+         * Scan flag array for optional message output
          */
-        unsigned int streamId;
+        unsigned int *scan_flag;
     };
 #ifndef __CUDACC_RTC__
     /**
@@ -254,8 +254,10 @@ class MsgBruteForce {
         ~CUDAModelHandler() { }
         /**
          * Updates the length of the messagelist stored on device
+         * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+         * @param streamId Index of stream specific structures used
          */
-        void buildIndex() override;
+        void buildIndex(CUDAScatter &scatter, const unsigned int &streamId) override;
         /**
          * Allocates memory for the constructed index.
          * The memory allocation is checked by build index.
@@ -481,7 +483,7 @@ __device__ void MsgBruteForce::Out::setVariable(const char(&variable_name)[N], T
     Curve::setVariable<T>(variable_name, combined_hash, value, index);
 
     // Set scan flag incase the message is optional
-    flamegpu_internal::CUDAScanCompaction::ds_configs[flamegpu_internal::CUDAScanCompaction::MESSAGE_OUTPUT][streamId].scan_flag[index] = 1;
+    this->scan_flag[index] = 1;
 }
 #ifndef __CUDACC_RTC__
 /**

--- a/include/flamegpu/runtime/messaging/None.h
+++ b/include/flamegpu/runtime/messaging/None.h
@@ -9,6 +9,7 @@
  * Forward declaration, used for CUDASpecialisationHandler
  */
 class CUDAMessage;
+class CUDAScatter;
 /**
  * Interface for message specialisation
  * A derived implementation of this is required for each combination of message type (e.g. MsgBruteForce) and simulation type (e.g. CUDAAgentModel)
@@ -25,8 +26,10 @@ class MsgSpecialisationHandler {
     /**
      * Constructs an index for the message data structure (e.g. Partition boundary matrix for spatial message types)
      * This is called the first time messages are read, after new messages have been output
+     * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+     * @param streamId Index of stream specific structures used
      */
-    virtual void buildIndex() { }
+    virtual void buildIndex(CUDAScatter &, const unsigned int &) { }
     /**
      * Allocates memory for the constructed index.
      * The memory allocation is checked by build index.
@@ -79,7 +82,7 @@ class MsgNone {
          * Requires CURVE hashes for agent function and message name to retrieve variable memory locations
          * Takes a device pointer to a struct for metadata related to accessing the messages (e.g. an index data structure)
          */
-        __device__ Out(Curve::NamespaceHash /*agent fn hash*/, Curve::NamespaceHash /*message name hash*/, const void * /*metadata*/, unsigned int /*streamid*/){
+        __device__ Out(Curve::NamespaceHash /*agent fn hash*/, Curve::NamespaceHash /*message name hash*/, const void * /*metadata*/, unsigned int * /*scan_flag_messageOutput*/){
         }
     };
     /**

--- a/include/flamegpu/runtime/messaging/Spatial2D.h
+++ b/include/flamegpu/runtime/messaging/Spatial2D.h
@@ -311,10 +311,10 @@ class MsgSpatial2D {
          * Initialises member variables
          * @param agentfn_hash Added to msg_hash to produce combined_hash
          * @param msg_hash Added to agentfn_hash to produce combined_hash
-         * @param _streamId Stream index, used for optional message output flag array
+         * @param scan_flag_messageOutput Scan flag array for optional message output
          */
-        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *, unsigned int _streamId)
-            : MsgBruteForce::Out(agentfn_hash, msg_hash, nullptr, _streamId)
+        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *, unsigned int *scan_flag_messageOutput)
+            : MsgBruteForce::Out(agentfn_hash, msg_hash, nullptr, scan_flag_messageOutput)
         { }
         /**
          * Sets the location for this agents message
@@ -347,8 +347,10 @@ class MsgSpatial2D {
         /**
          * Reconstructs the partition boundary matrix
          * This should be called before reading newly output messages
+         * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+         * @param streamId Index of stream specific structures used
          */
-        void buildIndex() override;
+        void buildIndex(CUDAScatter &scatter, const unsigned int &streamId) override;
         /**
          * Allocates memory for the constructed index.
          * The memory allocation is checked by build index.

--- a/include/flamegpu/runtime/messaging/Spatial3D.h
+++ b/include/flamegpu/runtime/messaging/Spatial3D.h
@@ -324,10 +324,10 @@ class MsgSpatial3D {
          * Initialises member variables
          * @param agentfn_hash Added to msg_hash to produce combined_hash
          * @param msg_hash Added to agentfn_hash to produce combined_hash
-         * @param _streamId Stream index, used for optional message output flag array
+         * @param scan_flag_messageOutput Scan flag array for optional message output
          */
-        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *, unsigned int _streamId)
-            : MsgBruteForce::Out(agentfn_hash, msg_hash, nullptr, _streamId)
+        __device__ Out(Curve::NamespaceHash agentfn_hash, Curve::NamespaceHash msg_hash, const void *, unsigned int *scan_flag_messageOutput)
+            : MsgBruteForce::Out(agentfn_hash, msg_hash, nullptr, scan_flag_messageOutput)
         { }
         /**
          * Sets the location for this agents message
@@ -380,8 +380,10 @@ class MsgSpatial3D {
         /**
          * Reconstructs the partition boundary matrix
          * This should be called before reading newly output messages
+         * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+         * @param streamId Index of stream specific structures used
          */
-        void buildIndex() override;
+        void buildIndex(CUDAScatter &scatter, const unsigned int &streamId) override;
         /**
          * Allocates memory for the constructed index.
          * The memory allocation is checked by build index.

--- a/src/flamegpu/gpu/CUDAMessageList.cu
+++ b/src/flamegpu/gpu/CUDAMessageList.cu
@@ -14,22 +14,21 @@
 * CUDAMessageList class
 * @brief populates CUDA message map
 */
-CUDAMessageList::CUDAMessageList(CUDAMessage& cuda_message)
+CUDAMessageList::CUDAMessageList(CUDAMessage& cuda_message, CUDAScatter &scatter, const unsigned int &streamId)
     : message(cuda_message) {
     // allocate message lists
     allocateDeviceMessageList(d_list);
     allocateDeviceMessageList(d_swap_list);
     if (message.getMessageCount() != 0) {
-        auto &cs = CUDAScatter::getInstance(0);  // Probably need to actually use stream here
         {
             auto &a = cuda_message.getReadList();
             auto &_a = d_list;
-            cs.scatterAll(message.getMessageDescription().variables, a, _a, message.getMessageCount(), 0);
+            scatter.scatterAll(streamId, message.getMessageDescription().variables, a, _a, message.getMessageCount(), 0);
         }
         {  // Is copying writelist redundant?
             auto &a = cuda_message.getWriteList();
             auto &_a = d_swap_list;
-            cs.scatterAll(message.getMessageDescription().variables, a, _a, message.getMessageCount(), 0);
+            scatter.scatterAll(streamId, message.getMessageDescription().variables, a, _a, message.getMessageCount(), 0);
         }
     }
 }
@@ -139,29 +138,27 @@ void CUDAMessageList::swap() {
     std::swap(d_list, d_swap_list);
 }
 
-unsigned int CUDAMessageList::scatter(const unsigned int &newCount, const unsigned int &streamId, const bool &append) {
-    CUDAScatter &scatter = CUDAScatter::getInstance(streamId);
+unsigned int CUDAMessageList::scatter(const unsigned int &newCount, CUDAScatter &scatter, const unsigned int &streamId, const bool &append) {
     if (append) {
         unsigned int oldCount = message.getMessageCount();
-        return oldCount + scatter.scatter(
-            CUDAScatter::Type::Message,
+        return oldCount + scatter.scatter(streamId,
+            CUDAScatter::Type::MESSAGE_OUTPUT,
             message.getMessageDescription().variables,
             d_swap_list, d_list,
             newCount,
             oldCount);
     } else {
-        return scatter.scatter(
-            CUDAScatter::Type::Message,
+        return scatter.scatter(streamId,
+            CUDAScatter::Type::MESSAGE_OUTPUT,
             message.getMessageDescription().variables,
             d_swap_list, d_list,
             newCount,
             0);
     }
 }
-unsigned int CUDAMessageList::scatterAll(const unsigned int &newCount, const unsigned int &streamId) {
-    CUDAScatter &scatter = CUDAScatter::getInstance(streamId);
+unsigned int CUDAMessageList::scatterAll(const unsigned int &newCount, CUDAScatter &scatter, const unsigned int &streamId) {
     unsigned int oldCount = message.getMessageCount();
-    return oldCount + scatter.scatterAll(
+    return oldCount + scatter.scatterAll(streamId,
         message.getMessageDescription().variables,
         d_swap_list, d_list,
         newCount,

--- a/src/flamegpu/gpu/CUDAScanCompaction.cu
+++ b/src/flamegpu/gpu/CUDAScanCompaction.cu
@@ -4,33 +4,49 @@
 #include "flamegpu/gpu/CUDAErrorChecking.h"
 #include "flamegpu/gpu/CUDAAgentModel.h"
 
+/**
+ * CUDAScanCompaction methods
+ */
+void CUDAScanCompaction::purge() {
+    memset(configs, 0, sizeof(configs));
+}
 
-namespace flamegpu_internal {
-namespace CUDAScanCompaction {
-    /**
-    * These will remain unallocated until used
-    * They exist so that the correct array can be used with only the stream index known
-    */
-    __device__ CUDAScanCompactionPtrs ds_configs[MAX_TYPES][MAX_STREAMS];
-    /**
-    * Host mirror of ds_configs
-    */
-    CUDAScanCompactionConfig hd_configs[MAX_TYPES][MAX_STREAMS];
+void CUDAScanCompaction::resize(const unsigned int& newCount, const Type& type, const unsigned int& streamId) {
+    assert(streamId < MAX_STREAMS);
+    assert(type < MAX_TYPES);
+    configs[type][streamId].resize_scan_flag(newCount);
+}
 
-}  // namespace CUDAScanCompaction
-}  // namespace flamegpu_internal
+void CUDAScanCompaction::zero(const Type& type, const unsigned int& streamId) {
+    assert(streamId < MAX_STREAMS);
+    assert(type < MAX_TYPES);
+    configs[type][streamId].zero_scan_flag();
+}
 
-
-__host__ void CUDAScanCompactionConfig::free_scan_flag() {
+const CUDAScanCompactionConfig &CUDAScanCompaction::getConfig(const Type& type, const unsigned int& streamId) {
+    return configs[type][streamId];
+}
+CUDAScanCompactionConfig &CUDAScanCompaction::Config(const Type& type, const unsigned int& streamId) {
+    return configs[type][streamId];
+}
+/**
+ *
+ */
+CUDAScanCompactionConfig::~CUDAScanCompactionConfig() {
+    free_scan_flag();
+}
+void CUDAScanCompactionConfig::free_scan_flag() {
     if (d_ptrs.scan_flag) {
         gpuErrchk(cudaFree(d_ptrs.scan_flag));
+        d_ptrs.scan_flag = nullptr;
     }
     if (d_ptrs.position) {
         gpuErrchk(cudaFree(d_ptrs.position));
+        d_ptrs.position = nullptr;
     }
 }
 
-__host__ void CUDAScanCompactionConfig::zero_scan_flag() {
+void CUDAScanCompactionConfig::zero_scan_flag() {
     if (d_ptrs.position) {
         gpuErrchk(cudaMemset(d_ptrs.position, 0, scan_flag_len * sizeof(unsigned int)));
     }
@@ -39,34 +55,11 @@ __host__ void CUDAScanCompactionConfig::zero_scan_flag() {
     }
 }
 
-__host__ void CUDAScanCompactionConfig::resize_scan_flag(const unsigned int& count, const CUDAAgentModel& model) {
+void CUDAScanCompactionConfig::resize_scan_flag(const unsigned int& count) {
     if (count + 1 > scan_flag_len) {
         free_scan_flag();
         gpuErrchk(cudaMalloc(&d_ptrs.scan_flag, (count + 1) * sizeof(unsigned int)));  // +1 so we can get the total from the scan
         gpuErrchk(cudaMalloc(&d_ptrs.position, (count + 1) * sizeof(unsigned int)));  // +1 so we can get the total from the scan
-        // Calculate offset of this object from start of array, then divide by size of this object, and multiply by size of device object
-
         scan_flag_len = count + 1;
     }
-    // TODO: This can be moved back in side the check once CUDAScanCompation is no longer a singleton
-    ptrdiff_t output_dist = (std::distance(reinterpret_cast<char*>(flamegpu_internal::CUDAScanCompaction::hd_configs), reinterpret_cast<char*>(this)) / sizeof(CUDAScanCompactionConfig)) * sizeof(CUDAScanCompactionPtrs);
-    // gpuErrchk(cudaMemcpyToSymbol(flamegpu_internal::CUDAScanCompaction::ds_configs, &this->d_ptrs, sizeof(CUDAScanCompactionPtrs), output_dist));
-    // call the RTC safe version of cudamemcpy
-    model.RTCSafeCudaMemcpyToSymbol(flamegpu_internal::CUDAScanCompaction::ds_configs, "flamegpu_internal::CUDAScanCompaction::ds_configs", &this->d_ptrs, sizeof(CUDAScanCompactionPtrs), output_dist);
 }
-
-
-void flamegpu_internal::CUDAScanCompaction::resize(const unsigned int& newCount, const flamegpu_internal::CUDAScanCompaction::Type& type, const unsigned int& streamId, const CUDAAgentModel &model) {
-    assert(streamId < MAX_STREAMS);
-    assert(type < MAX_TYPES);
-    hd_configs[type][streamId].resize_scan_flag(newCount, model);
-}
-
-
-void flamegpu_internal::CUDAScanCompaction::zero(const flamegpu_internal::CUDAScanCompaction::Type& type, const unsigned int& streamId) {
-    assert(streamId < MAX_STREAMS);
-    assert(type < MAX_TYPES);
-    hd_configs[type][streamId].zero_scan_flag();
-}
-
-

--- a/src/flamegpu/runtime/messaging/Array2D.cu
+++ b/src/flamegpu/runtime/messaging/Array2D.cu
@@ -19,7 +19,7 @@ __device__ void MsgArray2D::Out::setIndex(const size_type &x, const size_type &y
         Curve::setVariable<size_type>("___INDEX", combined_hash, index_1d, index);
 
         // Set scan flag incase the message is optional
-        flamegpu_internal::CUDAScanCompaction::ds_configs[flamegpu_internal::CUDAScanCompaction::MESSAGE_OUTPUT][streamId].scan_flag[index] = 1;
+        this->scan_flag[index] = 1;
 }
 __device__ MsgArray2D::In::Filter::Filter(const MetaData *_metadata, const Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &y, const size_type &_radius)
     : radius(_radius)
@@ -82,7 +82,7 @@ void MsgArray2D::CUDAModelHandler::freeMetaDataDevicePtr() {
     d_write_flag = nullptr;
     d_write_flag_len = 0;
 }
-void MsgArray2D::CUDAModelHandler::buildIndex() {
+void MsgArray2D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const unsigned int &streamId) {
     const unsigned int MESSAGE_COUNT = this->sim_message.getMessageCount();
     // Zero the output arrays
     auto &read_list = this->sim_message.getReadList();
@@ -107,8 +107,7 @@ void MsgArray2D::CUDAModelHandler::buildIndex() {
         }
         t_d_write_flag = d_write_flag;
     }
-    auto &cs = CUDAScatter::getInstance(0);  // Choose proper stream_id in future!d
-    cs.arrayMessageReorder(this->sim_message.getMessageDescription().variables, read_list, write_list, MESSAGE_COUNT, hd_metadata.length, t_d_write_flag);
+    scatter.arrayMessageReorder(streamId, this->sim_message.getMessageDescription().variables, read_list, write_list, MESSAGE_COUNT, hd_metadata.length, t_d_write_flag);
     this->sim_message.swap();
     // Reset message count back to full array length
     // Array message exposes not output messages as 0

--- a/src/flamegpu/runtime/messaging/BruteForce.cu
+++ b/src/flamegpu/runtime/messaging/BruteForce.cu
@@ -15,7 +15,7 @@ void MsgBruteForce::CUDAModelHandler::freeMetaDataDevicePtr() {
     d_metadata = nullptr;
 }
 
-void MsgBruteForce::CUDAModelHandler::buildIndex() {
+void MsgBruteForce::CUDAModelHandler::buildIndex(CUDAScatter &, const unsigned int &) {
     unsigned int newLength = this->sim_message.getMessageCount();
     if (newLength != hd_metadata.length) {
         hd_metadata.length = newLength;

--- a/src/flamegpu/runtime/utility/RandomManager.cu
+++ b/src/flamegpu/runtime/utility/RandomManager.cu
@@ -18,7 +18,7 @@ RandomManager::RandomManager() :
     reseed(static_cast<unsigned int>(seedFromTime() % UINT_MAX));
 }
 RandomManager::~RandomManager() {
-    // free(); // @todo call free/freeDevice not in the constructor! instead just log that?
+    free();  // @todo call free/freeDevice not in the constructor! instead just log that?
 }
 void RandomManager::purge() {
     length = 0;


### PR DESCRIPTION
They are now part of `CUDAAgentModel::singletons` for convenience, however they aren't implemented as global singletons.

Due to how widely `CUDAScatter` is used, many functions now require the arguments `CUDAScatter &scatter, const unsigned int &streamId`. In future, when streams are being used properly, it may be worth restructuring all this so that they're all packaged within a single `StreamData` object/structure, given `CUDAScatter` and `CUDAScanCompaction` all operate using stream specific data.

Tests all pass on Windows.

Closes #232 