### PR TITLE
HostAgentInstance::sort()

### DIFF
--- a/include/flamegpu/gpu/CUDAAgent.h
+++ b/include/flamegpu/gpu/CUDAAgent.h
@@ -150,6 +150,14 @@ class CUDAAgent : public AgentInterface {
      */
     void scatterHostCreation(const std::string &state_name, const unsigned int &newSize, char *const d_inBuff, const VarOffsetStruct &offsets, CUDAScatter &scatter, const unsigned int &streamId);
     /**
+     * Sorts all agent variables according to the positions stored inside Message Output scan buffer
+     * @param state_name The state agents are scattered into
+     * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+     * @param streamId The stream in which the corresponding agent function has executed
+     * @see HostAgentInstance::sort(const std::string &, HostAgentInstance::Order, int, int)
+     */
+    void scatterSort(const std::string &state_name, CUDAScatter &scatter, const unsigned int &streamId);
+    /**
      * Allocates a buffer for storing new agents into and
      * uses the cuRVE runtime to map variables for use with an agent function that has device agent birth
      * @param func The agent function being processed

--- a/include/flamegpu/gpu/CUDAAgentModel.h
+++ b/include/flamegpu/gpu/CUDAAgentModel.h
@@ -22,6 +22,10 @@
  */
 class CUDAAgentModel : public Simulation {
     /**
+     * Requires internal access to scan/scatter singletons
+     */
+    friend class HostAgentInstance;
+    /**
      * Map of a number of CUDA agents by name.
      * The CUDA agents are responsible for allocating and managing all the device memory
      */

--- a/include/flamegpu/gpu/CUDAAgentStateList.h
+++ b/include/flamegpu/gpu/CUDAAgentStateList.h
@@ -93,6 +93,12 @@ class CUDAAgentStateList {
      */
     void scatterHostCreation(const unsigned int &newSize, char *const d_inBuff, const VarOffsetStruct &offsets, CUDAScatter &scatter, const unsigned int &streamId);
     /**
+     * Sorts all agent variables according to the positions stored inside Message Output scan buffer
+     * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+     * @param streamId The stream in which the corresponding agent function has executed
+     */
+    void scatterSort(CUDAScatter &scatter, const unsigned int &streamId);
+    /**
      * Scatters agents from the currently assigned device agent birth buffer (see member variable newBuffs)
      * The device buffer must be packed in the same format as CUDAAgent::mapNewRuntimeVariables(const AgentFunctionData&, const unsigned int &, const unsigned int &)
      * @param d_newBuff The buffer holding the new agent data

--- a/include/flamegpu/gpu/CUDAFatAgentStateList.h
+++ b/include/flamegpu/gpu/CUDAFatAgentStateList.h
@@ -217,6 +217,12 @@ class CUDAFatAgentStateList {
      */
     unsigned int scatterAgentFunctionConditionTrue(const unsigned int &conditionFailCount, CUDAScatter &scatter, const unsigned int &streamId);
     /**
+     * Sorts all agent variables according to the positions stored inside Message Output scan buffer
+     * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+     * @param streamId The stream in which the corresponding agent function has executed
+     */
+    void scatterSort(CUDAScatter &scatter, const unsigned int &streamId);
+    /**
      * Set the number of disabled agents within the state list
      * Updates member var disabledAgents and data_condition for every item inside variables_unique
      * @param numberOfDisabled The new number of disabled agents (this can increase of decrease)

--- a/include/flamegpu/gpu/CUDAScatter.h
+++ b/include/flamegpu/gpu/CUDAScatter.h
@@ -123,6 +123,20 @@ class CUDAScatter {
         const bool &invert_scan_flag = false,
         const unsigned int &scatter_all_count = 0);
     /**
+     * Scatters agents from SoA to SoA according to d_position flag as input_source, all variables are scattered
+     * Used for Host function sort agent
+     * CUDAScanCompaction::position is used to decide where to scatter to
+     * @param streamId Index of internal resources to use
+     * @param messageOrAgent Flag of whether message or agent CUDAScanCompaction arrays should be used
+     * @param scatterData Vector of scatter configuration for each variable to be scattered
+     * @param itemCount Total number of items in input array to consider
+     */
+    void scatterPosition(
+        const unsigned int &streamId,
+        const Type &messageOrAgent,
+        const std::vector<ScatterData> &scatterData,
+        const unsigned int &itemCount);
+    /**
      * Returns the final CUDAScanCompaction::position item 
      * Same value as scatter, - scatter_a__count
      * @param streamId Index of internal resources to use

--- a/include/flamegpu/runtime/flamegpu_host_api.h
+++ b/include/flamegpu/runtime/flamegpu_host_api.h
@@ -92,7 +92,8 @@ class FLAMEGPU_HOST_API {
         MAX,
         SUM,
         CUSTOM_REDUCE,
-        HISTOGRAM_EVEN
+        HISTOGRAM_EVEN,
+        SORT
     };
     // Can't put type_info in map, deleted constructors, so we use it's hash code
     // Histogram always has type int, so we use number of bins instead

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -156,7 +156,8 @@ SET(SRC_FLAMEGPU2
     ${FLAMEGPU_ROOT}/src/flamegpu/gpu/CUDAAgentModel.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/cuRVE/curve.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/cuRVE/curve_rtc.cpp
-    ${FLAMEGPU_ROOT}/src/flamegpu/runtime/flamegpu_host_api.cu    
+    ${FLAMEGPU_ROOT}/src/flamegpu/runtime/flamegpu_host_api.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/runtime/flamegpu_host_agent_api.cu 
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/messaging/BruteForce.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/messaging/Spatial2D.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/messaging/Spatial3D.cu

--- a/src/flamegpu/gpu/CUDAAgent.cu
+++ b/src/flamegpu/gpu/CUDAAgent.cu
@@ -263,6 +263,15 @@ void CUDAAgent::scatterHostCreation(const std::string &state_name, const unsigne
     }
     sm->second->scatterHostCreation(newSize, d_inBuff, offsets, scatter, streamId);
 }
+void CUDAAgent::scatterSort(const std::string &state_name, CUDAScatter &scatter, const unsigned int &streamId) {
+    auto sm = state_map.find(state_name);
+    if (sm == state_map.end()) {
+        THROW InvalidCudaAgentState("Error: Agent ('%s') state ('%s') was not found "
+            "in CUDAAgent::scatterHostCreation()",
+            agent_description.name.c_str(), state_name.c_str());
+    }
+    sm->second->scatterSort(scatter, streamId);
+}
 void CUDAAgent::mapNewRuntimeVariables(const AgentFunctionData& func, const unsigned int &maxLen, CUDAScatter &scatter, const unsigned int &streamId) {
     // Confirm agent output is set
     if (auto oa = func.agent_output.lock()) {

--- a/src/flamegpu/gpu/CUDAAgentStateList.cu
+++ b/src/flamegpu/gpu/CUDAAgentStateList.cu
@@ -172,6 +172,9 @@ void CUDAAgentStateList::scatterHostCreation(const unsigned int &newSize, char *
     // Update number of alive agents
     parent_list->setAgentCount(parent_list->getSize() + newSize);
 }
+void CUDAAgentStateList::scatterSort(CUDAScatter &scatter, const unsigned int &streamId) {
+    parent_list->scatterSort(scatter, streamId);
+}
 void CUDAAgentStateList::scatterNew(void * d_newBuff, const unsigned int &newSize, CUDAScatter &scatter, const unsigned int &streamId) {
     if (newSize) {
         CUDAScanCompactionConfig &scanCfg = scatter.Scan().Config(CUDAScanCompaction::Type::AGENT_OUTPUT, streamId);

--- a/src/flamegpu/runtime/flamegpu_host_agent_api.cu
+++ b/src/flamegpu/runtime/flamegpu_host_agent_api.cu
@@ -1,0 +1,25 @@
+#include "flamegpu/runtime/flamegpu_host_agent_api.h"
+
+__global__ void initToThreadIndex(unsigned int *output, unsigned int threadCount) {
+    const unsigned int TID = blockIdx.x * blockDim.x + threadIdx.x;
+    if (TID < threadCount) {
+        output[TID] = TID;
+    }
+}
+
+void HostAgentInstance::fillTIDArray(unsigned int *buffer, const unsigned int &threadCount) {
+    initToThreadIndex<<<(threadCount/512)+1, 512 >>>(buffer, threadCount);
+    gpuErrchkLaunch();
+}
+
+__global__ void sortBuffer_kernel(char *dest, char*src, unsigned int *position, size_t typeLen, unsigned int threadCount) {
+    const unsigned int TID = blockIdx.x * blockDim.x + threadIdx.x;
+    if (TID < threadCount) {
+        memcpy(dest + TID * typeLen, src + position[TID] * typeLen, typeLen);
+    }
+}
+
+void HostAgentInstance::sortBuffer(void *dest, void*src, unsigned int *position, const size_t &typeLen, const unsigned int &threadCount) {
+    sortBuffer_kernel<<<(threadCount/512)+1, 512 >>>(static_cast<char*>(dest), static_cast<char*>(src), position, typeLen, threadCount);
+    gpuErrchkLaunch();
+}

--- a/src/flamegpu/runtime/flamegpu_host_api.cu
+++ b/src/flamegpu/runtime/flamegpu_host_api.cu
@@ -99,3 +99,5 @@ void FLAMEGPU_HOST_API::resizeTempStorage(const CUB_Config &cc, const unsigned i
 unsigned int FLAMEGPU_HOST_API::getStepCounter() const {
     return agentModel.getStepCounter();
 }
+
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -111,6 +111,7 @@ SET(TEST_CASE_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_device_api.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_environment_manager.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_host_api.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_host_agent_sort.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_host_agent_creation.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_host_environment.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_host_random.cu

--- a/tests/test_cases/runtime/test_host_agent_sort.cu
+++ b/tests/test_cases/runtime/test_host_agent_sort.cu
@@ -1,0 +1,461 @@
+#include "gtest/gtest.h"
+
+#include "flamegpu/flame_api.h"
+#include "flamegpu/runtime/flamegpu_api.h"
+
+namespace test_host_agent_sort {
+
+const unsigned int AGENT_COUNT = 1024;
+FLAMEGPU_STEP_FUNCTION(sort_ascending_float) {
+    FLAMEGPU->agent("agent").sort<float>("float", HostAgentInstance::Asc);
+}
+FLAMEGPU_STEP_FUNCTION(sort_descending_float) {
+    FLAMEGPU->agent("agent").sort<float>("float", HostAgentInstance::Desc);
+}
+FLAMEGPU_STEP_FUNCTION(sort_ascending_int) {
+  FLAMEGPU->agent("agent").sort<int>("int", HostAgentInstance::Asc);
+}
+FLAMEGPU_STEP_FUNCTION(sort_descending_int) {
+    FLAMEGPU->agent("agent").sort<int>("int", HostAgentInstance::Desc);
+}
+
+TEST(HostAgentSort, Ascending_float) {
+    // Define model
+    ModelDescription model("model");
+    AgentDescription &agent = model.newAgent("agent");
+    agent.newVariable<float>("float");
+    agent.newVariable<int>("spare");
+    model.newLayer().addHostFunction(sort_ascending_float);
+    std::mt19937 rd(31313131);  // Fixed seed (at Pete's request)
+    std::uniform_real_distribution <float> dist(1, 1000000);
+
+    // Init pop
+    AgentPopulation pop(agent, AGENT_COUNT);
+    for (int i = 0; i< static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = pop.getNextInstance();
+        const float t = dist(rd);
+        instance.setVariable<float>("float", t);
+        instance.setVariable<int>("spare", static_cast<int>(t+12));
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(pop);
+    // Execute step fn
+    cuda_model.step();
+    // Check results
+    cuda_model.getPopulationData(pop);
+    EXPECT_EQ(AGENT_COUNT, pop.getCurrentListSize());
+    float prev = 1;
+    for (int i = 0; i< static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = pop.getInstanceAt(i);
+        const float f = instance.getVariable<float>("float");
+        const int s = instance.getVariable<int>("spare");
+        // Agent variables are still aligned
+        EXPECT_EQ(static_cast<int>(f+12), s);
+        // Agent variables are ordered
+        EXPECT_GE(f, prev);
+        // Store prev
+        prev = f;
+    }
+}
+TEST(HostAgentSort, Descending_float) {
+    // Define model
+    ModelDescription model("model");
+    AgentDescription &agent = model.newAgent("agent");
+    agent.newVariable<float>("float");
+    agent.newVariable<int>("spare");
+    model.newLayer().addHostFunction(sort_descending_float);
+    std::mt19937 rd(888);  // Fixed seed (at Pete's request)
+    std::uniform_real_distribution <float> dist(1, 1000000);
+
+    // Init pop
+    AgentPopulation pop(agent, AGENT_COUNT);
+    for (int i = 0; i< static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = pop.getNextInstance();
+        const float t = dist(rd);
+        instance.setVariable<float>("float", t);
+        instance.setVariable<int>("spare", static_cast<int>(t+12));
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(pop);
+    // Execute step fn
+    cuda_model.step();
+    // Check results
+    cuda_model.getPopulationData(pop);
+    EXPECT_EQ(AGENT_COUNT, pop.getCurrentListSize());
+    float prev = 1000000;
+    for (int i = 0; i< static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = pop.getInstanceAt(i);
+        const float f = instance.getVariable<float>("float");
+        const int s = instance.getVariable<int>("spare");
+        // Agent variables are still aligned
+        EXPECT_EQ(static_cast<int>(f+12), s);
+        // Agent variables are ordered
+        EXPECT_LE(f, prev);
+        // Store prev
+        prev = f;
+    }
+}
+TEST(HostAgentSort, Ascending_int) {
+    // Define model
+    ModelDescription model("model");
+    AgentDescription &agent = model.newAgent("agent");
+    agent.newVariable<int>("int");
+    agent.newVariable<int>("spare");
+    model.newLayer().addHostFunction(sort_ascending_int);
+    std::mt19937 rd(77777);  // Fixed seed (at Pete's request)
+    std::uniform_int_distribution <int> dist(0, 1000000);
+
+    // Init pop
+    AgentPopulation pop(agent, AGENT_COUNT);
+    for (int i = 0; i< static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = pop.getNextInstance();
+        const int t = i == AGENT_COUNT/2 ? 0 : dist(rd);  // Ensure zero is output atleast once
+        instance.setVariable<int>("int", t);
+        instance.setVariable<int>("spare", t+12);
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(pop);
+    // Execute step fn
+    cuda_model.step();
+    // Check results
+    cuda_model.getPopulationData(pop);
+    EXPECT_EQ(AGENT_COUNT, pop.getCurrentListSize());
+    int prev = 0;
+    for (int i = 0; i< static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = pop.getInstanceAt(i);
+        const int f = instance.getVariable<int>("int");
+        const int s = instance.getVariable<int>("spare");
+        // Agent variables are still aligned
+        EXPECT_EQ(s-f, 12);
+        // Agent variables are ordered
+        EXPECT_GE(f, prev);
+        // Store prev
+        prev = f;
+    }
+}
+TEST(HostAgentSort, Descending_int) {
+    // Define model
+    ModelDescription model("model");
+    AgentDescription &agent = model.newAgent("agent");
+    agent.newVariable<int>("int");
+    agent.newVariable<int>("spare");
+    model.newLayer().addHostFunction(sort_descending_int);
+    std::mt19937 rd(12);  // Fixed seed (at Pete's request)
+    std::uniform_int_distribution <int> dist(1, 1000000);
+
+    // Init pop
+    AgentPopulation pop(agent, AGENT_COUNT);
+    for (int i = 0; i< static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = pop.getNextInstance();
+        const int t = dist(rd);
+        instance.setVariable<int>("int", t);
+        instance.setVariable<int>("spare", t+12);
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(pop);
+    // Execute step fn
+    cuda_model.step();
+    // Check results
+    cuda_model.getPopulationData(pop);
+    EXPECT_EQ(AGENT_COUNT, pop.getCurrentListSize());
+    int prev = 1000000;
+    for (int i = 0; i< static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = pop.getInstanceAt(i);
+        const int f = instance.getVariable<int>("int");
+        const int s = instance.getVariable<int>("spare");
+        // Agent variables are still aligned
+        EXPECT_EQ(s-f, 12);
+        // Agent variables are ordered
+        EXPECT_LE(f, prev);
+        // Store prev
+        prev = f;
+    }
+}
+
+FLAMEGPU_STEP_FUNCTION(sort2x_ascending_float) {
+    FLAMEGPU->agent("agent").sort<float, float>("float1", HostAgentInstance::Asc, "float2", HostAgentInstance::Asc);
+}
+FLAMEGPU_STEP_FUNCTION(sort2x_descending_float) {
+    FLAMEGPU->agent("agent").sort<float, float>("float1", HostAgentInstance::Desc, "float2", HostAgentInstance::Desc);
+}
+FLAMEGPU_STEP_FUNCTION(sort2x_ascending_int) {
+    FLAMEGPU->agent("agent").sort<int, int>("int1", HostAgentInstance::Asc, "int2", HostAgentInstance::Asc);
+}
+FLAMEGPU_STEP_FUNCTION(sort2x_descending_int) {
+    FLAMEGPU->agent("agent").sort<int, int>("int1", HostAgentInstance::Desc, "int2", HostAgentInstance::Desc);
+}
+FLAMEGPU_STEP_FUNCTION(sort2x_ascdesc_int) {
+    FLAMEGPU->agent("agent").sort<int, int>("int1", HostAgentInstance::Asc, "int2", HostAgentInstance::Desc);
+}
+FLAMEGPU_STEP_FUNCTION(sort2x_descasc_int) {
+    FLAMEGPU->agent("agent").sort<int, int>("int1", HostAgentInstance::Desc, "int2", HostAgentInstance::Asc);
+}
+TEST(HostAgentSort, 2x_Ascending_float) {
+    // Define model
+    ModelDescription model("model");
+    AgentDescription &agent = model.newAgent("agent");
+    agent.newVariable<float>("float1");
+    agent.newVariable<float>("float2");
+    agent.newVariable<int>("spare");
+    model.newLayer().addHostFunction(sort2x_ascending_float);
+    std::mt19937 rd(54323);  // Fixed seed (at Pete's request)
+    std::uniform_int_distribution <int> dist1(0, 9);
+    std::uniform_real_distribution <float> dist2(0, 999);
+
+    // Init pop
+    AgentPopulation pop(agent, AGENT_COUNT);
+    for (int i = 0; i< static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = pop.getNextInstance();
+        const float t1 = static_cast<float>(dist1(rd)*1000);
+        const float t2 = dist2(rd);
+        instance.setVariable<float>("float1", t1);
+        instance.setVariable<float>("float2", t2);
+        instance.setVariable<int>("spare", static_cast<int>(t2+12));
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(pop);
+    // Execute step fn
+    cuda_model.step();
+    // Check results
+    cuda_model.getPopulationData(pop);
+    EXPECT_EQ(AGENT_COUNT, pop.getCurrentListSize());
+    float prev = 1;
+    for (int i = 0; i< static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = pop.getInstanceAt(i);
+        const float f1 = instance.getVariable<float>("float1");
+        const float f2 = instance.getVariable<float>("float2");
+        const int s = instance.getVariable<int>("spare");
+        // Agent variables are still aligned
+        EXPECT_EQ(static_cast<int>(f2+12), s);
+        // Agent variables are ordered
+        EXPECT_GE(f1 + f2, prev);
+        // Store prev
+        prev = f1 + f2;
+    }
+}
+TEST(HostAgentSort, 2x_Descending_float) {
+    // Define model
+    ModelDescription model("model");
+    AgentDescription &agent = model.newAgent("agent");
+    agent.newVariable<float>("float1");
+    agent.newVariable<float>("float2");
+    agent.newVariable<int>("spare");
+    model.newLayer().addHostFunction(sort2x_descending_float);
+    std::mt19937 rd(5422323);  // Fixed seed (at Pete's request)
+    std::uniform_int_distribution <int> dist1(0, 9);
+    std::uniform_real_distribution <float> dist2(0, 999);
+
+    // Init pop
+    AgentPopulation pop(agent, AGENT_COUNT);
+    for (int i = 0; i< static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = pop.getNextInstance();
+        const float t1 = static_cast<float>(dist1(rd)*1000);
+        const float t2 = dist2(rd);
+        instance.setVariable<float>("float1", t1);
+        instance.setVariable<float>("float2", t2);
+        instance.setVariable<int>("spare", static_cast<int>(t2+12));
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(pop);
+    // Execute step fn
+    cuda_model.step();
+    // Check results
+    cuda_model.getPopulationData(pop);
+    EXPECT_EQ(AGENT_COUNT, pop.getCurrentListSize());
+    float prev = 1000000;
+    for (int i = 0; i< static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = pop.getInstanceAt(i);
+        const float f1 = instance.getVariable<float>("float1");
+        const float f2 = instance.getVariable<float>("float2");
+        const int s = instance.getVariable<int>("spare");
+        // Agent variables are still aligned
+        EXPECT_EQ(static_cast<int>(f2+12), s);
+        // Agent variables are ordered
+        EXPECT_LE(f1 + f2, prev);
+        // Store prev
+        prev = f1 + f2;
+    }
+}
+TEST(HostAgentSort, 2x_Ascending_int) {
+    // Define model
+    ModelDescription model("model");
+    AgentDescription &agent = model.newAgent("agent");
+    agent.newVariable<int>("int1");
+    agent.newVariable<int>("int2");
+    agent.newVariable<int>("spare");
+    model.newLayer().addHostFunction(sort2x_ascending_int);
+    std::mt19937 rd(123123);  // Fixed seed (at Pete's request)
+    std::uniform_int_distribution <int> dist1(0, 9);
+    std::uniform_int_distribution <int> dist2(0, 999);
+
+    // Init pop
+    AgentPopulation pop(agent, AGENT_COUNT);
+    for (int i = 0; i< static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = pop.getNextInstance();
+        const int t1 = static_cast<float>(dist1(rd)*1000);
+        const int t2 = dist2(rd);
+        instance.setVariable<int>("int1", t1);
+        instance.setVariable<int>("int2", t2);
+        instance.setVariable<int>("spare", static_cast<int>(t2+12));
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(pop);
+    // Execute step fn
+    cuda_model.step();
+    // Check results
+    cuda_model.getPopulationData(pop);
+    EXPECT_EQ(AGENT_COUNT, pop.getCurrentListSize());
+    int prev = 0;
+    for (int i = 0; i< static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = pop.getInstanceAt(i);
+        const int f1 = instance.getVariable<int>("int1");
+        const int f2 = instance.getVariable<int>("int2");
+        const int s = instance.getVariable<int>("spare");
+        // Agent variables are still aligned
+        EXPECT_EQ(f2+12, s);
+        // Agent variables are ordered
+        EXPECT_GE(f1 + f2, prev);
+        // Store prev
+        prev = f1 + f2;
+    }
+}
+TEST(HostAgentSort, 2x_Descending_int) {
+    // Define model
+    ModelDescription model("model");
+    AgentDescription &agent = model.newAgent("agent");
+    agent.newVariable<int>("int1");
+    agent.newVariable<int>("int2");
+    agent.newVariable<int>("spare");
+    model.newLayer().addHostFunction(sort2x_descending_int);
+    std::mt19937 rd(12333123);  // Fixed seed (at Pete's request)
+    std::uniform_int_distribution <int> dist1(0, 9);
+    std::uniform_int_distribution <int> dist2(0, 999);
+
+    // Init pop
+    AgentPopulation pop(agent, AGENT_COUNT);
+    for (int i = 0; i< static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = pop.getNextInstance();
+        const int t1 = static_cast<float>(dist1(rd)*1000);
+        const int t2 = dist2(rd);
+        instance.setVariable<int>("int1", t1);
+        instance.setVariable<int>("int2", t2);
+        instance.setVariable<int>("spare", static_cast<int>(t2+12));
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(pop);
+    // Execute step fn
+    cuda_model.step();
+    // Check results
+    cuda_model.getPopulationData(pop);
+    EXPECT_EQ(AGENT_COUNT, pop.getCurrentListSize());
+    int prev = 1000000;
+    for (int i = 0; i< static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = pop.getInstanceAt(i);
+        const int f1 = instance.getVariable<int>("int1");
+        const int f2 = instance.getVariable<int>("int2");
+        const int s = instance.getVariable<int>("spare");
+        // Agent variables are still aligned
+        EXPECT_EQ(f2+12, s);
+        // Agent variables are ordered
+        EXPECT_LE(f1 + f2, prev);
+        // Store prev
+        prev = f1 + f2;
+    }
+}
+TEST(HostAgentSort, 2x_AscDesc_int) {
+    // Define model
+    ModelDescription model("model");
+    AgentDescription &agent = model.newAgent("agent");
+    agent.newVariable<int>("int1");
+    agent.newVariable<int>("int2");
+    agent.newVariable<int>("spare");
+    model.newLayer().addHostFunction(sort2x_ascdesc_int);
+    std::mt19937 rd(123123);  // Fixed seed (at Pete's request)
+    std::uniform_int_distribution <int> dist1(0, 9);
+    std::uniform_int_distribution <int> dist2(0, 999);
+
+    // Init pop
+    AgentPopulation pop(agent, AGENT_COUNT);
+    for (int i = 0; i< static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = pop.getNextInstance();
+        const int t1 = static_cast<float>(dist1(rd)*1000);
+        const int t2 = dist2(rd);
+        instance.setVariable<int>("int1", t1);
+        instance.setVariable<int>("int2", t2);
+        instance.setVariable<int>("spare", static_cast<int>(t2+12));
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(pop);
+    // Execute step fn
+    cuda_model.step();
+    // Check results
+    cuda_model.getPopulationData(pop);
+    EXPECT_EQ(AGENT_COUNT, pop.getCurrentListSize());
+    int prev = 0;
+    for (int i = 0; i< static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = pop.getInstanceAt(i);
+        const int f1 = instance.getVariable<int>("int1");
+        const int f2 = instance.getVariable<int>("int2");
+        const int s = instance.getVariable<int>("spare");
+        // Agent variables are still aligned
+        EXPECT_EQ(f2+12, s);
+        // Agent variables are ordered
+        EXPECT_GE(f1 + (999-f2), prev);
+        // Store prev
+        prev = f1 + (999-f2);
+    }
+}
+TEST(HostAgentSort, 2x_DescAsc_int) {
+    // Define model
+    ModelDescription model("model");
+    AgentDescription &agent = model.newAgent("agent");
+    agent.newVariable<int>("int1");
+    agent.newVariable<int>("int2");
+    agent.newVariable<int>("spare");
+    model.newLayer().addHostFunction(sort2x_descasc_int);
+    std::mt19937 rd(12333123);  // Fixed seed (at Pete's request)
+    std::uniform_int_distribution <int> dist1(0, 9);
+    std::uniform_int_distribution <int> dist2(0, 999);
+
+    // Init pop
+    AgentPopulation pop(agent, AGENT_COUNT);
+    for (int i = 0; i< static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = pop.getNextInstance();
+        const int t1 = static_cast<float>(dist1(rd)*1000);
+        const int t2 = dist2(rd);
+        instance.setVariable<int>("int1", t1);
+        instance.setVariable<int>("int2", t2);
+        instance.setVariable<int>("spare", static_cast<int>(t2+12));
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(pop);
+    // Execute step fn
+    cuda_model.step();
+    // Check results
+    cuda_model.getPopulationData(pop);
+    EXPECT_EQ(AGENT_COUNT, pop.getCurrentListSize());
+    int prev = 1000000;
+    for (int i = 0; i< static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = pop.getInstanceAt(i);
+        const int f1 = instance.getVariable<int>("int1");
+        const int f2 = instance.getVariable<int>("int2");
+        const int s = instance.getVariable<int>("spare");
+        // Agent variables are still aligned
+        EXPECT_EQ(f2+12, s);
+        // Agent variables are ordered
+        EXPECT_LE(f1 + (999-f2), prev);
+        // Store prev
+        prev = f1 + (999-f2);
+    }
+}
+}  // namespace test_host_agent_sort


### PR DESCRIPTION
Adds the ability to sort agents via a one or two integer or floating point agent variables, during host functions.

This uses cub device radix sort, which provides no guarantee of a stable sort.

Includes 10 tests, these test both of the new methods with `integer` and `float` variables in a full range of orders.
The tests ensure that the key variable becomes sorted, and that other agent variables are reordered with the key variable.

Varadic support was not feasible to include without a hard to understand usage interface, similarly it is unlikely people will require sorting over more than 2 agent variables.

Closes #52 