### PR TITLE
Prevent CMake from trusting symbolic link within Thrust to Cub on Windows.

### DIFF
--- a/cmake/Thrust.cmake
+++ b/cmake/Thrust.cmake
@@ -35,7 +35,8 @@ if(NOT thrust_POPULATED)
     # Set the location for where to find cub (ideally)
     set(EXPECTED_CUB_CONFIG_LOCATION "${thrust_SOURCE_DIR}/cub/cmake/")
     # Check that CUB exists at the expected (symlinked) location.
-    if(EXISTS "${EXPECTED_CUB_CONFIG_LOCATION}")
+    # We can't trust the symlink with visual studio
+    if(EXISTS "${EXPECTED_CUB_CONFIG_LOCATION}" AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         # Use the symlinked "default" location
         set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${thrust_SOURCE_DIR}/cub/cmake")
     else()


### PR DESCRIPTION
Unknown changes to Windows CI with version change 20200706.1 -> 20200714.1, caused the symbolic link to be created/detected, however visual studio was not working as though the symbolic link existed. Hence we now ignore the symbolic link if compiling with Visual Studio.

Had some help off Pete diagnosing this.