### PR TITLE
Fix Windows CUDA 10.2 CI

### DIFF
--- a/examples/circles_bruteforce/src/main.cu
+++ b/examples/circles_bruteforce/src/main.cu
@@ -1,12 +1,4 @@
-#include <iostream>
-#include <cstdio>
-#include <cstdlib>
-#include <fstream>
-
-
 #include "flamegpu/flame_api.h"
-#include "flamegpu/runtime/flamegpu_api.h"
-#include "flamegpu/io/factory.h"
 #include "flamegpu/util/nvtx.h"
 
 

--- a/examples/circles_spatial3D/src/main.cu
+++ b/examples/circles_spatial3D/src/main.cu
@@ -1,13 +1,4 @@
-#include <iostream>
-#include <cstdio>
-#include <cstdlib>
-#include <fstream>
-
-
 #include "flamegpu/flame_api.h"
-#include "flamegpu/runtime/flamegpu_api.h"
-#include "flamegpu/io/factory.h"
-#include "flamegpu/visualiser/ModelVis.h"
 
 FLAMEGPU_AGENT_FUNCTION(output_message, MsgNone, MsgSpatial3D) {
     FLAMEGPU->message_out.setVariable<int>("id", FLAMEGPU->getVariable<int>("id"));

--- a/examples/game_of_life/src/main.cu
+++ b/examples/game_of_life/src/main.cu
@@ -1,12 +1,4 @@
-#include <iostream>
-#include <cstdio>
-#include <cstdlib>
-#include <fstream>
-
-
 #include "flamegpu/flame_api.h"
-#include "flamegpu/runtime/flamegpu_api.h"
-#include "flamegpu/io/factory.h"
 #include "flamegpu/util/nvtx.h"
 
 void printPopulation(AgentPopulation &pop);

--- a/examples/host_functions/src/main.cu
+++ b/examples/host_functions/src/main.cu
@@ -1,9 +1,4 @@
-#include <iostream>
-#include <cstdio>
-#include <cstdlib>
-
 #include "flamegpu/flame_api.h"
-#include "flamegpu/runtime/flamegpu_api.h"
 
 const unsigned int AGENT_COUNT = 1024;
 

--- a/examples/rtc_example/src/main.cu
+++ b/examples/rtc_example/src/main.cu
@@ -11,10 +11,6 @@
  * Date    Feb 2017
  *****************************************************************************/
 
-#include <iostream>
-#include <cstdio>
-#include <cstdlib>
-
 #include "flamegpu/flame_api.h"
 
 

--- a/include/flamegpu/exception/FGPUStaticAssert.h
+++ b/include/flamegpu/exception/FGPUStaticAssert.h
@@ -1,6 +1,8 @@
 #ifndef INCLUDE_FLAMEGPU_EXCEPTION_FGPUSTATICASSERT_H_
 #define INCLUDE_FLAMEGPU_EXCEPTION_FGPUSTATICASSERT_H_
 
+#include <cstdint>
+
 /**
  * These are taken from MSVCs std to allow us to perform static assertions
  */

--- a/include/flamegpu/flame_api.h
+++ b/include/flamegpu/flame_api.h
@@ -23,5 +23,6 @@
 #include "flamegpu/runtime/messaging.h"
 #include "flamegpu/runtime/AgentFunction_shim.h"
 #include "flamegpu/runtime/AgentFunctionCondition_shim.h"
+#include "flamegpu/visualiser/ModelVis.h"
 
 #endif  // INCLUDE_FLAMEGPU_FLAME_API_H_


### PR DESCRIPTION
I cannot reproduce this locally, however only 3 examples are failing and all share the same includes (which the others do not). Therefore I have simplified their headers.

I had a similar edgecase locally, whereby i could not build a particular file in release mode due to a cub issue (but it was passing CI). Reordering headers also fixed that, even though I was reordering headers infront of the cub include. Hence, the exact cause is unclear.

A thorough removal of redundant headers might help prevent this recurring in future.