### PR TITLE
Bucket Messaging format.

### DIFF
--- a/include/flamegpu/runtime/flamegpu_host_agent_api.h
+++ b/include/flamegpu/runtime/flamegpu_host_agent_api.h
@@ -93,7 +93,7 @@ class HostAgentInstance {
     OutT sum(const std::string &variable) const;
     /**
      * Wraps cub::DeviceReduce::Min()
-     * @param variable The agent variable to perform the min reduction across
+     * @param variable The agent variable to perform the lowerBound reduction across
      * @tParam InT The type of the variable as specified in the model description hierarchy
      * @throws UnsupportedVarType Array variables are not supported
      * @throws InvalidAgentVar If the agent does not contain a variable of the same name
@@ -103,7 +103,7 @@ class HostAgentInstance {
     InT min(const std::string &variable) const;
     /**
      * Wraps cub::DeviceReduce::Max()
-     * @param variable The agent variable to perform the max reduction across
+     * @param variable The agent variable to perform the upperBound reduction across
      * @tParam InT The type of the variable as specified in the model description hierarchy
      * @throws UnsupportedVarType Array variables are not supported
      * @throws InvalidAgentVar If the agent does not contain a variable of the same name
@@ -266,10 +266,10 @@ InT HostAgentInstance::min(const std::string &variable) const {
     const auto &agentDesc = agent.getAgentDescription();
     const std::type_index typ = agentDesc.description->getVariableType(variable);  // This will throw name exception
     if (agentDesc.variables.at(variable).elements != 1) {
-        THROW UnsupportedVarType("HostAgentInstance::min() does not support agent array variables.");
+        THROW UnsupportedVarType("HostAgentInstance::lowerBound() does not support agent array variables.");
     }
     if (std::type_index(typeid(InT)) != typ) {
-        THROW InvalidVarType("Wrong variable type passed to HostAgentInstance::min(). "
+        THROW InvalidVarType("Wrong variable type passed to HostAgentInstance::lowerBound(). "
             "This call expects '%s', but '%s' was requested.",
             agentDesc.variables.at(variable).type.name(), typeid(InT).name());
     }
@@ -297,10 +297,10 @@ InT HostAgentInstance::max(const std::string &variable) const {
     const auto &agentDesc = agent.getAgentDescription();
     const std::type_index typ = agentDesc.description->getVariableType(variable);  // This will throw name exception
     if (agentDesc.variables.at(variable).elements != 1) {
-        THROW UnsupportedVarType("HostAgentInstance::max() does not support agent array variables.");
+        THROW UnsupportedVarType("HostAgentInstance::upperBound() does not support agent array variables.");
     }
     if (std::type_index(typeid(InT)) != typ) {
-        THROW InvalidVarType("Wrong variable type passed to FLAMEGPU_HOST_AGENT_API::max(). "
+        THROW InvalidVarType("Wrong variable type passed to FLAMEGPU_HOST_AGENT_API::upperBound(). "
             "This call expects '%s', but '%s' was requested.",
             agentDesc.variables.at(variable).type.name(), typeid(InT).name());
     }

--- a/include/flamegpu/runtime/messaging.h
+++ b/include/flamegpu/runtime/messaging.h
@@ -13,6 +13,7 @@
 #include "flamegpu/runtime/messaging/Array.h"
 #include "flamegpu/runtime/messaging/Array2D.h"
 #include "flamegpu/runtime/messaging/Array3D.h"
+#include "flamegpu/runtime/messaging/Bucket.h"
 
 /**
  * ######################################################

--- a/include/flamegpu/runtime/messaging/Spatial3D.h
+++ b/include/flamegpu/runtime/messaging/Spatial3D.h
@@ -67,7 +67,7 @@ class MsgSpatial3D {
          */
         unsigned int gridDim[3];
         /**
-         * max-min
+         * max-lowerBound
          */
         float environmentWidth[3];
     };

