### PR TITLE
Update windows CI to use CUDA 11.0.194

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           # Windows2019 & VS 2019 supports 10.1+
           - os: windows-2019
-            cuda: "11.0.167"
+            cuda: "11.0.194"
             visual_studio: "Visual Studio 16 2019"
           - os: windows-2019
             cuda: "10.2.89"

--- a/scripts/actions/install_cuda_windows.ps1
+++ b/scripts/actions/install_cuda_windows.ps1
@@ -15,6 +15,7 @@ $CUDA_KNOWN_URLS = @{
     "10.1.243" = "http://developer.download.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.243_win10_network.exe";
     "10.2.89" = "http://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe";
     "11.0.167" = "http://developer.download.nvidia.com/compute/cuda/11.0.1/network_installers/cuda_11.0.1_win10_network.exe"
+    "11.0.194" = "http://developer.download.nvidia.com/compute/cuda/11.0.2/network_installers/cuda_11.0.2_win10_network.exe"
 }
 
 # @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead?


### PR DESCRIPTION
This is the full release of CUDA 11.0 rather than the Release Candidate

Ubuntu CI doesn't differentiate between patch versions.