### PR TITLE
Add runtime arg '--console', this will disable the visualisation.

### DIFF
--- a/examples/circles_bruteforce/src/main.cu
+++ b/examples/circles_bruteforce/src/main.cu
@@ -125,6 +125,7 @@ int main(int argc, const char ** argv) {
      */
     NVTX_PUSH("CUDAAgentModel creation");
     CUDAAgentModel cuda_model(model);
+    cuda_model.initialise(argc, argv);
     NVTX_POP();
 
     /**
@@ -147,7 +148,6 @@ int main(int argc, const char ** argv) {
     /**
      * Initialisation
      */
-    cuda_model.initialise(argc, argv);
     if (cuda_model.getSimulationConfig().input_file.empty()) {
         // Currently population has not been init, so generate an agent population on the fly
         std::default_random_engine rng;

--- a/examples/circles_bruteforce/src/main.cu
+++ b/examples/circles_bruteforce/src/main.cu
@@ -124,8 +124,7 @@ int main(int argc, const char ** argv) {
      * Create Model Runner
      */
     NVTX_PUSH("CUDAAgentModel creation");
-    CUDAAgentModel cuda_model(model);
-    cuda_model.initialise(argc, argv);
+    CUDAAgentModel cuda_model(model, argc, argv);
     NVTX_POP();
 
     /**

--- a/examples/circles_spatial3D/src/main.cu
+++ b/examples/circles_spatial3D/src/main.cu
@@ -117,6 +117,7 @@ int main(int argc, const char ** argv) {
      * Create Model Runner
      */
     CUDAAgentModel cuda_model(model);
+    cuda_model.initialise(argc, argv);
 
     /**
      * Create visualisation
@@ -165,7 +166,6 @@ int main(int argc, const char ** argv) {
     /**
      * Initialisation
      */
-    cuda_model.initialise(argc, argv);
     if (cuda_model.getSimulationConfig().input_file.empty()) {
         // Currently population has not been init, so generate an agent population on the fly
         std::default_random_engine rng;

--- a/examples/circles_spatial3D/src/main.cu
+++ b/examples/circles_spatial3D/src/main.cu
@@ -116,8 +116,7 @@ int main(int argc, const char ** argv) {
     /**
      * Create Model Runner
      */
-    CUDAAgentModel cuda_model(model);
-    cuda_model.initialise(argc, argv);
+    CUDAAgentModel cuda_model(model, argc, argv);
 
     /**
      * Create visualisation

--- a/examples/game_of_life/src/main.cu
+++ b/examples/game_of_life/src/main.cu
@@ -78,12 +78,12 @@ int main(int argc, const char ** argv) {
      */
     NVTX_PUSH("CUDAAgentModel creation");
     CUDAAgentModel cuda_model(model);
+    cuda_model.initialise(argc, argv);
     NVTX_POP();
 
     /**
      * Initialisation
      */
-    cuda_model.initialise(argc, argv);
     if (cuda_model.getSimulationConfig().input_file.empty()) {
         // Currently population has not been init, so generate an agent population on the fly
         const unsigned int SQRT_AGENT_COUNT = 10;

--- a/examples/game_of_life/src/main.cu
+++ b/examples/game_of_life/src/main.cu
@@ -77,8 +77,7 @@ int main(int argc, const char ** argv) {
      * Create Model Runner
      */
     NVTX_PUSH("CUDAAgentModel creation");
-    CUDAAgentModel cuda_model(model);
-    cuda_model.initialise(argc, argv);
+    CUDAAgentModel cuda_model(model, argc, argv);
     NVTX_POP();
 
     /**

--- a/include/flamegpu/gpu/CUDAAgentModel.h
+++ b/include/flamegpu/gpu/CUDAAgentModel.h
@@ -57,9 +57,13 @@ class CUDAAgentModel : public Simulation {
     /**
      * Initialise cuda runner
      * Allocates memory for agents/messages, copies environment properties to device etc
+     * If provided, you can pass runtime arguments to this constructor, to automatically call inititialise()
+     * This is not required, you can call inititialise() manually later, or not at all.
      * @param model The model description to initialise the runner to execute
+     * @param argc Runtime argument count
+     * @param argv Runtime argument list ptr
      */
-    explicit CUDAAgentModel(const ModelDescription& model);
+    explicit CUDAAgentModel(const ModelDescription& model, int argc = 0, const char** argv = nullptr);
 
  private:
     /**

--- a/include/flamegpu/sim/Simulation.h
+++ b/include/flamegpu/sim/Simulation.h
@@ -17,11 +17,26 @@ class Simulation {
     struct Config {
         Config() : random_seed(static_cast<unsigned int>(time(nullptr))) {
         }
+        void operator=(const Config &other) {
+            input_file = other.input_file;
+            random_seed = other.random_seed;
+            steps = other.steps;
+            verbose = other.verbose;
+            timing = other.timing;
+#ifdef VISUALISATION
+            console_mode = other.console_mode;
+#endif
+        }
         std::string input_file;
         unsigned int random_seed;
         unsigned int steps = 0;
         bool verbose = false;
         bool timing = false;
+#ifdef VISUALISATION
+        bool console_mode = false;
+#else
+        const bool console_mode = true;
+#endif
     };
     virtual ~Simulation() = default;
     /**

--- a/src/flamegpu/gpu/CUDAAgentModel.cu
+++ b/src/flamegpu/gpu/CUDAAgentModel.cu
@@ -22,7 +22,7 @@
 std::atomic<int> CUDAAgentModel::active_instances;  // This value should default init to 0, specifying =0 was causing warnings on Windows.
 bool CUDAAgentModel::AUTO_CUDA_DEVICE_RESET = true;
 
-CUDAAgentModel::CUDAAgentModel(const ModelDescription& _model)
+CUDAAgentModel::CUDAAgentModel(const ModelDescription& _model, int argc, const char** argv)
     : Simulation(_model)
     , step_count(0)
     , simulation_elapsed_time(0.f)
@@ -60,6 +60,10 @@ CUDAAgentModel::CUDAAgentModel(const ModelDescription& _model)
     // create new cuda message and add to the map
     for (auto it_sm = smm.cbegin(); it_sm != smm.cend(); ++it_sm) {
         submodel_map.emplace(it_sm->first, std::unique_ptr<CUDAAgentModel>(new CUDAAgentModel(it_sm->second, this)));
+    }
+
+    if (argc && argv) {
+        initialise(argc, argv);
     }
 }
 CUDAAgentModel::CUDAAgentModel(const std::shared_ptr<SubModelData> &submodel_desc, CUDAAgentModel *master_model)

--- a/src/flamegpu/gpu/CUDAAgentModel.cu
+++ b/src/flamegpu/gpu/CUDAAgentModel.cu
@@ -871,6 +871,17 @@ void CUDAAgentModel::printHelp_derived() {
 
 void CUDAAgentModel::applyConfig_derived() {
     NVTX_RANGE("applyConfig_derived");
+
+    // Handle console_mode
+#ifdef VISUALISATION
+    if (getSimulationConfig().console_mode) {
+        if (visualisation) {
+            visualisation->deactivate();
+        }
+    }
+#endif
+
+
     cudaError_t cudaStatus;
     int device_count;
 

--- a/src/flamegpu/io/jsonReader.cpp
+++ b/src/flamegpu/io/jsonReader.cpp
@@ -275,6 +275,14 @@ class jsonReader_agentsize_counter : public rapidjson::BaseReaderHandler<rapidjs
                     sim_instance->SimulationConfig().timing = static_cast<bool>(val);
                 } else if (lastKey == "verbose") {
                     sim_instance->SimulationConfig().verbose = static_cast<bool>(val);
+                } else if (lastKey == "console_mode") {
+#ifdef VISUALISATION
+                    sim_instance->SimulationConfig().console_mode = static_cast<bool>(val);
+#else
+                    if (static_cast<bool>(val) == false) {
+                        fprintf(stderr, "Warning: Cannot disable 'console_mode' with input file '%s', FLAMEGPU2 library has not been built with visualisation support enabled.\n", filename.c_str());
+                    }
+#endif
                 } else {
                     THROW RapidJSONError("Unexpected simulation config item '%s' in input file '%s'.\n", lastKey.c_str(), filename.c_str());
                 }

--- a/src/flamegpu/io/jsonWriter.cpp
+++ b/src/flamegpu/io/jsonWriter.cpp
@@ -52,6 +52,9 @@ void jsonWriter::doWrite(T &writer) {
                 // Verbose output
                 writer.Key("verbose");
                 writer.Bool(sim_cfg.verbose);
+                // Console mode
+                writer.Key("console_mode");
+                writer.Bool(sim_cfg.console_mode);
             }
             writer.EndObject();
         }

--- a/src/flamegpu/io/xmlReader.cpp
+++ b/src/flamegpu/io/xmlReader.cpp
@@ -124,6 +124,22 @@ int xmlReader::parse() {
                     } else {
                         sim_instance->SimulationConfig().verbose = static_cast<bool>(stoll(val));
                     }
+                } else if (key == "console_mode") {
+#ifdef VISUALISATION
+                    for (auto& c : val)
+                        c = static_cast<char>(::tolower(c));
+                    if (val == "true") {
+                        sim_instance->SimulationConfig().console_mode = true;
+                    } else if (val == "false") {
+                        sim_instance->SimulationConfig().console_mode = false;
+                    } else {
+                        sim_instance->SimulationConfig().console_mode = static_cast<bool>(stoll(val));
+                    }
+#else
+                    if (val == "false") {
+                        fprintf(stderr, "Warning: Cannot disable 'console_mode' with input file '%s', FLAMEGPU2 library has not been built with visualisation support enabled.\n", inputFile.c_str());
+                    }
+#endif
                 }  else {
                     fprintf(stderr, "Warning: Input file '%s' contains unexpected simulation config property '%s'.\n", inputFile.c_str(), key.c_str());
                 }

--- a/src/flamegpu/io/xmlWriter.cpp
+++ b/src/flamegpu/io/xmlWriter.cpp
@@ -100,6 +100,9 @@ int xmlWriter::writeStates(bool prettyPrint) {
             // Verbose output
             pListElement = doc.NewElement("verbose");
             pListElement->SetText(sim_cfg.verbose);
+            // Verbose output
+            pListElement = doc.NewElement("console_mode");
+            pListElement->SetText(sim_cfg.console_mode);
             pSimCfg->InsertEndChild(pListElement);
         }
         pElement->InsertEndChild(pSimCfg);

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -167,6 +167,13 @@ int Simulation::checkArgs(int argc, const char** argv) {
             config.timing = true;
             continue;
         }
+#ifdef VISUALISATION
+        // -c/--console, Renders the visualisation inert
+        if (arg.compare("--console") == 0 || arg.compare("-c") == 0) {
+            config.console_mode = true;
+            continue;
+        }
+#endif
         // Test this arg with the derived class
         if (checkArgs_derived(argc, argv, i)) {
             continue;
@@ -187,6 +194,9 @@ void Simulation::printHelp(const char* executable) {
     printf(line_fmt, "-r, --random <seed>", "RandomManager seed");
     printf(line_fmt, "-v, --verbose", "Verbose FLAME GPU output");
     printf(line_fmt, "-t, --timing", "Output timing information to stdout");
+#ifdef VISUALISATION
+    printf(line_fmt, "-c, --console", "Console mode, disable the visualisation");
+#endif
     printHelp_derived();
 }
 

--- a/src/flamegpu/visualiser/ModelVis.cpp
+++ b/src/flamegpu/visualiser/ModelVis.cpp
@@ -45,7 +45,7 @@ AgentVis &ModelVis::Agent(const std::string &agent_name) {
 // Below methods are related to executing the visualiser
 void ModelVis::activate() {
     // Only execute if background thread is not active
-    if (!visualiser || !visualiser->isRunning()) {
+    if ((!visualiser || !visualiser->isRunning()) && !model.getSimulationConfig().console_mode) {
         // Init visualiser
         visualiser = std::make_unique<FLAMEGPU_Visualisation>(modelCfg);  // Window resolution
         for (auto &agent : agents) {


### PR DESCRIPTION
Adds command line argument `-c` or `--console` to disable visualisation.
This is represented by the `Simulation::Config::console_mode` variable, which can also be managed programatically and via file import.
This is locked to true when not building with `VISUALISATION` enabled.

Closes #231 

-----

Slight issue, if a user activates visualisation before parse args the vis will be open and then close when parse args is called. Only fix for this would be to make parse args part of the `CUDAAgentModel` constructor, so it was always executed at the start. This would however prevent users from overriding the default config as they can currently do.

Compromise could be to allow args to be passed to constructor, but leave the manual call there too. This would hopefully encourage use via the constructor to be the default behaviour.
