### PR TITLE
Support for multiple CUDAAgentModel instances of same ModelDescription.

### DIFF
--- a/include/flamegpu/gpu/CUDAAgentModel.h
+++ b/include/flamegpu/gpu/CUDAAgentModel.h
@@ -162,6 +162,11 @@ class CUDAAgentModel : public Simulation {
      * With a resolution of around 0.5 microseconds (cudaEventElapsedtime)
      */
     float getSimulationElapsedTime() const;
+    /**
+     * Returns the unique instance id of this CUDAAgentModel instance
+     * @note This value is used internally for environment property storage
+     */
+    using Simulation::getInstanceID;
 
  protected:
     /**
@@ -293,10 +298,6 @@ class CUDAAgentModel : public Simulation {
      * @note called at the end of step() and after all init/hostLayer functions and exit conditions have finished
      */
     void processHostAgentCreation(const unsigned int &streamId);
-    /**
-     * Runs a specific agent function
-     * @param func_des the agent function to execute
-     */
 
  public:
     typedef std::vector<NewAgentStorage> AgentDataBuffer;

--- a/include/flamegpu/io/factory.h
+++ b/include/flamegpu/io/factory.h
@@ -36,11 +36,25 @@ inline std::string getFileExt(const std::string& s) {
 */
 class ReaderFactory {
  public:
-    static StateReader *createReader(const std::string &model_name, const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &model_state, const std::string &input) {
-        std::string extension = getFileExt(input);
+    /**
+     * Returns a reader capable of reading 'input'
+     * Environment properties will be read into the Simulation instance pointed to by 'sim_instance_id'
+     * Agent data will be read into 'model_state'
+     * @param model_name Name from the model description hierarchy of the model to be loaded
+     * @param sim_instance_id Instance is from the Simulation instance to load the environment properties into
+     * @param model_state Map of AgentPopulation to load the agent data into per agent, key should be agent name
+     * @param input Filename of the input file (This will be used to determine which reader to return)
+     * @throws UnsupportedFileType If the file extension does not match an appropriate reader
+     */
+    static StateReader *createReader(
+        const std::string &model_name,
+        const unsigned int &sim_instance_id,
+        const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &model_state,
+        const std::string &input) {
+        const std::string extension = getFileExt(input);
 
         if (extension == "xml") {
-            return new xmlReader(model_name, model_state, input);
+            return new xmlReader(model_name, sim_instance_id, model_state, input);
         }
         /*
         if (extension == "bin") {
@@ -55,8 +69,31 @@ class ReaderFactory {
 
 class WriterFactory {
  public:
-     static StateWriter *createWriter(const std::string &model_name, const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &model_state, const unsigned int &iterations, const std::string &output_file) {
-         return new xmlWriter(model_name, model_state, iterations, output_file);
+    /**
+     * Returns a writer capable of writing model state to 'output_file'
+     * Environment properties from the Simulation instance pointed to by 'sim_instance_id' will be used
+     * Agent data will be read from 'model_state'
+     * @param model_name Name from the model description hierarchy of the model to be exported
+     * @param sim_instance_id Instance is from the Simulation instance to export the environment properties from
+     * @param model_state Map of AgentPopulation to read the agent data from per agent, key should be agent name
+     * @param iterations The value from the step counter at the time of export.
+     * @param output_file Filename of the input file (This will be used to determine which reader to return)
+     * @throws UnsupportedFileType If the file extension does not match an appropriate reader
+     */
+    static StateWriter *createWriter(
+        const std::string &model_name,
+        const unsigned int &sim_instance_id,
+        const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &model_state,
+        const unsigned int &iterations,
+        const std::string &output_file) {
+        const std::string extension = getFileExt(output_file);
+
+        if (extension == "xml") {
+            return new xmlWriter(model_name, sim_instance_id, model_state, iterations, output_file);
+        }
+        THROW UnsupportedFileType("File '%s' is not a type which can be written "
+            "by WriterFactory::createWriter().",
+            output_file.c_str());
      }
 };
 

--- a/include/flamegpu/io/statereader.h
+++ b/include/flamegpu/io/statereader.h
@@ -19,19 +19,30 @@
 // Base class
 class StateReader {
  public:
-    // -----------------------------------------------------------------------
-    //  Constructors and Destructor
-    // -----------------------------------------------------------------------
-    StateReader(const std::string &_model_name, const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &_model_state, const std::string &input)
+    /**
+     * Constructs a reader capable of reading model state from a specific format (this class is abstract)
+     * Environment properties will be read into the Simulation instance pointed to by 'sim_instance_id'
+     * Agent data will be read into 'model_state'
+     * @param _model_name Name from the model description hierarchy of the model to be loaded
+     * @param _sim_instance_id Instance is from the Simulation instance to load the environment properties into
+     * @param _model_state Map of AgentPopulation to load the agent data into per agent, key should be agent name
+     * @param input Filename of the input file (This will be used to determine which reader to return)
+     */
+    StateReader(const std::string &_model_name, const unsigned int &_sim_instance_id, const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &_model_state, const std::string &input)
     : model_state(_model_state)
     , inputFile(input)
-    , model_name(_model_name) {}
+    , model_name(_model_name)
+    , sim_instance_id(_sim_instance_id)  {}
     ~StateReader() {}
 
     // -----------------------------------------------------------------------
     //  The interface
     // -----------------------------------------------------------------------
-
+    /**
+     * Actually perform the file load
+     * @return Returns a return code
+     * @todo: This should probably be the same return code between subclasses, and seems redundant with our exceptions as should never return fail.
+     */
     virtual int parse() = 0;
 
     // void setFileName(const char* input) {    inputFile = std::string(input); }
@@ -57,6 +68,7 @@ class StateReader {
     const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &model_state;
     std::string inputFile;
     const std::string model_name;
+    const unsigned int sim_instance_id;
 };
 
 #endif  // INCLUDE_FLAMEGPU_IO_STATEREADER_H_

--- a/include/flamegpu/io/statewriter.h
+++ b/include/flamegpu/io/statewriter.h
@@ -19,28 +19,40 @@
 
 class StateWriter {
  public:
-    // -----------------------------------------------------------------------
-    //  Constructors and Destructor
-    // -----------------------------------------------------------------------
-
-    StateWriter(const std::string &_model_name, const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &_model_state, const unsigned int &_iterations, const std::string &output_file)
+    /**
+     * Returns a writer capable of writing model state to a specific format (this class is abstract)
+     * Environment properties from the Simulation instance pointed to by 'sim_instance_id' will be used 
+     * Agent data will be read from 'model_state'
+     * @param _model_name Name from the model description hierarchy of the model to be exported
+     * @param _sim_instance_id Instance is from the Simulation instance to export the environment properties fromo
+     * @param _model_state Map of AgentPopulation to read the agent data from per agent, key should be agent name
+     * @param _iterations The value from the step counter at the time of export.
+     * @param output_file Filename of the input file (This will be used to determine which reader to return)
+     */
+    StateWriter(const std::string &_model_name, const unsigned int &_sim_instance_id, const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &_model_state, const unsigned int &_iterations, const std::string &output_file)
     : model_state(_model_state)
     , iterations(_iterations)
     , outputFile(output_file)
-    , model_name(_model_name) {}
+    , model_name(_model_name)
+    , sim_instance_id(_sim_instance_id) {}
     ~StateWriter() {}
 
     // -----------------------------------------------------------------------
     //  The interface
     // -----------------------------------------------------------------------
-
+    /**
+     * Actually perform the file export
+     * @return Returns a return code
+     * @todo: This should probably be the same return code between subclasses, and seems redundant with our exceptions as should never return fail.
+     */
     virtual int writeStates() = 0;
 
  protected:
-    const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> model_state;
+    const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> model_state{};
     unsigned int iterations;
     std::string outputFile;
     const std::string model_name;
+    const unsigned int sim_instance_id;
 };
 
 #endif  // INCLUDE_FLAMEGPU_IO_STATEWRITER_H_

--- a/include/flamegpu/io/xmlReader.h
+++ b/include/flamegpu/io/xmlReader.h
@@ -20,7 +20,21 @@
 // Derived classes
 class xmlReader : public StateReader {
  public:
-    xmlReader(const std::string &model_name, const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &model_state, const std::string &input_file);
+    /**
+     * Constructs a reader capable of reading model state from XML files
+     * Environment properties will be read into the Simulation instance pointed to by 'sim_instance_id'
+     * Agent data will be read into 'model_state'
+     * @param model_name Name from the model description hierarchy of the model to be loaded
+     * @param sim_instance_id Instance is from the Simulation instance to load the environment properties into
+     * @param model_state Map of AgentPopulation to load the agent data into per agent, key should be agent name
+     * @param input_file Filename of the input file (This will be used to determine which reader to return)
+     */
+    xmlReader(const std::string &model_name, const unsigned int &sim_instance_id, const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &model_state, const std::string &input_file);
+    /**
+     * Actual performs the XML parsing to load the model state
+     * @return Always tinyxml2::XML_SUCCESS
+     * @throws TinyXMLError If parsing of the input file fails
+     */
     int parse();
 };
 

--- a/include/flamegpu/io/xmlWriter.h
+++ b/include/flamegpu/io/xmlWriter.h
@@ -20,7 +20,22 @@
 // Derived classes
 class xmlWriter : public StateWriter {
  public:
-    xmlWriter(const std::string &model_name, const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &model_state, const unsigned int &iterations, const std::string &output_file);
+    /**
+     * Returns a writer capable of writing model state to an XML file
+     * Environment properties from the Simulation instance pointed to by 'sim_instance_id' will be used 
+     * Agent data will be read from 'model_state'
+     * @param model_name Name from the model description hierarchy of the model to be exported
+     * @param sim_instance_id Instance is from the Simulation instance to export the environment properties from
+     * @param model_state Map of AgentPopulation to read the agent data from per agent, key should be agent name
+     * @param iterations The value from the step counter at the time of export.
+     * @param output_file Filename of the input file (This will be used to determine which reader to return)
+     */
+    xmlWriter(const std::string &model_name, const unsigned int &sim_instance_id, const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &model_state, const unsigned int &iterations, const std::string &output_file);
+    /**
+     * Actually perform the writing to file
+     * @return Always tinyxml2::XML_SUCCESS
+     * @throws TinyXMLError If export of the model state fails
+     */
     int writeStates();
 };
 

--- a/include/flamegpu/runtime/AgentFunction.h
+++ b/include/flamegpu/runtime/AgentFunction.h
@@ -15,7 +15,7 @@
 enum FLAME_GPU_AGENT_STATUS { ALIVE = 1, DEAD = 0 };
 
 typedef void(AgentFunctionWrapper)(
-    Curve::NamespaceHash model_name_hash,
+    Curve::NamespaceHash instance_id_hash,
     Curve::NamespaceHash agent_func_name_hash,
     Curve::NamespaceHash messagename_inp_hash,
     Curve::NamespaceHash messagename_outp_hash,
@@ -31,12 +31,12 @@ typedef void(AgentFunctionWrapper)(
 /**
  * Wrapper function for launching agent functions
  * Initialises FLAMEGPU_API instance
- * @param model_name_hash CURVE hash of the model's name
+ * @param instance_id_hash CURVE hash of the CUDAAgentModel's instance id
  * @param agent_func_name_hash CURVE hash of the agent + function's names
  * @param messagename_inp_hash CURVE hash of the input message's name
  * @param messagename_outp_hash CURVE hash of the output message's name
  * @param agent_output_hash CURVE hash of "_agent_birth" or 0 if agent birth not present
- * @param popNo Total number of agents exeucting the function (number of threads launched)
+ * @param popNo Total number of agents executing the function (number of threads launched)
  * @param in_messagelist_metadata Pointer to the MsgIn metadata struct, it is interpreted by MsgIn
  * @param out_messagelist_metadata Pointer to the MsgOut metadata struct, it is interpreted by MsgOut
  * @param d_rng Array of curand states for this kernel
@@ -49,7 +49,7 @@ typedef void(AgentFunctionWrapper)(
  */
 template<typename AgentFunction, typename MsgIn, typename MsgOut>
 __global__ void agent_function_wrapper(
-    Curve::NamespaceHash model_name_hash,
+    Curve::NamespaceHash instance_id_hash,
     Curve::NamespaceHash agent_func_name_hash,
     Curve::NamespaceHash messagename_inp_hash,
     Curve::NamespaceHash messagename_outp_hash,
@@ -66,7 +66,7 @@ __global__ void agent_function_wrapper(
         return;
     // create a new device FLAME_GPU instance
     FLAMEGPU_DEVICE_API<MsgIn, MsgOut> *api = new FLAMEGPU_DEVICE_API<MsgIn, MsgOut>(
-        model_name_hash,
+        instance_id_hash,
         agent_func_name_hash,
         agent_output_hash,
         d_rng,

--- a/include/flamegpu/runtime/AgentFunctionCondition.h
+++ b/include/flamegpu/runtime/AgentFunctionCondition.h
@@ -10,7 +10,7 @@
 
 // ! FLAMEGPU function return type
 typedef void(AgentFunctionConditionWrapper)(
-    Curve::NamespaceHash model_name_hash,
+    Curve::NamespaceHash instance_id_hash,
     Curve::NamespaceHash agent_func_name_hash,
     const int popNo,
     curandState *d_rng,
@@ -19,7 +19,7 @@ typedef void(AgentFunctionConditionWrapper)(
 /**
  * Wrapper function for launching agent functions
  * Initialises FLAMEGPU_API instance
- * @param model_name_hash CURVE hash of the model's name
+ * @param instance_id_hash CURVE hash of the CUDAAgentModel's instance id
  * @param agent_func_name_hash CURVE hash of the agent + function's names
  * @param popNo Total number of agents exeucting the function (number of threads launched)
  * @param d_rng Array of curand states for this kernel
@@ -29,7 +29,7 @@ typedef void(AgentFunctionConditionWrapper)(
  */
 template<typename AgentFunctionCondition>
 __global__ void agent_function_condition_wrapper(
-    Curve::NamespaceHash model_name_hash,
+    Curve::NamespaceHash instance_id_hash,
     Curve::NamespaceHash agent_func_name_hash,
     const int popNo,
     curandState *d_rng,
@@ -39,7 +39,7 @@ __global__ void agent_function_condition_wrapper(
         return;
     // create a new device FLAME_GPU instance
     FLAMEGPU_READ_ONLY_DEVICE_API *api = new FLAMEGPU_READ_ONLY_DEVICE_API(
-        model_name_hash,
+        instance_id_hash,
         agent_func_name_hash,
         d_rng);
 

--- a/include/flamegpu/runtime/cuRVE/curve.h
+++ b/include/flamegpu/runtime/cuRVE/curve.h
@@ -56,6 +56,7 @@ class Curve {
      *  @return a 32 bit cuRVE string variable hash.
      */
     __host__ static VariableHash variableRuntimeHash(const char* str);
+    __host__ static VariableHash variableRuntimeHash(unsigned int num);
 
     /** @brief Main cuRVE variable hashing function
      *  Calls recursive hashing functions

--- a/include/flamegpu/runtime/flamegpu_device_api.h
+++ b/include/flamegpu/runtime/flamegpu_device_api.h
@@ -39,12 +39,12 @@ class FLAMEGPU_READ_ONLY_DEVICE_API {
 
  public:
     /**
-     * @param _thread_in_layer_offset This offset can be added to TID to give a thread-safe unique index for the thread
+     * @param instance_id_hash CURVE hash of the CUDAAgentModel's instance id
      * @param modelname_hash CURVE hash of the model's name
      */
-    __device__ FLAMEGPU_READ_ONLY_DEVICE_API(const Curve::NamespaceHash &modelname_hash, const Curve::NamespaceHash &agentfuncname_hash, curandState *&d_rng)
+    __device__ FLAMEGPU_READ_ONLY_DEVICE_API(const Curve::NamespaceHash &instance_id_hash, const Curve::NamespaceHash &agentfuncname_hash, curandState *&d_rng)
         : random(AgentRandom(&d_rng[TID()]))
-        , environment(DeviceEnvironment(modelname_hash))
+        , environment(DeviceEnvironment(instance_id_hash))
         , agent_func_name_hash(agentfuncname_hash) { }
 
     template<typename T, unsigned int N> __device__
@@ -157,7 +157,12 @@ class FLAMEGPU_DEVICE_API : public FLAMEGPU_READ_ONLY_DEVICE_API{
          unsigned int * const scan_flag;
      };
     /**
+<<<<<<< HEAD
      * @param modelname_hash CURVE hash of the model's name
+=======
+     * @param _thread_in_layer_offset This offset can be added to TID to give a thread-safe unique index for the thread
+     * @param instance_id_hash CURVE hash of the CUDAAgentModel's instance id
+>>>>>>> 8c3509e... Support for multiple CUDAAgentModel instances of same ModelDescription.
      * @param agentfuncname_hash Combined CURVE hashes of agent name and func name
      * @param _agent_output_hash Combined CURVE hashes for agent output
      * @param d_rng Device pointer to curand state for this kernel, index 0 should for TID()==0
@@ -166,14 +171,14 @@ class FLAMEGPU_DEVICE_API : public FLAMEGPU_READ_ONLY_DEVICE_API{
      * @param msg_out Output message handler
      */
     __device__ FLAMEGPU_DEVICE_API(
-        const Curve::NamespaceHash &modelname_hash,
+        const Curve::NamespaceHash &instance_id_hash,
         const Curve::NamespaceHash &agentfuncname_hash,
         const Curve::NamespaceHash &_agent_output_hash,
         curandState *&d_rng,
         unsigned int *&scanFlag_agentOutput,
         typename MsgIn::In &&msg_in,
         typename MsgOut::Out &&msg_out)
-        : FLAMEGPU_READ_ONLY_DEVICE_API(modelname_hash, agentfuncname_hash, d_rng)
+        : FLAMEGPU_READ_ONLY_DEVICE_API(instance_id_hash, agentfuncname_hash, d_rng)
         , message_in(msg_in)
         , message_out(msg_out)
         , agent_out(AgentOut(_agent_output_hash, scanFlag_agentOutput))

--- a/include/flamegpu/runtime/utility/EnvironmentManager.cuh
+++ b/include/flamegpu/runtime/utility/EnvironmentManager.cuh
@@ -56,11 +56,13 @@ class EnvironmentManager {
      */
     friend class xmlWriter;
     friend class xmlReader;
-
-    typedef std::pair<std::string, std::string> NamePair;
+    /**
+     * CUDAAgentModel instance id and Property name
+     */
+    typedef std::pair<unsigned int, std::string> NamePair;
     struct NamePairHash {
         size_t operator()(const NamePair& k) const {
-            return std::hash<std::string>()(k.first) ^
+            return std::hash<unsigned int>()(k.first) ^
                 (std::hash<std::string>()(k.second) << 1);
         }
     };
@@ -161,30 +163,31 @@ class EnvironmentManager {
     typedef std::multimap<size_t, std::pair<const NamePair, DefragProp>> DefragMap;
     /**
      * Activates a models environment properties, by adding them to constant cache
-     * @param model_name Name of the model
+     * @param instance_id instance_id of the CUDAAgentModel instance the properties are attached to
      * @param desc environment properties description to use
      */
-    void init(const std::string& model_name, const EnvironmentDescription &desc);
+    void init(const unsigned int &instance_id, const EnvironmentDescription &desc);
     /**
      * Submodel variant of init()
      * Activates a models unmapped environment properties, by adding them to constant cache
      * Maps a models mapped environment properties to their master property
-     * @param model_name Name of the model
+     * @param instance_id instance_id of the CUDAAgentModel instance the properties are attached to
+     * @param master_instance_id instance_id of the CUDAAgentModel instance of the parent of the submodel
      * @param desc environment properties description to use
      */
-    void init(const std::string& model_name, const EnvironmentDescription &desc, const std::string& master_model_name, const SubEnvironmentData &mapping);
+    void init(const unsigned int &instance_id, const EnvironmentDescription &desc, const unsigned int &master_instance_id, const SubEnvironmentData &mapping);
     /**
-     * RTC functions hold thier own unique constants for environment variables. This function copies all environment variable to the RTC copies.
+     * RTC functions hold their own unique constants for environment variables. This function copies all environment variable to the RTC copies.
      * It can not be incorporated into init() as init will be called before RTC functions have been compiled.
      * Uses the already populated Environment data from the cuda_model rather than environmentDescription.
      * @param cuda_model the cuda model being initialised.
      */
-    void initRTC(const CUDAAgentModel& cuda_model);
+    void initRTC(const CUDAAgentModel &cuda_model);
     /**
      * Deactives all environmental properties linked to the named model from constant cache
-     * @param model_name Name of the model
+     * @param instance_id instance_id of the CUDAAgentModel instance the properties are attached to
      */
-    void free(const std::string &model_name);
+    void free(const unsigned int &instance_id);
     /**
      * Max amount of space that can be used for storing environmental properties
      */
@@ -201,7 +204,7 @@ class EnvironmentManager {
     void add(const NamePair &name, const T &value, const bool &isConst = false);
     /**
      * Convenience method: Adds a new environment property
-     * @param model_name name of the model the property is attached to
+     * @param instance_id instance_id of the CUDAAgentModel instance the property is attached to
      * @param var_name name used for accessing the property
      * @param value stored value of the property
      * @param isConst If set to true, it is not possible to change the value
@@ -210,7 +213,7 @@ class EnvironmentManager {
      * @see add(const NamePair &, const T &, const bool &)
      */
     template<typename T>
-    void add(const std::string &model_name, const std::string &var_name, const T &value, const bool &isConst = false);
+    void add(const unsigned int &instance_id, const std::string &var_name, const T &value, const bool &isConst = false);
     /**
      * Adds a new environment property array
      * @param name name used for accessing the property
@@ -224,7 +227,7 @@ class EnvironmentManager {
     void add(const NamePair &name, const std::array<T, N> &value, const bool &isConst = false);
     /**
      * Convenience method: Adds a new environment property array
-     * @param model_name name of the model the property is attached to
+     * @param instance_id instance_id of the CUDAAgentModel instance the property is attached to
      * @param var_name name used for accessing the property
      * @param value stored value of the property
      * @param isConst If set to true, it is not possible to change the value
@@ -234,7 +237,7 @@ class EnvironmentManager {
      * @see add(const NamePair &, const std::array<T, N> &, const bool &)
      */
     template<typename T, size_type N>
-    void add(const std::string &model_name, const std::string &var_name, const std::array<T, N> &value, const bool &isConst = false);
+    void add(const unsigned int &instance_id, const std::string &var_name, const std::array<T, N> &value, const bool &isConst = false);
     /**
      * Sets an environment property
      * @param name name used for accessing the property
@@ -248,7 +251,7 @@ class EnvironmentManager {
     T set(const NamePair &name, const T &value);
     /**
      * Convenience method: Sets an environment property
-     * @param model_name name of the model the property is attached to
+     * @param instance_id instance_id of the CUDAAgentModel instance the property is attached to
      * @param var_name name used for accessing the property
      * @param value value to set the property
      * @tparam T Type of the environmental property array to be created
@@ -258,7 +261,7 @@ class EnvironmentManager {
      * @see add(const NamePair &, const T &)
      */
     template<typename T>
-    T set(const std::string &model_name, const std::string &var_name, const T &value);
+    T set(const unsigned int &instance_id, const std::string &var_name, const T &value);
     /**
      * Sets an environment property array
      * @param name name used for accessing the property array
@@ -273,7 +276,7 @@ class EnvironmentManager {
     std::array<T, N> set(const NamePair &name, const std::array<T, N> &value);
     /**
      * Convenience method: Sets an environment property array
-     * @param model_name name of the model the property is attached to
+     * @param instance_id instance_id of the CUDAAgentModel instance the property is attached to
      * @param var_name name used for accessing the property
      * @param value value to set the property array
      * @tparam T Type of the environmental property array to be created
@@ -284,10 +287,11 @@ class EnvironmentManager {
      * @see set(const NamePair &, const std::array<T, N> &)
      */
     template<typename T, size_type N>
-    std::array<T, N> set(const std::string &model_name, const std::string &var_name, const std::array<T, N> &value);
+    std::array<T, N> set(const unsigned int &instance_id, const std::string &var_name, const std::array<T, N> &value);
     /**
      * Sets an element of an environment property array
      * @param name name used for accessing the property array
+     * @param index Index of the element within the array
      * @param value value to set the element of the property array
      * @tparam T Type of the environmental property array to be created
      * @return Returns the previous value
@@ -298,8 +302,9 @@ class EnvironmentManager {
     T set(const NamePair &name, const size_type &index, const T &value);
     /**
      * Convenience method: Sets an element of an environment property array
-     * @param model_name name of the model the property is attached to
+     * @param instance_id instance_id of the CUDAAgentModel instance the property is attached to
      * @param var_name name used for accessing the property
+     * @param index Index of the element within the array
      * @param value value to set the element of the property array
      * @tparam T Type of the environmental property array to be created
      * @return Returns the previous value
@@ -308,7 +313,7 @@ class EnvironmentManager {
      * @see set(const NamePair &, const size_type &, const T &)
      */
     template<typename T>
-    T set(const std::string &model_name, const std::string &var_name, const size_type &index, const T &value);
+    T set(const unsigned int &instance_id, const std::string &var_name, const size_type &index, const T &value);
     /**
      * Gets an environment property
      * @param name name used for accessing the property
@@ -320,13 +325,13 @@ class EnvironmentManager {
     T get(const NamePair &name);
     /**
      * Convenience method: Gets an environment property
-     * @param model_name name of the model the property is attached to
+     * @param instance_id instance_id of the CUDAAgentModel instance the property is attached to
      * @param var_name name used for accessing the property
      * @tparam T Type of the environmental property array to be created
      * @throws InvalidEnvProperty If a property of the name does not exist
      */
     template<typename T>
-    T get(const std::string &model_name, const std::string &var_name);
+    T get(const unsigned int &instance_id, const std::string &var_name);
     /**
      * Gets an environment property array
      * @param name name used for accessing the property array
@@ -338,7 +343,7 @@ class EnvironmentManager {
     std::array<T, N> get(const NamePair &name);
     /**
      * Convenience method: Gets an environment property array
-     * @param model_name name of the model the property is attached to
+     * @param instance_id instance_id of the CUDAAgentModel instance the property is attached to
      * @param var_name name used for accessing the property
      * @tparam T Type of the environmental property array to be created
      * @tparam N Length of the environmental property array to be created
@@ -346,10 +351,11 @@ class EnvironmentManager {
      * @see get(const NamePair &)
      */
     template<typename T, size_type N>
-    std::array<T, N> get(const std::string &model_name, const std::string &var_name);
+    std::array<T, N> get(const unsigned int &instance_id, const std::string &var_name);
     /**
      * Gets an element of an environment property array
      * @param name name used for accessing the property array
+     * @param index Index of the element within the array
      * @tparam T Type of the value to be returned
      * @throws InvalidEnvProperty If a property of the name does not exist
      * @throws std::out_of_range
@@ -358,7 +364,7 @@ class EnvironmentManager {
     T get(const NamePair &name, const size_type &index);
     /**
      * Convenience method: Gets an element of an environment property array
-     * @param model_name name of the model the property is attached to
+     * @param instance_id instance_id of the CUDAAgentModel instance the property is attached to
      * @param var_name name used for accessing the property
      * @tparam T Type of the value to be returned
      * @throws InvalidEnvProperty If a property of the name does not exist
@@ -366,7 +372,7 @@ class EnvironmentManager {
      * @see get(const NamePair &, const size_type &)
      */
     template<typename T>
-    T get(const std::string &model_name, const std::string &var_name, const size_type &index);
+    T get(const unsigned int &instance_id, const std::string &var_name, const size_type &index);
     /**
      * Removes an environment property
      * @param name name used for accessing the property
@@ -376,21 +382,21 @@ class EnvironmentManager {
     void remove(const NamePair &name);
     /**
      * Convenience method: Removes an environment property
-     * @param model_name name of the model the property is attached to
+     * @param instance_id instance_id of the CUDAAgentModel instance the property is attached to
      * @param var_name name used for accessing the property
      * @throws InvalidEnvProperty If a property of the name does not exist
      * @note This may be used to remove and recreate environment properties (and arrays) marked const
      * @see remove(const NamePair &)
      */
-    void remove(const std::string &model_name, const std::string &var_name);
+    void remove(const unsigned int &instance_id, const std::string &var_name);
     /**
      * Returns all environment properties owned by a model to their default values
      * This means that properties inherited by a submodel will not be reset to their default values
-     * @param model_name name of the model the property is attached to
+     * @param instance_id instance_id of the CUDAAgentModel instance the property is attached to
      * @param desc The environment description (this is where the defaults are pulled from)
      * @todo This is not a particularly efficient implementation, as it updates them all individually.
      */
-    void resetModel(const std::string &model_name, const EnvironmentDescription &desc);
+    void resetModel(const unsigned int &instance_id, const EnvironmentDescription &desc);
     /**
      * Returns whether the named env property exists
      * @param name name used for accessing the property
@@ -398,11 +404,11 @@ class EnvironmentManager {
     inline bool contains(const NamePair &name) const { return properties.find(name) != properties.end() || mapped_properties.find(name) != mapped_properties.end(); }
     /**
      * Convenience method: Returns whether the named env property exists
-     * @param model_name name of the model the property is attached to
+     * @param instance_id instance_id of the CUDAAgentModel instance the property is attached to
      * @param var_name name used for accessing the property
      * @see contains(const NamePair &)
      */
-    inline bool contains(const std::string &model_name, const std::string &var_name) const { return contains(toName(model_name, var_name)); }
+    inline bool contains(const unsigned int &instance_id, const std::string &var_name) const { return contains(toName(instance_id, var_name)); }
     /**
      * Returns whether the named env property is marked as const
      * @param name name used for accessing the property
@@ -417,19 +423,19 @@ class EnvironmentManager {
         if (b != mapped_properties.end()) {
             return b->second.isConst;
         }
-        THROW InvalidEnvProperty("Environmental property with name '%s:%s' does not exist, "
+        THROW InvalidEnvProperty("Environmental property with name '%u:%s' does not exist, "
             "in EnvironmentManager::isConst().",
-            name.first.c_str(), name.second.c_str());
+            name.first, name.second.c_str());
     }
     /**
      * Convenience method: Returns whether the named env property is marked as const
-     * @param model_name name of the model the property is attached to
+     * @param instance_id instance_id of the CUDAAgentModel instance the property is attached to
      * @param var_name name used for accessing the property
      * @return true if the var is marked as constant (cannot be changed during simulation)
      * @throws InvalidEnvProperty If a property of the name does not exist
      * @see isConst(const NamePair &)
      */
-    inline bool isConst(const std::string &model_name, const std::string &var_name) const { return isConst(toName(model_name, var_name)); }
+    inline bool isConst(const unsigned int &instance_id, const std::string &var_name) const { return isConst(toName(instance_id, var_name)); }
     /**
      * Returns the number of elements of the named env property (1 if not an array)
      * @param name name used for accessing the property
@@ -444,22 +450,22 @@ class EnvironmentManager {
             a = properties.find(b->second.masterProp);
             if (a != properties.end())
                 return a->second.elements;
-            THROW InvalidEnvProperty("Mapped environmental property with name '%s:%s' maps to missing property with name '%s:%s', "
+            THROW InvalidEnvProperty("Mapped environmental property with name '%u:%s' maps to missing property with name '%u:%s', "
                 "in EnvironmentManager::type().",
-                name.first.c_str(), name.second.c_str(), b->second.masterProp.first.c_str(), b->second.masterProp.second.c_str());
+                name.first, name.second.c_str(), b->second.masterProp.first, b->second.masterProp.second.c_str());
         }
-        THROW InvalidEnvProperty("Environmental property with name '%s:%s' does not exist, "
+        THROW InvalidEnvProperty("Environmental property with name '%u:%s' does not exist, "
             "in EnvironmentManager::length().",
-            name.first.c_str(), name.second.c_str());
+            name.first, name.second.c_str());
     }
     /**
      * Convenience method: Returns the number of elements of the named env property (1 if not an array)
-     * @param model_name name of the model the property is attached to
+     * @param instance_id instance_id of the CUDAAgentModel instance the property is attached to
      * @param var_name name used for accessing the property
      * @throws InvalidEnvProperty If a property of the name does not exist
      * @see length(const NamePair &)
      */
-    inline size_type length(const std::string &model_name, const std::string &var_name) const { return length(toName(model_name, var_name)); }
+    inline size_type length(const unsigned int &instance_id, const std::string &var_name) const { return length(toName(instance_id, var_name)); }
     /**
      * Returns the variable type of named env property
      * @param name name used for accessing the property
@@ -474,22 +480,22 @@ class EnvironmentManager {
             a = properties.find(b->second.masterProp);
             if (a != properties.end())
                 return a->second.type;
-            THROW InvalidEnvProperty("Mapped environmental property with name '%s:%s' maps to missing property with name '%s:%s', "
+            THROW InvalidEnvProperty("Mapped environmental property with name '%u:%s' maps to missing property with name '%u:%s', "
                 "in EnvironmentManager::type().",
-                name.first.c_str(), name.second.c_str(), b->second.masterProp.first.c_str(), b->second.masterProp.second.c_str());
+                name.first, name.second.c_str(), b->second.masterProp.first, b->second.masterProp.second.c_str());
         }
-        THROW InvalidEnvProperty("Environmental property with name '%s:%s' does not exist, "
+        THROW InvalidEnvProperty("Environmental property with name '%u:%s' does not exist, "
             "in EnvironmentManager::type().",
-            name.first.c_str(), name.second.c_str());
+            name.first, name.second.c_str());
     }
     /**
      * Convenience method: Returns the variable type of named env property
-     * @param model_name name of the model the property is attached to
+     * @param instance_id instance_id of the CUDAAgentModel instance the property is attached to
      * @param var_name name used for accessing the property
      * @throws InvalidEnvProperty If a property of the name does not exist
      * @see type(const NamePair &)
      */
-    inline std::type_index type(const std::string &model_name, const std::string &var_name) const { return type(toName(model_name, var_name)); }
+    inline std::type_index type(const unsigned int &instance_id, const std::string &var_name) const { return type(toName(instance_id, var_name)); }
     /**
      * Returns the available space remaining (bytes) for storing environmental properties
      */
@@ -516,11 +522,11 @@ class EnvironmentManager {
  private:
     /**
      * Joins the two strings into a std::pair
-     * @param model_name becomes first item of pair
+     * @param instance_id becomes first item of pair
      * @param var_name becomes second item of pair
-     * @return Returns std::make_pair(model_name, var_name)
+     * @return Returns std::make_pair(instance_id, var_name)
      */
-    static NamePair toName(const std::string &model_name, const std::string &var_name);
+    static NamePair toName(const unsigned int &instance_id, const std::string &var_name);
     /**
      * Returns the sum of the curve variable hash for the two items within name
      * @param name Pair of the two items to produce the curve value hash
@@ -569,7 +575,7 @@ class EnvironmentManager {
     /**
      * Map of model name to CUDAAgentModel for use in updating RTC values
      */
-    std::unordered_map<std::string, const CUDAAgentModel&> cuda_agent_models;
+    std::unordered_map<unsigned int, const CUDAAgentModel&> cuda_agent_models;
 
     /**
      * Flag indicating that curve has/hasn't been initialised yet on a device.
@@ -599,9 +605,9 @@ class EnvironmentManager {
         return instance;                     // Instantiated on first use.
     }
 
-    const CUDAAgentModel& getCUDAAgentModel(std::string model_name);
+    const CUDAAgentModel& getCUDAAgentModel(const unsigned int &instance_id);
 
-    void setRTCValue(const std::string &model_name, const std::string &variable_name, const void* src, size_t count, size_t offset = 0);
+    void setRTCValue(const unsigned int &instance_id, const std::string &variable_name, const void* src, size_t count, size_t offset = 0);
 
  public:
     // Public deleted creates better compiler errors
@@ -619,15 +625,15 @@ void EnvironmentManager::add(const NamePair &name, const T &value, const bool &i
     static_assert(std::is_arithmetic<T>::value || std::is_enum<T>::value,
         "Only arithmetic types can be used as environmental properties");
     if (contains(name)) {
-        THROW DuplicateEnvProperty("Environmental property with name '%s:%s' already exists, "
+        THROW DuplicateEnvProperty("Environmental property with name '%u:%s' already exists, "
             "in EnvironmentManager::add().",
-            name.first.c_str(), name.second.c_str());
+            name.first, name.second.c_str());
     }
     add(name, reinterpret_cast<const char*>(&value), sizeof(T), isConst, 1, typeid(T));
 }
 template<typename T>
-void EnvironmentManager::add(const std::string &model_name, const std::string &var_name, const T &value, const bool &isConst) {
-    add<T>(toName(model_name, var_name), value, isConst);
+void EnvironmentManager::add(const unsigned int &instance_id, const std::string &var_name, const T &value, const bool &isConst) {
+    add<T>(toName(instance_id, var_name), value, isConst);
 }
 template<typename T, EnvironmentManager::size_type N>
 void EnvironmentManager::add(const NamePair &name, const std::array<T, N> &value, const bool &isConst) {
@@ -636,15 +642,15 @@ void EnvironmentManager::add(const NamePair &name, const std::array<T, N> &value
     static_assert(std::is_arithmetic<T>::value || std::is_enum<T>::value,
         "Only arithmetic types can be used as environmental properties");
     if (contains(name)) {
-        THROW DuplicateEnvProperty("Environmental property with name '%s:%s' already exists, "
+        THROW DuplicateEnvProperty("Environmental property with name '%u:%s' already exists, "
             "in EnvironmentManager::add().",
-            name.first.c_str(), name.second.c_str());
+            name.first, name.second.c_str());
     }
     add(name, reinterpret_cast<const char*>(value.data()), N * sizeof(T), isConst, N, typeid(T));
 }
 template<typename T, EnvironmentManager::size_type N>
-void EnvironmentManager::add(const std::string &model_name, const std::string &var_name, const std::array<T, N> &value, const bool &isConst) {
-    add<T, N>(toName(model_name, var_name), value, isConst);
+void EnvironmentManager::add(const unsigned int &instance_id, const std::string &var_name, const std::array<T, N> &value, const bool &isConst) {
+    add<T, N>(toName(instance_id, var_name), value, isConst);
 }
 
 /**
@@ -654,14 +660,14 @@ template<typename T>
 T EnvironmentManager::set(const NamePair &name, const T &value) {
     const std::type_index typ_id = type(name);
     if (typ_id != std::type_index(typeid(T))) {
-        THROW InvalidEnvPropertyType("Environmental property ('%s:%s') type (%s) does not match template argument T (%s), "
+        THROW InvalidEnvPropertyType("Environmental property ('%u:%s') type (%s) does not match template argument T (%s), "
             "in EnvironmentManager::set().",
-            name.first.c_str(), name.second.c_str(), typ_id.name(), typeid(T).name());
+            name.first, name.second.c_str(), typ_id.name(), typeid(T).name());
     }
     if (isConst(name)) {
-        THROW ReadOnlyEnvProperty("Environmental property ('%s:%s') is marked as const and cannot be changed, "
+        THROW ReadOnlyEnvProperty("Environmental property ('%u:%s') is marked as const and cannot be changed, "
             "in EnvironmentManager::set().",
-            name.first.c_str(), name.second.c_str());
+            name.first, name.second.c_str());
     }
     // Copy old data to return
     T rtn = get<T>(name);
@@ -682,21 +688,21 @@ T EnvironmentManager::set(const NamePair &name, const T &value) {
     return rtn;
 }
 template<typename T>
-T EnvironmentManager::set(const std::string &model_name, const std::string &var_name, const T &value) {
-    return set<T>(toName(model_name, var_name), value);
+T EnvironmentManager::set(const unsigned int &instance_id, const std::string &var_name, const T &value) {
+    return set<T>(toName(instance_id, var_name), value);
 }
 template<typename T, EnvironmentManager::size_type N>
 std::array<T, N> EnvironmentManager::set(const NamePair &name, const std::array<T, N> &value) {
     const std::type_index typ_id = type(name);
     if (typ_id != std::type_index(typeid(T))) {
-        THROW InvalidEnvPropertyType("Environmental property array ('%s:%s') type (%s) does not match template argument T (%s), "
+        THROW InvalidEnvPropertyType("Environmental property array ('%u:%s') type (%s) does not match template argument T (%s), "
             "in EnvironmentManager::set().",
-            name.first.c_str(), name.second.c_str(), typ_id.name(), typeid(T).name());
+            name.first, name.second.c_str(), typ_id.name(), typeid(T).name());
     }
     if (isConst(name)) {
-        THROW ReadOnlyEnvProperty("Environmental property array ('%s:%s') is marked as const and cannot be changed, "
+        THROW ReadOnlyEnvProperty("Environmental property array ('%u:%s') is marked as const and cannot be changed, "
             "in EnvironmentManager::set().",
-            name.first.c_str(), name.second.c_str());
+            name.first, name.second.c_str());
     }
     const size_type array_len = length(name);
     if (array_len != N) {
@@ -723,21 +729,21 @@ std::array<T, N> EnvironmentManager::set(const NamePair &name, const std::array<
     return rtn;
 }
 template<typename T, EnvironmentManager::size_type N>
-std::array<T, N> EnvironmentManager::set(const std::string &model_name, const std::string &var_name, const std::array<T, N> &value) {
-    return set<T, N>(toName(model_name, var_name), value);
+std::array<T, N> EnvironmentManager::set(const unsigned int &instance_id, const std::string &var_name, const std::array<T, N> &value) {
+    return set<T, N>(toName(instance_id, var_name), value);
 }
 template<typename T>
 T EnvironmentManager::set(const NamePair &name, const size_type &index, const T &value) {
     const std::type_index typ_id = type(name);
     if (typ_id != std::type_index(typeid(T))) {
-        THROW InvalidEnvPropertyType("Environmental property array ('%s:%s') type (%s) does not match template argument T (%s), "
+        THROW InvalidEnvPropertyType("Environmental property array ('%u:%s') type (%s) does not match template argument T (%s), "
             "in EnvironmentManager::set().",
-            name.first.c_str(), name.second.c_str(), typ_id.name(), typeid(T).name());
+            name.first, name.second.c_str(), typ_id.name(), typeid(T).name());
     }
     if (isConst(name)) {
-        THROW ReadOnlyEnvProperty("Environmental property array ('%s:%s') is marked as const and cannot be changed, "
+        THROW ReadOnlyEnvProperty("Environmental property array ('%u:%s') is marked as const and cannot be changed, "
             "in EnvironmentManager::set().",
-            name.first.c_str(), name.second.c_str());
+            name.first, name.second.c_str());
     }
     const size_type array_len = length(name);
     if (index >= array_len) {
@@ -764,8 +770,8 @@ T EnvironmentManager::set(const NamePair &name, const size_type &index, const T 
     return rtn;
 }
 template<typename T>
-T EnvironmentManager::set(const std::string &model_name, const std::string &var_name, const size_type &index, const T &value) {
-    return set<T>(toName(model_name, var_name), index, value);
+T EnvironmentManager::set(const unsigned int &instance_id, const std::string &var_name, const size_type &index, const T &value) {
+    return set<T>(toName(instance_id, var_name), index, value);
 }
 
 /**
@@ -779,9 +785,9 @@ T EnvironmentManager::get(const NamePair &name) {
         "Only arithmetic types can be used as environmental properties");
     std::type_index typ_id = type(name);
     if (typ_id != std::type_index(typeid(T))) {
-        THROW InvalidEnvPropertyType("Environmental property ('%s:%s') type (%s) does not match template argument T (%s), "
+        THROW InvalidEnvPropertyType("Environmental property ('%u:%s') type (%s) does not match template argument T (%s), "
             "in EnvironmentManager::get().",
-            name.first.c_str(), name.second.c_str(), typ_id.name(), typeid(T).name());
+            name.first, name.second.c_str(), typ_id.name(), typeid(T).name());
     }
     // Copy old data to return
     const auto a = properties.find(name);
@@ -790,8 +796,8 @@ T EnvironmentManager::get(const NamePair &name) {
     return *reinterpret_cast<T*>(hc_buffer + properties.at(mapped_properties.at(name).masterProp).offset);
 }
 template<typename T>
-T EnvironmentManager::get(const std::string &model_name, const std::string &var_name) {
-    return get<T>(toName(model_name, var_name));
+T EnvironmentManager::get(const unsigned int &instance_id, const std::string &var_name) {
+    return get<T>(toName(instance_id, var_name));
 }
 template<typename T, EnvironmentManager::size_type N>
 std::array<T, N> EnvironmentManager::get(const NamePair &name) {
@@ -801,9 +807,9 @@ std::array<T, N> EnvironmentManager::get(const NamePair &name) {
         "Only arithmetic types can be used as environmental properties");
     const std::type_index typ_id = type(name);
     if (typ_id != std::type_index(typeid(T))) {
-        THROW InvalidEnvPropertyType("Environmental property array ('%s:%s') type (%s) does not match template argument T (%s), "
+        THROW InvalidEnvPropertyType("Environmental property array ('%u:%s') type (%s) does not match template argument T (%s), "
             "in EnvironmentManager::get().",
-            name.first.c_str(), name.second.c_str(), typ_id.name(), typeid(T).name());
+            name.first, name.second.c_str(), typ_id.name(), typeid(T).name());
     }
     const size_type array_len = length(name);
     if (array_len != N) {
@@ -822,8 +828,8 @@ std::array<T, N> EnvironmentManager::get(const NamePair &name) {
     return rtn;
 }
 template<typename T, EnvironmentManager::size_type N>
-std::array<T, N> EnvironmentManager::get(const std::string &model_name, const std::string &var_name) {
-    return get<T, N>(toName(model_name, var_name));
+std::array<T, N> EnvironmentManager::get(const unsigned int &instance_id, const std::string &var_name) {
+    return get<T, N>(toName(instance_id, var_name));
 }
 template<typename T>
 T EnvironmentManager::get(const NamePair &name, const size_type &index) {
@@ -833,9 +839,9 @@ T EnvironmentManager::get(const NamePair &name, const size_type &index) {
         "Only arithmetic types can be used as environmental properties");
     const std::type_index typ_id = type(name);
     if (typ_id != std::type_index(typeid(T))) {
-        THROW InvalidEnvPropertyType("Environmental property array ('%s:%s') type (%s) does not match template argument T (%s), "
+        THROW InvalidEnvPropertyType("Environmental property array ('%u:%s') type (%s) does not match template argument T (%s), "
             "in EnvironmentManager::get().",
-            name.first.c_str(), name.second.c_str(), typ_id.name(), typeid(T).name());
+            name.first, name.second.c_str(), typ_id.name(), typeid(T).name());
     }
     const size_type array_len = length(name);
     if (index >= array_len) {
@@ -850,8 +856,8 @@ T EnvironmentManager::get(const NamePair &name, const size_type &index) {
     return *reinterpret_cast<T*>(hc_buffer + properties.at(mapped_properties.at(name).masterProp).offset + index * sizeof(T));
 }
 template<typename T>
-T EnvironmentManager::get(const std::string &model_name, const std::string &var_name, const size_type &index) {
-    return get<T>(toName(model_name, var_name), index);
+T EnvironmentManager::get(const unsigned int &instance_id, const std::string &var_name, const size_type &index) {
+    return get<T>(toName(instance_id, var_name), index);
 }
 
 #endif  // INCLUDE_FLAMEGPU_RUNTIME_UTILITY_ENVIRONMENTMANAGER_CUH_

--- a/include/flamegpu/runtime/utility/HostEnvironment.cuh
+++ b/include/flamegpu/runtime/utility/HostEnvironment.cuh
@@ -29,16 +29,16 @@ class HostEnvironment {
     /**
      * Constructor, to be called by FLAMEGPU_HOST_API
      */
-    explicit HostEnvironment(const std::string &model_name);
+    explicit HostEnvironment(const unsigned int &instance_id);
     /**
      * Provides access to EnvironmentManager singleton
      */
     EnvironmentManager &env_mgr;
     /**
-     * Access to name of the model
+     * Access to instance id of the CUDAAgentModel
      * This is used to augment all variable names
      */
-    const std::string model_name;
+    const unsigned int instance_id;
 
  public:
     /**
@@ -113,7 +113,7 @@ T HostEnvironment::set(const std::string &name, const T &value) const {
         THROW ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
             "in HostEnvironment::set().");
     }
-    return env_mgr.set<T>({ model_name, name }, value);
+    return env_mgr.set<T>({ instance_id, name }, value);
 }
 template<typename T, EnvironmentManager::size_type N>
 std::array<T, N> HostEnvironment::set(const std::string &name, const std::array<T, N> &value) const {
@@ -121,7 +121,7 @@ std::array<T, N> HostEnvironment::set(const std::string &name, const std::array<
         THROW ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
             "in HostEnvironment::set().");
     }
-    return env_mgr.set<T, N>({ model_name, name }, value);
+    return env_mgr.set<T, N>({ instance_id, name }, value);
 }
 template<typename T>
 T HostEnvironment::set(const std::string &name, const EnvironmentManager::size_type &index, const T &value) const {
@@ -129,7 +129,7 @@ T HostEnvironment::set(const std::string &name, const EnvironmentManager::size_t
         THROW ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
             "in HostEnvironment::set().");
     }
-    return env_mgr.set<T>({ model_name, name }, index, value);
+    return env_mgr.set<T>({ instance_id, name }, index, value);
 }
 
 /**
@@ -137,15 +137,15 @@ T HostEnvironment::set(const std::string &name, const EnvironmentManager::size_t
  */
 template<typename T>
 T HostEnvironment::get(const std::string &name) const  {
-    return env_mgr.get<T>({ model_name, name });
+    return env_mgr.get<T>({ instance_id, name });
 }
 template<typename T, EnvironmentManager::size_type N>
 std::array<T, N> HostEnvironment::get(const std::string &name) const  {
-    return env_mgr.get<T, N>({ model_name, name });
+    return env_mgr.get<T, N>({ instance_id, name });
 }
 template<typename T>
 T HostEnvironment::get(const std::string &name, const EnvironmentManager::size_type &index) const  {
-    return env_mgr.get<T>({ model_name, name }, index);
+    return env_mgr.get<T>({ instance_id, name }, index);
 }
 
 #endif  // INCLUDE_FLAMEGPU_RUNTIME_UTILITY_HOSTENVIRONMENT_CUH_

--- a/include/flamegpu/sim/Simulation.h
+++ b/include/flamegpu/sim/Simulation.h
@@ -80,6 +80,11 @@ class Simulation {
     virtual bool checkArgs_derived(int argc, const char** argv, int &i) = 0;
     virtual void printHelp_derived() = 0;
     virtual void resetDerivedConfig() = 0;
+    /**
+     * Returns the unique instance id of this CUDAAgentModel instance
+     * @note This value is used internally for environment property storage
+     */
+    unsigned int getInstanceID() const { return instance_id; }
     const std::shared_ptr<const ModelData> model;
 
     /**
@@ -93,8 +98,16 @@ class Simulation {
     CUDAAgentModel const * mastermodel;
 
     Config config;
+    /**
+     * Unique index of Simulation instance
+     */
+    const unsigned int instance_id;
 
  private:
+    /**
+     * Generates a unique id number for the instance
+     */
+    static unsigned int get_instance_id();
     void printHelp(const char *executable);
     int checkArgs(int argc, const char** argv);
 };

--- a/src/flamegpu/gpu/CUDAAgent.cu
+++ b/src/flamegpu/gpu/CUDAAgent.cu
@@ -487,13 +487,13 @@ void CUDAAgent::addInstantitateRTCFunction(jitify::JitCache &kernel_cache, const
     }
 
     // Set Environment variables in curve
-    Curve::NamespaceHash model_hash = Curve::variableRuntimeHash(cuda_model.getModelDescription().name.c_str());
+    Curve::NamespaceHash instance_id_hash = Curve::variableRuntimeHash(cuda_model.getInstanceID());
     for (auto p : EnvironmentManager::getInstance().getPropertiesMap()) {
-        if (p.first.first == cuda_model.getModelDescription().name) {
+        if (p.first.first == cuda_model.getInstanceID()) {
             const char* variableName = p.first.second.c_str();
             const char* type = p.second.type.name();
             unsigned int elements = p.second.elements;
-            curve_header.registerEnvVariable(variableName, model_hash, type, elements);
+            curve_header.registerEnvVariable(variableName, instance_id_hash, type, elements);
         }
     }
 

--- a/src/flamegpu/io/xmlReader.cpp
+++ b/src/flamegpu/io/xmlReader.cpp
@@ -54,8 +54,8 @@
 }
 #endif
 
-xmlReader::xmlReader(const std::string &model_name, const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &model_state, const std::string &input)
-    : StateReader(model_name, model_state, input) {}
+xmlReader::xmlReader(const std::string &model_name, const unsigned int &sim_instance_id, const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &model_state, const std::string &input)
+    : StateReader(model_name, sim_instance_id, model_state, input) {}
 
 /**
 * \brief parses the xml file
@@ -90,7 +90,7 @@ int xmlReader::parse() {
             const char *key = envElement->Value();
             std::stringstream ss(envElement->GetText());
             std::string token;
-            const EnvironmentManager::NamePair np = { model_name , std::string(key) };
+            const EnvironmentManager::NamePair np = { sim_instance_id , std::string(key) };
             if (env_manager.contains(np)) {
                 const std::type_index val_type = env_manager.type(np);
                 const auto elements = env_manager.length(np);

--- a/src/flamegpu/io/xmlWriter.cpp
+++ b/src/flamegpu/io/xmlWriter.cpp
@@ -53,8 +53,8 @@
 }
 #endif
 
-xmlWriter::xmlWriter(const std::string &model_name, const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &model, const unsigned int &iterations, const std::string &output_file)
-    : StateWriter(model_name, model, iterations, output_file) {}
+xmlWriter::xmlWriter(const std::string &model_name, const unsigned int &sim_instance_id, const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &model, const unsigned int &iterations, const std::string &output_file)
+    : StateWriter(model_name, sim_instance_id, model, iterations, output_file) {}
 
 int xmlWriter::writeStates() {
     tinyxml2::XMLDocument doc;
@@ -72,7 +72,7 @@ int xmlWriter::writeStates() {
     const char *env_buffer = reinterpret_cast<const char *>(env_manager.getHostBuffer());
     for (auto &a : env_manager.getPropertiesMap()) {
         // If it is from this model
-        if (a.first.first == model_name) {
+        if (a.first.first == sim_instance_id) {
             tinyxml2::XMLElement* pListElement = doc.NewElement(a.first.second.c_str());
             pListElement->SetAttribute("type", a.second.type.name());
                 // Output properties

--- a/src/flamegpu/runtime/cuRVE/curve.cu
+++ b/src/flamegpu/runtime/cuRVE/curve.cu
@@ -72,6 +72,9 @@ __host__ Curve::VariableHash Curve::variableRuntimeHash(const char* str) {
     }
     return hash;
 }
+__host__ Curve::VariableHash Curve::variableRuntimeHash(unsigned int num) {
+    return variableRuntimeHash(std::to_string(num).c_str());
+}
 
 __host__ Curve::Variable Curve::getVariableHandle(VariableHash variable_hash) {
     unsigned int i, n;

--- a/src/flamegpu/runtime/flamegpu_host_api.cu
+++ b/src/flamegpu/runtime/flamegpu_host_api.cu
@@ -10,7 +10,7 @@ FLAMEGPU_HOST_API::FLAMEGPU_HOST_API(CUDAAgentModel &_agentModel,
     const AgentOffsetMap &_agentOffsets,
     AgentDataMap &_agentData)
     : random(rng)
-    , environment(_agentModel.getModelDescription().name)
+    , environment(_agentModel.getInstanceID())
     , agentModel(_agentModel)
     , d_cub_temp(nullptr)
     , d_cub_temp_size(0)

--- a/src/flamegpu/runtime/utility/HostEnvironment.cu
+++ b/src/flamegpu/runtime/utility/HostEnvironment.cu
@@ -1,5 +1,5 @@
 #include "flamegpu/runtime/utility/HostEnvironment.cuh"
 
-HostEnvironment::HostEnvironment(const std::string &_model_name)
+HostEnvironment::HostEnvironment(const unsigned int &_instance_id)
     : env_mgr(EnvironmentManager::getInstance())
-    , model_name(_model_name) { }
+    , instance_id(_instance_id) { }

--- a/tests/test_cases/gpu/test_cuda_agent_model.cu
+++ b/tests/test_cases/gpu/test_cuda_agent_model.cu
@@ -350,5 +350,18 @@ TEST(TestCUDAAgentModel, getSimulationElapsedTime) {
     EXPECT_GT(simulate10StepDuration, 0.0f);
     EXPECT_NE(simulate1StepDuration, simulate10StepDuration);
 }
+// test that we can have 2 instances of the same ModelDescription simultaneously
+TEST(TestCUDAAgentModel, MultipleInstances) {
+    // Define a simple model - doesn't need to do anything other than take some time.
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    AgentPopulation pop(a, static_cast<unsigned int>(AGENT_COUNT));
+    m.addStepFunction(IncrementCounter);
+
+    CUDAAgentModel c1(m);
+    c1.setPopulationData(pop);
+    // Set population data should trigger initialiseSingletons(), which is what leads to crash if EnvManager has matching name/id
+    EXPECT_NO_THROW(CUDAAgentModel c2(m); c2.setPopulationData(pop););
+}
 
 }  // namespace test_cuda_agent_model

--- a/tests/test_cases/runtime/test_environment_manager.cu
+++ b/tests/test_cases/runtime/test_environment_manager.cu
@@ -131,34 +131,3 @@ TEST(EnvironmentManagerTest2, MultipleModels) {
     delete ms1;
     delete ms2;
 }
-
-// Free/Rehost model
-// This test will need expanding once Environment manager is separated into host and device management so the EnvDescriptionAlreadyLoaded can be thrown at construction rather than first use.
-TEST(EnvironmentManagerTest2, RehostModel) {
-    MiniSim *ms1 = new MiniSim();
-    ms1->env.add<float>("ms1_float", MS1_VAL);
-    CUDAAgentModel *cuda_model1 = new CUDAAgentModel(ms1->model);
-    cuda_model1->SimulationConfig().steps = 1;
-    cuda_model1->setPopulationData(*ms1->population);
-    EXPECT_NO_THROW(cuda_model1->simulate());
-    MiniSim *ms2 = new MiniSim();
-    ms2->env.add<float>("ms1_float", MS1_VAL);
-    {
-        CUDAAgentModel *cuda_model2 = nullptr;
-        cuda_model2 = new CUDAAgentModel(ms2->model);
-        // Errors because ms1 CUDAAgentModel still alive, but a method must be called on it to initialise the device (rather than error at construction)
-        EXPECT_THROW(cuda_model2->step(), EnvDescriptionAlreadyLoaded);
-        delete cuda_model2;
-    }
-    delete cuda_model1;
-    // Try again now ms1 has been deleted
-    CUDAAgentModel *cuda_model2 = nullptr;
-    cuda_model2 = new CUDAAgentModel(ms2->model);
-    EXPECT_NO_THROW(cuda_model2->step());
-    cuda_model2->setPopulationData(*ms2->population);
-    cuda_model2->SimulationConfig().steps = 1;
-    EXPECT_NO_THROW(cuda_model2->simulate());
-    delete cuda_model2;
-    delete ms1;
-    delete ms2;
-}


### PR DESCRIPTION
Closes #324 

**Edit:** This resolves the limiting factor with `EnvironmentManager`, however on closer inspection Curve is not setup to work with two instances of `CUDAAgentModel`, let alone two instances with the same `ModelDescription`.

Whilst it is setup with  the concept of namespace, I don't believe that's being used during agent function execution. This isn't really a problem at the moment, given the calls to `CUDAAgentModel::step()` will be synchronous, but needs fixing in future (although `Curve` singleton would actually need some internal changes to make it thread safe too).