### PR TITLE
Read empty messagelist

### DIFF
--- a/include/flamegpu/gpu/CUDAMessage.h
+++ b/include/flamegpu/gpu/CUDAMessage.h
@@ -62,6 +62,13 @@ class CUDAMessage {
      */
     void setMessageCount(const unsigned int &_message_count);
     /**
+     * Initialise the CUDAMessagelist
+     * This allocates and initialises any CUDA data structures for reading the messagelist, and sets them asthough the messagelist were empty.
+     * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+     * @param streamId Index of stream specific structures used
+     */
+    void init(CUDAScatter &scatter, const unsigned int &streamId);
+    /**
      * Updates message_count to equal newSize, internally reallocates buffer space if more space is required
      * @param newSize The number of messages that the buffer should be capable of storing
      * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)

--- a/include/flamegpu/runtime/messaging/Array.h
+++ b/include/flamegpu/runtime/messaging/Array.h
@@ -388,6 +388,13 @@ class MsgArray {
          */
         ~CUDAModelHandler() { }
         /**
+         * Allocates memory for the constructed index.
+         * Allocates message buffers, and memsets data to 0
+         * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+         * @param streamId Index of stream specific structures used
+         */
+        void init(CUDAScatter &scatter, const unsigned int &streamId) override;
+        /**
          * Sort messages according to index
          * Detect and report any duplicate indicies/gaps
          * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)

--- a/include/flamegpu/runtime/messaging/Array2D.h
+++ b/include/flamegpu/runtime/messaging/Array2D.h
@@ -424,6 +424,13 @@ class MsgArray2D {
          */
         ~CUDAModelHandler() { }
         /**
+         * Allocates memory for the constructed index.
+         * Allocates message buffers, and memsets data to 0
+         * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+         * @param streamId Index of stream specific structures used
+         */
+        void init(CUDAScatter &scatter, const unsigned int &streamId) override;
+        /**
          * Sort messages according to index
          * Detect and report any duplicate indicies/gaps
          * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)

--- a/include/flamegpu/runtime/messaging/Array3D.h
+++ b/include/flamegpu/runtime/messaging/Array3D.h
@@ -440,6 +440,13 @@ class MsgArray3D {
          */
         ~CUDAModelHandler() { }
         /**
+         * Allocates memory for the constructed index.
+         * Allocates message buffers, and memsets data to 0
+         * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+         * @param streamId Index of stream specific structures used
+         */
+        void init(CUDAScatter &scatter, const unsigned int &streamId) override;
+        /**
          * Sort messages according to index
          * Detect and report any duplicate indicies/gaps
          * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)

--- a/include/flamegpu/runtime/messaging/BruteForce.h
+++ b/include/flamegpu/runtime/messaging/BruteForce.h
@@ -42,7 +42,7 @@ class MsgBruteForce {
      * MetaData required by brute force during message reads
      */
     struct MetaData {
-        unsigned int length;
+        unsigned int length = 0;
     };
     /**
      * This class is accessible via FLAMEGPU_DEVICE_API.message_in if MsgBruteForce is specified in FLAMEGPU_AGENT_FUNCTION
@@ -252,6 +252,13 @@ class MsgBruteForce {
          * Should free any local host memory (device memory cannot be freed in destructors)
          */
         ~CUDAModelHandler() { }
+        /**
+         * Allocates memory for the constructed index.
+         * Sets data asthough message list is empty
+         * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+         * @param streamId Index of stream specific structures used
+         */
+        void init(CUDAScatter &scatter, const unsigned int &streamId) override;
         /**
          * Updates the length of the messagelist stored on device
          * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)

--- a/include/flamegpu/runtime/messaging/None.h
+++ b/include/flamegpu/runtime/messaging/None.h
@@ -22,7 +22,13 @@ class MsgSpecialisationHandler {
     /**
      * Destructor, should free any allocated memory in derived classes
      */
-    virtual ~MsgSpecialisationHandler() { }
+    virtual ~MsgSpecialisationHandler() {  }
+    /**
+     * Allocate and fill metadata, as though message list was empty
+     * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+     * @param streamId Index of stream specific structures used
+     */
+    virtual void init(CUDAScatter &scatter, const unsigned int &streamId) = 0;
     /**
      * Constructs an index for the message data structure (e.g. Partition boundary matrix for spatial message types)
      * This is called the first time messages are read, after new messages have been output

--- a/include/flamegpu/runtime/messaging/Spatial2D.h
+++ b/include/flamegpu/runtime/messaging/Spatial2D.h
@@ -345,6 +345,13 @@ class MsgSpatial2D {
          */
          ~CUDAModelHandler() override;
         /**
+         * Allocates memory for the constructed index.
+         * Sets data asthough message list is empty
+         * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+         * @param streamId Index of stream specific structures used
+         */
+        void init(CUDAScatter &scatter, const unsigned int &streamId) override;
+        /**
          * Reconstructs the partition boundary matrix
          * This should be called before reading newly output messages
          * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)

--- a/include/flamegpu/runtime/messaging/Spatial3D.h
+++ b/include/flamegpu/runtime/messaging/Spatial3D.h
@@ -378,6 +378,13 @@ class MsgSpatial3D {
          */
         ~CUDAModelHandler() override { }
         /**
+         * Allocates memory for the constructed index.
+         * Sets data asthough message list is empty
+         * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)
+         * @param streamId Index of stream specific structures used
+         */
+        void init(CUDAScatter &scatter, const unsigned int &streamId) override;
+        /**
          * Reconstructs the partition boundary matrix
          * This should be called before reading newly output messages
          * @param scatter Scatter instance and scan arrays to be used (CUDAAgentModel::singletons->scatter)

--- a/src/flamegpu/gpu/CUDAFatAgentStateList.cu
+++ b/src/flamegpu/gpu/CUDAFatAgentStateList.cu
@@ -157,7 +157,7 @@ unsigned int CUDAFatAgentStateList::scatterDeath(CUDAScatter &scatter, const uns
     return living_agents;
 }
 unsigned int CUDAFatAgentStateList::scatterAgentFunctionConditionFalse(CUDAScatter &scatter, const unsigned int &streamId) {
-    // This makes no sense if we have disabled agents (it's suppose to reorder to create disabled agents)
+    // This makes no sense if we have disabled agents (it's supposed to reorder to create disabled agents)
     assert(disabledAgents == 0);
     // Build scatter data
     std::vector<CUDAScatter::ScatterData> sd;

--- a/src/flamegpu/runtime/messaging/Array2D.cu
+++ b/src/flamegpu/runtime/messaging/Array2D.cu
@@ -63,6 +63,21 @@ MsgArray2D::CUDAModelHandler::CUDAModelHandler(CUDAMessage &a)
     hd_metadata.length = d.dimensions[0] * d.dimensions[1];
 }
 
+void MsgArray2D::CUDAModelHandler::init(CUDAScatter &scatter, const unsigned int &streamId) {
+    allocateMetaDataDevicePtr();
+    // Allocate messages
+    this->sim_message.resize(hd_metadata.length, scatter, streamId);
+    this->sim_message.setMessageCount(hd_metadata.length);
+    // Zero the output arrays
+    auto &read_list = this->sim_message.getReadList();
+    auto &write_list = this->sim_message.getWriteList();
+    for (auto &var : this->sim_message.getMessageDescription().variables) {
+        // Elements is harmless, futureproof for arrays support
+        // hd_metadata.length is used, as message array can be longer than message count
+        gpuErrchk(cudaMemset(write_list.at(var.first), 0, var.second.type_size * var.second.elements * hd_metadata.length));
+        gpuErrchk(cudaMemset(read_list.at(var.first), 0, var.second.type_size * var.second.elements * hd_metadata.length));
+    }
+}
 void MsgArray2D::CUDAModelHandler::allocateMetaDataDevicePtr() {
     if (d_metadata == nullptr) {
         gpuErrchk(cudaMalloc(&d_metadata, sizeof(MetaData)));

--- a/src/flamegpu/runtime/messaging/Array3D.cu
+++ b/src/flamegpu/runtime/messaging/Array3D.cu
@@ -75,6 +75,21 @@ MsgArray3D::CUDAModelHandler::CUDAModelHandler(CUDAMessage &a)
     hd_metadata.length = d.dimensions[0] * d.dimensions[1] * d.dimensions[2];
 }
 
+void MsgArray3D::CUDAModelHandler::init(CUDAScatter &scatter, const unsigned int &streamId) {
+    allocateMetaDataDevicePtr();
+    // Allocate messages
+    this->sim_message.resize(hd_metadata.length, scatter, streamId);
+    this->sim_message.setMessageCount(hd_metadata.length);
+    // Zero the output arrays
+    auto &read_list = this->sim_message.getReadList();
+    auto &write_list = this->sim_message.getWriteList();
+    for (auto &var : this->sim_message.getMessageDescription().variables) {
+        // Elements is harmless, futureproof for arrays support
+        // hd_metadata.length is used, as message array can be longer than message count
+        gpuErrchk(cudaMemset(write_list.at(var.first), 0, var.second.type_size * var.second.elements * hd_metadata.length));
+        gpuErrchk(cudaMemset(read_list.at(var.first), 0, var.second.type_size * var.second.elements * hd_metadata.length));
+    }
+}
 void MsgArray3D::CUDAModelHandler::allocateMetaDataDevicePtr() {
     if (d_metadata == nullptr) {
         gpuErrchk(cudaMalloc(&d_metadata, sizeof(MetaData)));

--- a/src/flamegpu/runtime/messaging/BruteForce.cu
+++ b/src/flamegpu/runtime/messaging/BruteForce.cu
@@ -2,6 +2,13 @@
 #include "flamegpu/model/AgentDescription.h"  // Used by Move-Assign
 #include "flamegpu/gpu/CUDAMessage.h"
 
+void MsgBruteForce::CUDAModelHandler::init(CUDAScatter &, const unsigned int &) {
+    allocateMetaDataDevicePtr();
+    // Allocate messages
+    hd_metadata.length = 0;  // This value should already be 0
+    gpuErrchk(cudaMemcpy(d_metadata, &hd_metadata, sizeof(MetaData), cudaMemcpyHostToDevice));
+}
+
 void MsgBruteForce::CUDAModelHandler::allocateMetaDataDevicePtr() {
     if (d_metadata == nullptr) {
         gpuErrchk(cudaMalloc(&d_metadata, sizeof(MetaData)));

--- a/src/flamegpu/runtime/messaging/Spatial2D.cu
+++ b/src/flamegpu/runtime/messaging/Spatial2D.cu
@@ -123,6 +123,12 @@ __global__ void atomicHistogram2D(
     bin_sub_index[index] = bin_idx;
 }
 
+void MsgSpatial2D::CUDAModelHandler::init(CUDAScatter &, const unsigned int &) {
+    allocateMetaDataDevicePtr();
+    // Set PBM to 0
+    gpuErrchk(cudaMemset(hd_data.PBM, 0x00000000, (binCount + 1) * sizeof(unsigned int)));
+}
+
 void MsgSpatial2D::CUDAModelHandler::allocateMetaDataDevicePtr() {
     if (d_data == nullptr) {
         gpuErrchk(cudaMalloc(&d_histogram, (binCount + 1) * sizeof(unsigned int)));

--- a/src/flamegpu/runtime/messaging/Spatial3D.cu
+++ b/src/flamegpu/runtime/messaging/Spatial3D.cu
@@ -107,6 +107,12 @@ __global__ void atomicHistogram3D(
     bin_sub_index[index] = bin_idx;
 }
 
+void MsgSpatial3D::CUDAModelHandler::init(CUDAScatter &, const unsigned int &) {
+    allocateMetaDataDevicePtr();
+    // Set PBM to 0
+    gpuErrchk(cudaMemset(hd_data.PBM, 0x00000000, (binCount + 1) * sizeof(unsigned int)));
+}
+
 void MsgSpatial3D::CUDAModelHandler::allocateMetaDataDevicePtr() {
     if (d_data == nullptr) {
         gpuErrchk(cudaMalloc(&d_histogram, (binCount + 1) * sizeof(unsigned int)));

--- a/tests/test_cases/runtime/messaging/test_array.cu
+++ b/tests/test_cases/runtime/messaging/test_array.cu
@@ -309,5 +309,42 @@ TEST(TestMessage_Array, reserved_name) {
     MsgArray::Description &message = model.newMessage<MsgArray>(MESSAGE_NAME);
     EXPECT_THROW(message.newVariable<int>("_"), ReservedName);
 }
+FLAMEGPU_AGENT_FUNCTION(countArray, MsgArray, MsgNone) {
+    unsigned int value = FLAMEGPU->message_in.at(0).getVariable<unsigned int>("value");
+    FLAMEGPU->setVariable<unsigned int>("value", value);
+    return ALIVE;
+}
+TEST(TestMessage_Array, ReadEmpty) {
+// What happens if we read a message list before it has been output?
+    ModelDescription model("Model");
+    {   // Location message
+        MsgArray::Description &message = model.newMessage<MsgArray>("location");
+        message.setLength(2);
+        message.newVariable<int>("id");  // unused by current test
+    }
+    {   // Circle agent
+        AgentDescription &agent = model.newAgent("agent");
+        agent.newVariable<unsigned int>("value", 32323);  // Count the number of messages read
+        agent.newFunction("in", countArray).setMessageInput("location");
+    }
+    {   // Layer #1
+        LayerDescription &layer = model.newLayer();
+        layer.addAgentFunction(countArray);
+    }
+    // Create 1 agent
+    AgentPopulation pop_in(model.Agent("agent"), 1);
+    pop_in.getNextInstance();
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(pop_in);
+    // Execute model
+    EXPECT_NO_THROW(cuda_model.step());
+    // Check result
+    AgentPopulation pop_out(model.Agent("agent"), 1);
+    pop_out.getNextInstance().setVariable<unsigned int>("value", 22221);
+    cuda_model.getPopulationData(pop_out);
+    EXPECT_EQ(pop_out.getCurrentListSize(), 1u);
+    auto ai = pop_out.getInstanceAt(0);
+    EXPECT_EQ(ai.getVariable<unsigned int>("value"), 0u);  // Unset array msgs should be 0
+}
 
 }  // namespace test_message_array

--- a/tests/test_cases/runtime/messaging/test_array_3d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_3d.cu
@@ -351,5 +351,42 @@ TEST(TestMessage_Array3D, reserved_name) {
     MsgArray3D::Description &message = model.newMessage<MsgArray3D>(MESSAGE_NAME);
     EXPECT_THROW(message.newVariable<int>("_"), ReservedName);
 }
+FLAMEGPU_AGENT_FUNCTION(countArray3D, MsgArray3D, MsgNone) {
+    unsigned int value = FLAMEGPU->message_in.at(0, 0, 0).getVariable<unsigned int>("value");
+    FLAMEGPU->setVariable<unsigned int>("value", value);
+    return ALIVE;
+}
+TEST(TestMessage_Array3D, ReadEmpty) {
+// What happens if we read a message list before it has been output?
+    ModelDescription model("Model");
+    {   // Location message
+        MsgArray3D::Description &message = model.newMessage<MsgArray3D>("location");
+        message.setDimensions(2, 2, 2);
+        message.newVariable<int>("id");  // unused by current test
+    }
+    {   // Circle agent
+        AgentDescription &agent = model.newAgent("agent");
+        agent.newVariable<unsigned int>("value", 32323);  // Count the number of messages read
+        agent.newFunction("in", countArray3D).setMessageInput("location");
+    }
+    {   // Layer #1
+        LayerDescription &layer = model.newLayer();
+        layer.addAgentFunction(countArray3D);
+    }
+    // Create 1 agent
+    AgentPopulation pop_in(model.Agent("agent"), 1);
+    pop_in.getNextInstance();
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(pop_in);
+    // Execute model
+    EXPECT_NO_THROW(cuda_model.step());
+    // Check result
+    AgentPopulation pop_out(model.Agent("agent"), 1);
+    pop_out.getNextInstance().setVariable<unsigned int>("value", 22221);
+    cuda_model.getPopulationData(pop_out);
+    EXPECT_EQ(pop_out.getCurrentListSize(), 1u);
+    auto ai = pop_out.getInstanceAt(0);
+    EXPECT_EQ(ai.getVariable<unsigned int>("value"), 0u);  // Unset array msgs should be 0
+}
 
 }  // namespace test_message_array_3d


### PR DESCRIPTION
This fixes several bugs and adds new tests:
* Reading messages before message output would cause an error.
* Trying to allocate a messagelist of length less than 3 would not cause an allocation
* If agents all agents are disabled by agent function condition, they would never be released (this was a byproduct of #338). 

Furthermore, we could improve the case of all agents passing/failing an agent function condition by not performing the scatter. However we currently don't retrieve the number that passed condition until after the first scatter, so this is not possible. We could do it by adding an extra memcpy, but then the final one would be redundant. Need a small rework to all uses of `CUDAScatter::scatter()`, so they can recover that value manually with a second call.

Closes #342 