--- a/include/flamegpu/runtime/utility/AgentRandom.cuh
+++ b/include/flamegpu/runtime/utility/AgentRandom.cuh
@@ -41,7 +41,7 @@ class AgentRandom {
     template<typename T>
     __forceinline__ __device__ T logNormal(const T& mean, const T& stddev) const;
     /**
-     * Returns an integer uniformly distributed in the inclusive range [min, max]
+     * Returns an integer uniformly distributed in the inclusive range [lowerBound, max]
      * @note Available as signed and unsigned: char, short, int, long long
      */
     template<typename T>
@@ -98,7 +98,7 @@ __forceinline__ __device__ double AgentRandom::logNormal(const double& mean, con
 */
 template<typename T>
 __forceinline__ __device__ T AgentRandom::uniform(const T& min, const T& max) const {
-    static_assert(FGPU_SA::_Is_IntType<T>::value, "Invalid template argument for AgentRandom::uniform(const T& min, const T& max)");
+    static_assert(FGPU_SA::_Is_IntType<T>::value, "Invalid template argument for AgentRandom::uniform(const T& lowerBound, const T& max)");
     return static_cast<T>(min + (max - min) * uniform<float>());
 }
 template<>

--- a/include/flamegpu/runtime/utility/HostRandom.cuh
+++ b/include/flamegpu/runtime/utility/HostRandom.cuh
@@ -38,7 +38,7 @@ class HostRandom {
     template<typename T>
     inline T logNormal(const T& mean, const T& stddev) const;
     /**
-    * Returns an integer uniformly distributed in the inclusive range [min, max]
+    * Returns an integer uniformly distributed in the inclusive range [lowerBound, max]
     * @tparam T return type (must be integer)
     * @note Available as signed and unsigned: char, short, int, long long
     */
@@ -75,7 +75,7 @@ inline T HostRandom::logNormal(const T& mean, const T& stddev) const {
 
 template<typename T>
 inline T HostRandom::uniform(const T& min, const T& max) const {
-    static_assert(FGPU_SA::_Is_IntType<T>::value, "Invalid template argument for HostRandom::uniform(const T& min, const T& max)");
+    static_assert(FGPU_SA::_Is_IntType<T>::value, "Invalid template argument for HostRandom::uniform(const T& lowerBound, const T& max)");
     std::uniform_int_distribution<T> dist(min, max);
     return rng.getDistribution<T>(dist);
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -119,6 +119,7 @@ SET(SRC_INCLUDE
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/messaging/Array.h
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/messaging/Array2D.h
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/messaging/Array3D.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/runtime/messaging/Bucket.h
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/utility/AgentRandom.cuh
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/utility/DeviceEnvironment.cuh
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/utility/EnvironmentManager.cuh
@@ -169,6 +170,7 @@ SET(SRC_FLAMEGPU2
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/messaging/Array.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/messaging/Array2D.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/messaging/Array3D.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/runtime/messaging/Bucket.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/io/jsonReader.cpp
     ${FLAMEGPU_ROOT}/src/flamegpu/io/jsonWriter.cpp
     ${FLAMEGPU_ROOT}/src/flamegpu/io/xmlReader.cpp

--- a/src/flamegpu/runtime/messaging/Bucket.cu
+++ b/src/flamegpu/runtime/messaging/Bucket.cu
@@ -1,0 +1,215 @@
+#include "flamegpu/runtime/messaging/Bucket.h"
+
+#ifdef _MSC_VER
+#pragma warning(push, 1)
+#pragma warning(disable : 4706 4834)
+#include <cub/cub.cuh>
+#pragma warning(pop)
+#else
+#include <cub/cub.cuh>
+#endif
+
+#include "flamegpu/runtime/messaging.h"
+#include "flamegpu/gpu/CUDAMessage.h"
+#include "flamegpu/gpu/CUDAScatter.h"
+#include "flamegpu/util/nvtx.h"
+
+__device__ MsgBucket::In::Filter::Filter(const MetaData* _metadata, const Curve::NamespaceHash &_combined_hash, const IntT& beginKey, const IntT& endKey)
+    : bucket_begin(0)
+    , bucket_end(0)
+    , metadata(_metadata)
+    , combined_hash(_combined_hash) {
+    // If key is in bounds
+    if (beginKey >= metadata->min && endKey < metadata->max && beginKey <= endKey) {
+        bucket_begin = metadata->PBM[beginKey - metadata->min];
+        bucket_end = metadata->PBM[endKey - metadata->min];
+    }
+}
+
+__device__ void MsgBucket::Out::setKey(const IntT &key) const {
+    unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;  // + d_message_count;
+
+    // set the variables using curve
+    Curve::setVariable<IntT>("_key", combined_hash, key, index);
+
+    // Set scan flag incase the message is optional
+    this->scan_flag[index] = 1;
+}
+
+MsgBucket::CUDAModelHandler::CUDAModelHandler(CUDAMessage &a)
+    : MsgSpecialisationHandler()
+    , sim_message(a) {
+    NVTX_RANGE("MsgBucket::CUDAModelHandler::CUDAModelHandler");
+    const Data &d = (const Data &)a.getMessageDescription();
+    hd_data.min = d.lowerBound;
+    // Here we convert it so that upperBound is one greater than the final valid index
+    hd_data.max = d.upperBound + 1;
+    bucketCount = d.upperBound - d.lowerBound  + 1;
+}
+MsgBucket::CUDAModelHandler::~CUDAModelHandler() { }
+
+__global__ void atomicHistogram1D(
+    const MsgBucket::MetaData *md,
+    unsigned int* bin_index,
+    unsigned int* bin_sub_index,
+    unsigned int *pbm_counts,
+    unsigned int message_count,
+    const IntT * __restrict__ key) {
+    unsigned int index = (blockIdx.x * blockDim.x) + threadIdx.x;
+    // Kill excess threads
+    if (index >= message_count) return;
+
+    const unsigned int hash = key[index] - md->min;
+    bin_index[index] = hash;
+    unsigned int bin_idx = atomicInc((unsigned int*)&pbm_counts[hash], 0xFFFFFFFF);
+    bin_sub_index[index] = bin_idx;
+}
+
+void MsgBucket::CUDAModelHandler::init(CUDAScatter &, const unsigned int &) {
+    allocateMetaDataDevicePtr();
+    // Set PBM to 0
+    gpuErrchk(cudaMemset(hd_data.PBM, 0x00000000, (bucketCount + 1) * sizeof(unsigned int)));
+}
+
+void MsgBucket::CUDAModelHandler::allocateMetaDataDevicePtr() {
+    if (d_data == nullptr) {
+        gpuErrchk(cudaMalloc(&d_histogram, (bucketCount + 1) * sizeof(unsigned int)));
+        gpuErrchk(cudaMalloc(&hd_data.PBM, (bucketCount + 1) * sizeof(unsigned int)));
+        gpuErrchk(cudaMalloc(&d_data, sizeof(MetaData)));
+        gpuErrchk(cudaMemcpy(d_data, &hd_data, sizeof(MetaData), cudaMemcpyHostToDevice));
+        resizeCubTemp();
+    }
+}
+
+void MsgBucket::CUDAModelHandler::freeMetaDataDevicePtr() {
+    if (d_data != nullptr) {
+        d_CUB_temp_storage_bytes = 0;
+        gpuErrchk(cudaFree(d_CUB_temp_storage));
+        gpuErrchk(cudaFree(d_histogram));
+        gpuErrchk(cudaFree(hd_data.PBM));
+        gpuErrchk(cudaFree(d_data));
+        d_CUB_temp_storage = nullptr;
+        d_histogram = nullptr;
+        hd_data.PBM = nullptr;
+        d_data = nullptr;
+        if (d_keys) {
+            d_keys_vals_storage_bytes = 0;
+            gpuErrchk(cudaFree(d_keys));
+            gpuErrchk(cudaFree(d_vals));
+            d_keys = nullptr;
+            d_vals = nullptr;
+        }
+    }
+}
+
+void MsgBucket::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const unsigned int &streamId) {
+    const unsigned int MESSAGE_COUNT = this->sim_message.getMessageCount();
+    resizeKeysVals(this->sim_message.getMaximumListSize());  // Resize based on allocated amount rather than message count
+    {  // Build atomic histogram
+        gpuErrchk(cudaMemset(d_histogram, 0x00000000, (bucketCount + 1) * sizeof(unsigned int)));
+        int blockSize;  // The launch configurator returned block size
+        gpuErrchk(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&blockSize, atomicHistogram1D, 32, 0));  // Randomly 32
+                                                                                                         // Round up according to array size
+        int gridSize = (MESSAGE_COUNT + blockSize - 1) / blockSize;
+        atomicHistogram1D << <gridSize, blockSize >> >(d_data, d_keys, d_vals, d_histogram, MESSAGE_COUNT,
+            reinterpret_cast<IntT*>(this->sim_message.getReadPtr("_key")));
+        gpuErrchk(cudaDeviceSynchronize());
+    }
+    {  // Scan (sum), to finalise PBM
+        gpuErrchk(cub::DeviceScan::ExclusiveSum(d_CUB_temp_storage, d_CUB_temp_storage_bytes, d_histogram, hd_data.PBM, bucketCount + 1));
+    }
+    {  // Reorder messages
+       // Copy messages from d_messages to d_messages_swap, in hash order
+        scatter.pbm_reorder(streamId, this->sim_message.getMessageDescription().variables, this->sim_message.getReadList(), this->sim_message.getWriteList(), MESSAGE_COUNT, d_keys, d_vals, hd_data.PBM);
+        this->sim_message.swap();
+    }
+    {  // Fill PBM and Message Texture Buffers
+       // gpuErrchk(cudaBindTexture(nullptr, d_texMessages, d_agents, sizeof(glm::vec4) * MESSAGE_COUNT));
+       // gpuErrchk(cudaBindTexture(nullptr, d_texPBM, d_PBM, sizeof(unsigned int) * (bucketCount + 1)));
+    }
+}
+
+void MsgBucket::CUDAModelHandler::resizeCubTemp() {
+    size_t bytesCheck = 0;
+    gpuErrchk(cub::DeviceScan::ExclusiveSum(nullptr, bytesCheck, hd_data.PBM, d_histogram, bucketCount + 1));
+    if (bytesCheck > d_CUB_temp_storage_bytes) {
+        if (d_CUB_temp_storage) {
+            gpuErrchk(cudaFree(d_CUB_temp_storage));
+        }
+        d_CUB_temp_storage_bytes = bytesCheck;
+        gpuErrchk(cudaMalloc(&d_CUB_temp_storage, d_CUB_temp_storage_bytes));
+    }
+}
+
+void MsgBucket::CUDAModelHandler::resizeKeysVals(const unsigned int &newSize) {
+    size_t bytesCheck = newSize * sizeof(unsigned int);
+    if (bytesCheck > d_keys_vals_storage_bytes) {
+        if (d_keys) {
+            gpuErrchk(cudaFree(d_keys));
+            gpuErrchk(cudaFree(d_vals));
+        }
+        d_keys_vals_storage_bytes = bytesCheck;
+        gpuErrchk(cudaMalloc(&d_keys, d_keys_vals_storage_bytes));
+        gpuErrchk(cudaMalloc(&d_vals, d_keys_vals_storage_bytes));
+    }
+}
+
+
+MsgBucket::Data::Data(const std::shared_ptr<const ModelData> &model, const std::string &message_name)
+    : MsgBruteForce::Data(model, message_name)
+    , lowerBound(0)
+    , upperBound(std::numeric_limits<IntT>::max()) {
+    description = std::unique_ptr<MsgBucket::Description>(new MsgBucket::Description(model, this));
+    variables.emplace("_key", Variable(1, static_cast<IntT>(0)));
+}
+MsgBucket::Data::Data(const std::shared_ptr<const ModelData> &model, const Data &other)
+    : MsgBruteForce::Data(model, other)
+    , lowerBound(other.lowerBound)
+    , upperBound(other.upperBound) {
+    description = std::unique_ptr<MsgBucket::Description>(model ? new MsgBucket::Description(model, this) : nullptr);
+    if (lowerBound == std::numeric_limits<IntT>::max()) {
+        THROW InvalidMessage("Minimum bound has not been set for bucket message '%s.", other.name.c_str());
+    }
+    if (upperBound == std::numeric_limits<IntT>::max()) {
+        THROW InvalidMessage("Maximum bound has not been set for bucket message '%s.", other.name.c_str());
+    }
+}
+MsgBucket::Data *MsgBucket::Data::clone(const std::shared_ptr<const ModelData> &newParent) {
+    return new Data(newParent, *this);
+}
+std::unique_ptr<MsgSpecialisationHandler> MsgBucket::Data::getSpecialisationHander(CUDAMessage &owner) const {
+    return std::unique_ptr<MsgSpecialisationHandler>(new CUDAModelHandler(owner));
+}
+std::type_index MsgBucket::Data::getType() const { return std::type_index(typeid(MsgBucket)); }
+
+
+MsgBucket::Description::Description(const std::shared_ptr<const ModelData> &_model, Data *const data)
+    : MsgBruteForce::Description(_model, data) { }
+
+void MsgBucket::Description::setLowerBound(const IntT &min) {
+    if (reinterpret_cast<Data *>(message)->upperBound != std::numeric_limits<IntT>::max() &&
+        min >= reinterpret_cast<Data *>(message)->upperBound) {
+        THROW InvalidArgument("Bucket messaging minimum bound must be lower than upper bound, %lld !< %lld.", min, static_cast<int64_t>(reinterpret_cast<Data *>(message)->upperBound));
+    }
+    reinterpret_cast<Data *>(message)->lowerBound = min;
+}
+void MsgBucket::Description::setUpperBound(const IntT &max) {
+    if (max <= reinterpret_cast<Data *>(message)->lowerBound) {
+        THROW InvalidArgument("Bucket messaging upperBound bound must be greater than lower bound, %lld !> %lld.", static_cast<int64_t>(max), static_cast<int64_t>(reinterpret_cast<Data *>(message)->lowerBound));
+    }
+    reinterpret_cast<Data *>(message)->upperBound = max;
+}
+void MsgBucket::Description::setBounds(const IntT &min, const IntT &max) {
+    if (max <= min) {
+        THROW InvalidArgument("Bucket messaging upperBound bound must be greater than lower bound, %lld !> %lld.", static_cast<int64_t>(max), static_cast<int64_t>(min));
+    }
+    reinterpret_cast<Data *>(message)->lowerBound = min;
+    reinterpret_cast<Data *>(message)->upperBound = max;
+}
+
+IntT MsgBucket::Description::getLowerBound() const {
+    return reinterpret_cast<Data *>(message)->lowerBound;
+}
+IntT MsgBucket::Description::getUpperBound() const {
+    return reinterpret_cast<Data *>(message)->upperBound;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,6 +94,7 @@ SET(TEST_CASE_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_array.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_array_2d.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_array_3d.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_bucket.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_append_truncate.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/util/test_compute_capability.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/util/test_nvtx.cu

--- a/tests/test_cases/runtime/messaging/test_bucket.cu
+++ b/tests/test_cases/runtime/messaging/test_bucket.cu
@@ -1,0 +1,301 @@
+/**
+* Tests of feature Spatial 3D messaging
+*
+* Tests cover:
+* > validation on MsgBucket::Description
+*/
+
+
+#include "gtest/gtest.h"
+#include "flamegpu/flame_api.h"
+
+namespace test_message_bucket {
+TEST(BucketMsgTest, DescriptionValidation) {
+    ModelDescription model("BucketMsgTest");
+    // Test description accessors
+    MsgBucket::Description &message = model.newMessage<MsgBucket>("buckets");
+    EXPECT_THROW(message.setUpperBound(0), InvalidArgument);  // Min should default to 0, this would mean no buckets
+    EXPECT_NO_THROW(message.setLowerBound(10));
+    EXPECT_NO_THROW(message.setUpperBound(11));
+    EXPECT_THROW(message.setUpperBound(0), InvalidArgument);  // Max < Min
+    EXPECT_NO_THROW(message.setUpperBound(12));
+    EXPECT_THROW(message.setLowerBound(13), InvalidArgument);  // Min > Max
+    EXPECT_THROW(message.setBounds(12, 12), InvalidArgument);  // Min == Max
+    EXPECT_THROW(message.setBounds(13, 12), InvalidArgument);  // Min > Max
+    EXPECT_NO_THROW(message.setBounds(12, 13));
+    EXPECT_NO_THROW(message.newVariable<int>("somevar"));
+}
+TEST(BucketMsgTest, DataValidation) {
+    ModelDescription model("BucketMsgTest");
+    // Test Data copy constructor knows when bounds have not been init
+    MsgBucket::Description &message = model.newMessage<MsgBucket>("buckets");
+    EXPECT_THROW(CUDAAgentModel c(model), InvalidMessage);  // Max not set
+    message.setLowerBound(1);  // It should default to 0
+    EXPECT_THROW(CUDAAgentModel c(model), InvalidMessage);  // Max not set
+    message.setUpperBound(10);
+    EXPECT_NO_THROW(CUDAAgentModel c(model));
+}
+TEST(BucketMsgTest, reserved_name) {
+    ModelDescription model("BucketMsgTest");
+    MsgBucket::Description &message = model.newMessage<MsgBucket>("buckets");
+    EXPECT_THROW(message.newVariable<int>("_"), ReservedName);
+}
+
+FLAMEGPU_AGENT_FUNCTION(out_mandatory, MsgNone, MsgBucket) {
+    int id = FLAMEGPU->getVariable<int>("id");
+    FLAMEGPU->message_out.setVariable<int>("id", id);
+    FLAMEGPU->message_out.setKey(12 + (id/2));
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(out_optional, MsgNone, MsgBucket) {
+    if (FLAMEGPU->getVariable<int>("do_output")) {
+        int id = FLAMEGPU->getVariable<int>("id");
+        FLAMEGPU->message_out.setVariable<int>("id", id);
+        FLAMEGPU->message_out.setKey(12 + (id/2));
+    }
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(in, MsgBucket, MsgNone) {
+    const int id = FLAMEGPU->getVariable<int>("id");
+    const int id_m1 = id == 0 ? 0 : id-1;
+    unsigned int count = 0;
+    unsigned int sum = 0;
+    for (auto &m : FLAMEGPU->message_in(12 + (id_m1/2))) {
+        count++;
+        sum += m.getVariable<int>("id");
+    }
+    FLAMEGPU->setVariable<unsigned int>("count1", count);
+    FLAMEGPU->setVariable<unsigned int>("count2", FLAMEGPU->message_in(12 + (id_m1/2)).size());
+    FLAMEGPU->setVariable<unsigned int>("sum", sum);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(in_range, MsgBucket, MsgNone) {
+    const int id = FLAMEGPU->getVariable<int>("id");
+    const int id_m4 = 12 + ((id / 8) * 4);
+    unsigned int count = 0;
+    unsigned int sum = 0;
+    for (auto &m : FLAMEGPU->message_in(id_m4, id_m4 + 4)) {
+        count++;
+        sum += m.getVariable<int>("id");
+    }
+    FLAMEGPU->setVariable<unsigned int>("count1", count);
+    FLAMEGPU->setVariable<unsigned int>("count2", FLAMEGPU->message_in(12 + id/2).size());
+    FLAMEGPU->setVariable<unsigned int>("sum", sum);
+    return ALIVE;
+}
+TEST(BucketMsgTest, Mandatory) {
+    const int AGENT_COUNT = 1024;
+    std::unordered_map<int, unsigned int> bucket_count;
+    std::unordered_map<int, unsigned int> bucket_sum;
+    // Construct model
+    ModelDescription model("BucketMsgTest");
+    {   // MsgBucket::Description
+        MsgBucket::Description &message = model.newMessage<MsgBucket>("bucket");
+        message.setBounds(12, 12 +(AGENT_COUNT/2));  // None zero lowerBound, to check that's working
+        message.newVariable<int>("id");
+    }
+    {   // AgentDescription
+        AgentDescription &agent = model.newAgent("agent");
+        agent.newVariable<int>("id");
+        agent.newVariable<unsigned int>("count1", 0);  // Number of messages iterated
+        agent.newVariable<unsigned int>("count2", 0);  // Size of bucket as returned by size()
+        agent.newVariable<unsigned int>("sum", 0);  // Sums of IDs in bucket
+        agent.newFunction("out", out_mandatory).setMessageOutput("bucket");
+        agent.newFunction("in", in).setMessageInput("bucket");
+    }
+    {   // Layer #1
+        LayerDescription &layer = model.newLayer();
+        layer.addAgentFunction(out_mandatory);
+    }
+    {   // Layer #2
+        LayerDescription &layer = model.newLayer();
+        layer.addAgentFunction(in);
+    }
+    CUDAAgentModel cuda_model(model);
+
+    AgentPopulation population(model.Agent("agent"), AGENT_COUNT);
+    // Initialise agents (TODO)
+    {
+        // Currently population has not been init, so generate an agent population on the fly
+        for (unsigned int i = 0; i < AGENT_COUNT; i++) {
+            AgentInstance instance = population.getNextInstance();
+            instance.setVariable<int>("id", i);
+            // Create it if it doesn't already exist
+            if (bucket_count.find(i/2) == bucket_count.end()) {
+                bucket_count.emplace(i/2, 0);
+                bucket_sum.emplace(i/2, 0);
+            }
+            bucket_count[i/2] += 1;
+            bucket_sum[i/2] += i;
+        }
+        cuda_model.setPopulationData(population);
+    }
+
+    // Execute a single step of the model
+    cuda_model.step();
+
+    // Recover the results and check they match what was expected
+    cuda_model.getPopulationData(population);
+    // Validate each agent has correct result
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = population.getInstanceAt(i);
+        const int id = ai.getVariable<int>("id");
+        const int id_m1 = id == 0 ? 0 : id-1;
+        unsigned int count1 = ai.getVariable<unsigned int>("count1");
+        unsigned int count2 = ai.getVariable<unsigned int>("count2");
+        unsigned int sum = ai.getVariable<unsigned int>("sum");
+        EXPECT_EQ(count1, bucket_count.at(id_m1/2));
+        EXPECT_EQ(count2, bucket_count.at(id_m1/2));
+        EXPECT_EQ(sum, bucket_sum.at(id_m1/2));
+    }
+}
+TEST(BucketMsgTest, Optional) {
+    const int AGENT_COUNT = 1024;
+    std::unordered_map<int, unsigned int> bucket_count;
+    std::unordered_map<int, unsigned int> bucket_sum;
+    // Construct model
+    ModelDescription model("BucketMsgTest");
+    {   // MsgBucket::Description
+        MsgBucket::Description &message = model.newMessage<MsgBucket>("bucket");
+        message.setBounds(12, 12 +(AGENT_COUNT/2));  // None zero lowerBound, to check that's working
+        message.newVariable<int>("id");
+    }
+    {   // AgentDescription
+        AgentDescription &agent = model.newAgent("agent");
+        agent.newVariable<int>("id");
+        agent.newVariable<int>("do_output");
+        agent.newVariable<unsigned int>("count1", 0);  // Number of messages iterated
+        agent.newVariable<unsigned int>("count2", 0);  // Size of bucket as returned by size()
+        agent.newVariable<unsigned int>("sum", 0);  // Sums of IDs in bucket
+        auto &af = agent.newFunction("out", out_optional);
+        af.setMessageOutput("bucket");
+        af.setMessageOutputOptional(true);
+        agent.newFunction("in", in).setMessageInput("bucket");
+    }
+    {   // Layer #1
+        LayerDescription &layer = model.newLayer();
+        layer.addAgentFunction(out_optional);
+    }
+    {   // Layer #2
+        LayerDescription &layer = model.newLayer();
+        layer.addAgentFunction(in);
+    }
+    CUDAAgentModel cuda_model(model);
+
+    AgentPopulation population(model.Agent("agent"), AGENT_COUNT);
+    // Initialise agents (TODO)
+    {
+        // Currently population has not been init, so generate an agent population on the fly
+        std::default_random_engine rng;
+        std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+        for (unsigned int i = 0; i < AGENT_COUNT; i++) {
+            int do_out =  dist(rng) > 0.3 ? 1 : 0;
+            AgentInstance instance = population.getNextInstance();
+            instance.setVariable<int>("id", i);
+            instance.setVariable<int>("do_output", do_out);
+            // Create it if it doesn't already exist
+            if (bucket_count.find(i/2) == bucket_count.end()) {
+                bucket_count.emplace(i/2, 0);
+                bucket_sum.emplace(i/2, 0);
+            }
+            if (do_out) {
+                bucket_count[i/2] += 1;
+                bucket_sum[i/2] += i;
+            }
+        }
+        cuda_model.setPopulationData(population);
+    }
+
+    // Execute a single step of the model
+    cuda_model.step();
+
+    // Recover the results and check they match what was expected
+    cuda_model.getPopulationData(population);
+    // Validate each agent has correct result
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = population.getInstanceAt(i);
+        const int id = ai.getVariable<int>("id");
+        const int id_m1 = id == 0 ? 0 : id-1;
+        unsigned int count1 = ai.getVariable<unsigned int>("count1");
+        unsigned int count2 = ai.getVariable<unsigned int>("count2");
+        unsigned int sum = ai.getVariable<unsigned int>("sum");
+        EXPECT_EQ(count1, bucket_count.at(id_m1/2));
+        EXPECT_EQ(count2, bucket_count.at(id_m1/2));
+        EXPECT_EQ(sum, bucket_sum.at(id_m1/2));
+    }
+}
+TEST(BucketMsgTest, Mandatory_Range) {
+    // Agent count must be multiple of 4
+    const int AGENT_COUNT = 1024;
+    std::unordered_map<int, unsigned int> bucket_count;
+    std::unordered_map<int, unsigned int> bucket_sum;
+    // Construct model
+    ModelDescription model("BucketMsgTest");
+    {   // MsgBucket::Description
+        MsgBucket::Description &message = model.newMessage<MsgBucket>("bucket");
+        message.setBounds(12, 12 +(AGENT_COUNT/2));  // None zero lowerBound, to check that's working
+        message.newVariable<int>("id");
+    }
+    {   // AgentDescription
+        AgentDescription &agent = model.newAgent("agent");
+        agent.newVariable<int>("id");
+        agent.newVariable<unsigned int>("count1", 0);  // Number of messages iterated
+        agent.newVariable<unsigned int>("count2", 0);  // Size of id bucket as returned by size()
+        agent.newVariable<unsigned int>("sum", 0);  // Sums of IDs in bucket
+        agent.newFunction("out", out_mandatory).setMessageOutput("bucket");
+        agent.newFunction("in", in_range).setMessageInput("bucket");
+    }
+    {   // Layer #1
+        LayerDescription &layer = model.newLayer();
+        layer.addAgentFunction(out_mandatory);
+    }
+    {   // Layer #2
+        LayerDescription &layer = model.newLayer();
+        layer.addAgentFunction(in_range);
+    }
+    CUDAAgentModel cuda_model(model);
+
+    AgentPopulation population(model.Agent("agent"), AGENT_COUNT);
+    // Initialise agents (TODO)
+    {
+        // Currently population has not been init, so generate an agent population on the fly
+        for (unsigned int i = 0; i < AGENT_COUNT; i++) {
+            AgentInstance instance = population.getNextInstance();
+            instance.setVariable<int>("id", i);
+            // Create it if it doesn't already exist
+            if (bucket_count.find(i/2) == bucket_count.end()) {
+                bucket_count.emplace(i/2, 0);
+                bucket_sum.emplace(i/2, 0);
+            }
+            bucket_count[i/2] += 1;
+            bucket_sum[i/2] += i;
+        }
+        cuda_model.setPopulationData(population);
+    }
+
+    // Execute a single step of the model
+    cuda_model.step();
+
+    // Recover the results and check they match what was expected
+    cuda_model.getPopulationData(population);
+    // Validate each agent has correct result
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = population.getInstanceAt(i);
+        const int id = ai.getVariable<int>("id");
+        const int id_m4 = ((id / 8) * 4);
+        unsigned int count1 = ai.getVariable<unsigned int>("count1");
+        unsigned int count2 = ai.getVariable<unsigned int>("count2");
+        unsigned int sum = ai.getVariable<unsigned int>("sum");
+        unsigned int _count1 = 0;
+        unsigned int _sum = 0;
+        for (int j = 0; j < 4; ++j) {
+            _count1 += bucket_count.at(id_m4 + j);
+            _sum += bucket_sum.at(id_m4 + j);
+        }
+        EXPECT_EQ(count1, _count1);
+        EXPECT_EQ(count2, bucket_count.at(id/2));
+        EXPECT_EQ(sum, _sum);
+    }
+}
+
+}  // namespace test_message_bucket


### PR DESCRIPTION
Messages are assigned a key which is an integer from a fixed range (This is currently `typedef int IntT`, as I was unsure if it was worth fixing it to a specific type or not).

Multiple messages may share a key, similarly keys may have no messages.

This is based off master, so will require reformating in order to work with Swig.

Closes #82