### PR TITLE
Graceful Device Errors

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -361,6 +361,11 @@ function(add_flamegpu_executable NAME SRC FLAMEGPU_ROOT PROJECT_ROOT IS_EXAMPLE)
         # target_link_libraries(${NAME} flamegpu2_visualiser)
         add_compile_definitions(VISUALISATION)
     endif()
+    
+    # This macro disables expensive runtime checks (when not in debug mode)
+    if (NO_SEATBELTS)
+        add_compile_definitions($<IF:$<CONFIG:Debug>,,NO_SEATBELTS>)
+    endif()
 
     # Flag the new linter target and the files to be linted.
     new_linter_target(${NAME} "${SRC}")
@@ -407,7 +412,12 @@ function(add_flamegpu_library NAME SRC FLAMEGPU_ROOT)
         # set(SDL2_DIR ${VISUALISATION_BUILD}/sdl2)
         # find_package(SDL2 REQUIRED)   
     endif()
-
+    
+    # This macro disables expensive runtime checks (when not in debug mode)
+    if (NO_SEATBELTS)
+        add_compile_definitions($<IF:$<CONFIG:Debug>,,NO_SEATBELTS>)
+    endif()
+    
     # Enable RDC
     set_property(TARGET ${NAME}  PROPERTY CUDA_SEPARABLE_COMPILATION ON)
 

--- a/include/flamegpu/exception/FGPUDeviceException.h
+++ b/include/flamegpu/exception/FGPUDeviceException.h
@@ -1,0 +1,56 @@
+#ifndef INCLUDE_FLAMEGPU_EXCEPTION_FGPUDEVICEEXCEPTION_H_
+#define INCLUDE_FLAMEGPU_EXCEPTION_FGPUDEVICEEXCEPTION_H_
+
+#include <cuda_runtime.h>
+#include <device_launch_parameters.h>
+#include <string>
+#include <type_traits>
+
+#include "flamegpu/gpu/CUDAScanCompaction.h"
+
+#ifndef NO_SEATBELTS
+
+#include "flamegpu/exception/FGPUDeviceException_device.h"
+
+/**
+ * Host 'singleton', owned 1 per CUDAAgentModel, provides facility for generating and checking DeviceExceptionBuffers
+ */
+class DeviceExceptionManager {
+ public:
+    DeviceExceptionManager();
+    /**
+     * Free all device memory
+     */
+    ~DeviceExceptionManager();
+    DeviceExceptionBuffer *getDevicePtr(const unsigned int &streamId);
+    void checkError(const std::string &function, const unsigned int &streamId);
+
+ private:
+    /**
+     * Generate a string representing the throw location
+     */
+    static std::string getLocationString(const DeviceExceptionBuffer &b);
+    /**
+     * Generate a string representing the error message
+     */
+    static std::string getErrorString(const DeviceExceptionBuffer &b);
+    /**
+     * Pointers to device buffers for error reporting
+     * 1 per stream
+     * nullptr until used
+     */
+    DeviceExceptionBuffer *d_buffer[CUDAScanCompaction::MAX_STREAMS];
+    /**
+     * Host buffers to copy error buffers back to
+     * 1 per stream
+     */
+    DeviceExceptionBuffer hd_buffer[CUDAScanCompaction::MAX_STREAMS];
+};
+#else
+/**
+ * Ignore the device error macro when NO_SEATBELTS is enabled
+ * These checks are costly to performance
+ */
+#define DTHROW(nop)
+#endif  // NO_SEATBELTS
+#endif  // INCLUDE_FLAMEGPU_EXCEPTION_FGPUDEVICEEXCEPTION_H_

--- a/include/flamegpu/exception/FGPUDeviceException_device.h
+++ b/include/flamegpu/exception/FGPUDeviceException_device.h
@@ -1,0 +1,195 @@
+#ifndef INCLUDE_FLAMEGPU_EXCEPTION_FGPUDEVICEEXCEPTION_DEVICE_H_
+#define INCLUDE_FLAMEGPU_EXCEPTION_FGPUDEVICEEXCEPTION_DEVICE_H_
+
+#include <cuda_runtime.h>
+#include <device_launch_parameters.h>
+
+#include <cstring>
+
+#ifndef NO_SEATBELTS
+/**
+ * This allows us to write DTHROW("My Error message: %d", 12); or similar to report an error in device code
+ */
+#define DTHROW DeviceException::create(__FILE__, __LINE__).setMessage
+
+/**
+ * This struct should exist in device memory per stream
+ * It holds buffers for outputting a deconstructed format string
+ */
+struct DeviceExceptionBuffer {
+    static const unsigned int MAX_ARGS = 20;
+    static const unsigned int ARG_BUFF_LEN = 4096;
+    static const unsigned int FORMAT_BUFF_LEN = 4096;
+    static const unsigned int FILE_BUFF_LEN = 1024;
+    static const unsigned int OUT_STRING_LEN = FORMAT_BUFF_LEN * 2;
+    /**
+     * The number of threads reporting error
+     */
+    unsigned int error_count;
+    char file_path[FILE_BUFF_LEN];
+    unsigned int line_no;
+    unsigned int block_id[3];
+    unsigned int thread_id[3];
+    /**
+     * The format string passed by the user to the printer
+     */
+    char format_string[FORMAT_BUFF_LEN];
+    /**
+     * The type size of each of the args passed to the printer
+     */
+    unsigned int format_args_sizes[MAX_ARGS];
+    /**
+     * A compact buffer of each of the args passed to the printer
+     * Their size corresponds to the matching array above
+     */
+    char format_args[ARG_BUFF_LEN];
+    /**
+     * The total number of args passed to the printer
+     */
+    unsigned int arg_count;
+    /**
+     * The total space used by the args
+     */
+    unsigned int arg_offset;
+};
+/**
+ * This class is used on device for reporting errors
+ * It should be used indirectly via the DTHROW macro
+ * e.g. DTHROW("MyError %d", 12);
+ */
+class DeviceException {
+ public:
+    /**
+     * Create and return a new device exception
+     */
+    __device__ static DeviceException create(const char *file, const unsigned int line) {
+        return {file, line};
+    }
+    /**
+     * Construct the formatted message for the exception
+     * This should be used like printf
+     * It does not support '%s', all other format args should work
+     */
+    template<typename... Args>
+    __device__ void setMessage(const char *format, Args... args) {
+        extern __shared__ DeviceExceptionBuffer* buff[];
+        // Only the thread which first reported error gets to output
+        if (hasError) {
+            // Only output once
+            if (buff[0]->format_string[0])
+                return;
+            // Copy the format string
+            unsigned int eos = 0;
+            for (eos = 0; eos < DeviceExceptionBuffer::FORMAT_BUFF_LEN; ++eos)
+                if (format[eos] == '\0')
+                    break;
+            memcpy(buff[0]->format_string, format, eos * sizeof(char));
+            // Process args
+            subformat_recurse(buff[0], args...);
+        }
+    }
+
+ private:
+    /**
+     * Called by setMessage
+     * This is required to process var args, it performs the processing of a single arg
+     */
+    template<typename T>
+    __device__ void subformat(DeviceExceptionBuffer *buff, T t);
+    /**
+     * Called by setMessage
+     * This is required to process var args, it performs recursion to scrape of each arg
+     */
+    template<typename T, typename... Args>
+    __device__ void subformat_recurse(DeviceExceptionBuffer *buff, const T &t, Args... args) {
+        // Call subformat with T
+        subformat(buff, t);
+        // Recurse with the rest of the list
+        subformat_recurse(buff, args...);
+    }
+    __device__ void subformat_recurse(DeviceExceptionBuffer *buff) { }
+    /**
+     * strlen() implementation for use on device
+     * The regular strlen function is not available on device
+     */
+    __device__ unsigned int strlen(const char *c) {
+        unsigned int eos = 0;
+        for (eos = 0; eos < DeviceExceptionBuffer::FORMAT_BUFF_LEN; ++eos)
+            if (*(c + eos) == '\0' || eos >= DeviceExceptionBuffer::FORMAT_BUFF_LEN)
+                break;
+        return eos + 1;  // Include the terminating character
+    }
+    /**
+     * Construct the DeviceException
+     * Start by atomically incrementing the error count
+     * If the previous value was 0, we own the error so report the error location
+     */
+    __device__ DeviceException(const char *file, const unsigned int line)
+        : hasError(!getErrorCount()) {
+        extern __shared__ DeviceExceptionBuffer* buff[];
+        if (hasError) {
+            // Copy file location
+            const size_t file_len = strlen(file);
+            memcpy(buff[0]->file_path, file, file_len);
+            // Copy line no
+            buff[0]->line_no = line;
+            // Copy block/thread indices
+            const uint3 bid3 = blockIdx;
+            memcpy(buff[0]->block_id, &bid3, sizeof(unsigned int) * 3);
+            const uint3 tid3 = threadIdx;
+            memcpy(buff[0]->thread_id, &tid3, sizeof(unsigned int) * 3);
+        }
+    }
+    /**
+     * Atomically increments the error flag and returns the return value (previous value)
+     */
+    __device__ unsigned int getErrorCount();
+    /**
+     * True if we won the race to report the error
+     */
+    const bool hasError;
+};
+template<typename T>
+__device__ void DeviceException::subformat(DeviceExceptionBuffer *buff, T t) {
+    if (buff->arg_count < DeviceExceptionBuffer::MAX_ARGS) {
+        if (buff->arg_offset + sizeof(T) <= DeviceExceptionBuffer::ARG_BUFF_LEN) {
+            // Copy arg size
+            buff->format_args_sizes[buff->arg_count] = sizeof(T);
+            // Copy arg value
+            memcpy(buff->format_args + buff->arg_offset, &t, sizeof(T));
+            // Update offsets
+            ++buff->arg_count;
+            buff->arg_offset += sizeof(T);
+        }
+    }
+}
+#if defined(__CUDACC_RTC__) || defined(FGPUDEVICEEXCEPTION_CU)
+template<>
+__device__ void DeviceException::subformat(DeviceExceptionBuffer *buff, const char *t) {
+    if (buff->arg_count < DeviceExceptionBuffer::MAX_ARGS) {
+        const unsigned int string_length = strlen(t);
+        if (buff->arg_offset + string_length <= DeviceExceptionBuffer::ARG_BUFF_LEN) {
+            // Copy arg size
+            buff->format_args_sizes[buff->arg_count] = string_length;
+            // Copy arg value
+            memcpy(buff->format_args + buff->arg_offset, t, string_length);
+            // Update offsets
+            ++buff->arg_count;
+            buff->arg_offset += string_length;
+        }
+    }
+}
+__device__ unsigned int DeviceException::getErrorCount() {
+    extern __shared__ DeviceExceptionBuffer* buff[];
+    // Are we the first exception
+    return atomicInc(&buff[0]->error_count, UINT_MAX);
+}
+#endif
+#else
+/**
+ * Ignore the device error macro when NO_SEATBELTS is enabled
+ * These checks are costly to performance
+ */
+#define DTHROW(nop)
+#endif  // NO_SEATBELTS
+#endif  // INCLUDE_FLAMEGPU_EXCEPTION_FGPUDEVICEEXCEPTION_DEVICE_H_

--- a/include/flamegpu/exception/FGPUException.h
+++ b/include/flamegpu/exception/FGPUException.h
@@ -399,5 +399,9 @@ DERIVED_FGPUException(VisualisationException, "An exception prevented the visual
  * Defines when std::weak_ptr::lock() returns nullptr
  */
 DERIVED_FGPUException(ExpiredWeakPtr, "Unable to convert weak pointer to shared pointer.");
+/**
+ * Defines an error reported from cuda device code (agent functions and agent function conditions)
+ */
+DERIVED_FGPUException(DeviceError, "Error reported from device code");
 
 #endif  // INCLUDE_FLAMEGPU_EXCEPTION_FGPUEXCEPTION_H_

--- a/include/flamegpu/flame_api.h
+++ b/include/flamegpu/flame_api.h
@@ -9,6 +9,7 @@
 #define INCLUDE_FLAMEGPU_FLAME_API_H_
 
 // include all host API classes (top level header from each module)
+#include "flamegpu/runtime/flamegpu_api.h"
 #include "flamegpu/model/ModelDescription.h"
 #include "flamegpu/model/AgentDescription.h"
 #include "flamegpu/model/AgentFunctionDescription.h"
@@ -19,7 +20,6 @@
 #include "flamegpu/model/SubEnvironmentDescription.h"
 #include "flamegpu/pop/AgentPopulation.h"
 #include "flamegpu/gpu/CUDAAgentModel.h"
-#include "flamegpu/runtime/flamegpu_api.h"
 #include "flamegpu/runtime/messaging.h"
 #include "flamegpu/runtime/AgentFunction_shim.h"
 #include "flamegpu/runtime/AgentFunctionCondition_shim.h"

--- a/include/flamegpu/gpu/CUDAAgentModel.h
+++ b/include/flamegpu/gpu/CUDAAgentModel.h
@@ -7,6 +7,8 @@
 #include <unordered_map>
 #include <map>
 
+
+#include "flamegpu/exception/FGPUDeviceException.h"
 #include "flamegpu/sim/Simulation.h"
 
 #include "flamegpu/gpu/CUDAAgent.h"
@@ -269,6 +271,12 @@ class CUDAAgentModel : public Simulation {
        * Held here for tracking when to release cuda memory
        */
       EnvironmentManager &environment;
+#ifndef NO_SEATBELTS
+      /**
+       * Provides buffers for device error checking
+       */
+      DeviceExceptionManager exception;
+#endif
       Singletons(Curve &curve, EnvironmentManager &environment) : curve(curve), environment(environment) { }
     } * singletons;
     /**

--- a/include/flamegpu/runtime/cuRVE/curve_rtc.h
+++ b/include/flamegpu/runtime/cuRVE/curve_rtc.h
@@ -16,11 +16,11 @@ class CurveRTCHost {
  public:
     CurveRTCHost();
 
-    void registerVariable(const char* variableName, unsigned int namespace_hash, const char* type, unsigned int elements = 1, bool read = true, bool write = true);
+    void registerVariable(const char* variableName, unsigned int namespace_hash, const char* type, size_t type_size, unsigned int elements = 1, bool read = true, bool write = true);
 
     void unregisterVariable(const char* variableName, unsigned int namespace_hash);
 
-    void registerEnvVariable(const char* variableName, unsigned int namespace_hash, ptrdiff_t offset, const char* type, unsigned int elements = 1);
+    void registerEnvVariable(const char* variableName, unsigned int namespace_hash, ptrdiff_t offset, const char* type, size_t type_size, unsigned int elements = 1);
 
     void unregisterEnvVariable(const char* variableName, unsigned int namespace_hash);
 
@@ -50,12 +50,14 @@ class CurveRTCHost {
         bool read;
         bool write;
         unsigned int elements;
+        size_t type_size;
     };
 
     struct RTCEnvVariableProperties {
         std::string type;
         unsigned int elements;
         ptrdiff_t offset;
+        size_t type_size;
     };
 
  private:

--- a/include/flamegpu/runtime/flamegpu_api.h
+++ b/include/flamegpu/runtime/flamegpu_api.h
@@ -1,8 +1,8 @@
 #ifndef INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_API_H_
 #define INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_API_H_
 
-#include "flamegpu/runtime/flamegpu_device_api.h"
 #include "flamegpu/runtime/flamegpu_host_api.h"
 #include "flamegpu/runtime/flamegpu_host_agent_api.h"
+#include "flamegpu/runtime/flamegpu_device_api.h"
 
 #endif  // INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_API_H_

--- a/include/flamegpu/runtime/flamegpu_device_api.h
+++ b/include/flamegpu/runtime/flamegpu_device_api.h
@@ -31,6 +31,9 @@ class FLAMEGPU_READ_ONLY_DEVICE_API {
     // Friends have access to TID() & TS_ID()
     template<typename AgentFunctionCondition>
     friend __global__ void agent_function_condition_wrapper(
+#ifndef NO_SEATBELTS
+        DeviceExceptionBuffer *error_buffer,
+#endif
         Curve::NamespaceHash,
         Curve::NamespaceHash,
         const unsigned int,
@@ -42,7 +45,10 @@ class FLAMEGPU_READ_ONLY_DEVICE_API {
      * @param instance_id_hash CURVE hash of the CUDAAgentModel's instance id
      * @param modelname_hash CURVE hash of the model's name
      */
-    __device__ FLAMEGPU_READ_ONLY_DEVICE_API(const Curve::NamespaceHash &instance_id_hash, const Curve::NamespaceHash &agentfuncname_hash, curandState *&d_rng)
+    __device__ FLAMEGPU_READ_ONLY_DEVICE_API(
+        const Curve::NamespaceHash &instance_id_hash,
+        const Curve::NamespaceHash &agentfuncname_hash,
+        curandState *&d_rng)
         : random(AgentRandom(&d_rng[TID()]))
         , environment(DeviceEnvironment(instance_id_hash))
         , agent_func_name_hash(agentfuncname_hash) { }
@@ -108,6 +114,9 @@ class FLAMEGPU_DEVICE_API : public FLAMEGPU_READ_ONLY_DEVICE_API{
     // Friends have access to TID() & TS_ID()
     template<typename AgentFunction, typename _MsgIn, typename _MsgOut>
     friend __global__ void agent_function_wrapper(
+#ifndef NO_SEATBELTS
+        DeviceExceptionBuffer *error_buffer,
+#endif
         Curve::NamespaceHash,
         Curve::NamespaceHash,
         Curve::NamespaceHash,

--- a/include/flamegpu/runtime/messaging/Array2D.h
+++ b/include/flamegpu/runtime/messaging/Array2D.h
@@ -269,7 +269,11 @@ class MsgArray2D {
          * @note radius of 0 is unsupported
          */
         inline __device__ Filter operator() (const size_type &x, const size_type &y, const size_type &radius = 1) const {
-            assert(radius > 0);  // Radius of 0 is bad
+#ifndef NO_SEATBELTS
+            if (radius == 0) {
+                DTHROW("%llu is not a valid radius for accessing Array2D message lists.\n", radius);
+            }
+#endif
             return Filter(metadata, combined_hash, x, y, radius);
         }
         /**
@@ -292,6 +296,11 @@ class MsgArray2D {
             return metadata->length;
         }
         __device__ Message at(const size_type &x, const size_type &y) const {
+#ifndef NO_SEATBELTS
+            if (x >= metadata->dimensions[0] || y >= metadata->dimensions[1]) {
+                DTHROW("Index is out of bounds for Array2D messagelist ([%u, %u] >= [%u, %u]).\n", x, y, metadata->dimensions[0], metadata->dimensions[1]);
+            }
+#endif
             const size_type index_1d =
                 y * metadata->dimensions[0] +
                 x;

--- a/include/flamegpu/runtime/messaging/Array3D.h
+++ b/include/flamegpu/runtime/messaging/Array3D.h
@@ -279,7 +279,11 @@ class MsgArray3D {
          * @note radius of 0 is unsupported
          */
         inline __device__ Filter operator() (const size_type &x, const size_type &y, const size_type &z, const size_type &radius = 1) const {
-            assert(radius > 0);  // Radius of 0 is bad
+#ifndef NO_SEATBELTS
+            if (radius == 0) {
+                DTHROW("%llu is not a valid radius for accessing Array3D message lists.\n", radius);
+            }
+#endif
             return Filter(metadata, combined_hash, x, y, z, radius);
         }
         /**
@@ -308,6 +312,11 @@ class MsgArray3D {
             return metadata->length;
         }
         __device__ Message at(const size_type &x, const size_type &y, const size_type &z) const {
+#ifndef NO_SEATBELTS
+            if (x >= metadata->dimensions[0] || y >= metadata->dimensions[1] || z >= metadata->dimensions[2]) {
+                DTHROW("Index is out of bounds for Array3D messagelist ([%u, %u, %u] >= [%u, %u, %u]).\n", x, y, z, metadata->dimensions[0], metadata->dimensions[1], metadata->dimensions[2]);
+            }
+#endif
             const size_type index_1d =
                 z * metadata->dimensions[0] * metadata->dimensions[1]  +
                 y * metadata->dimensions[0]  +

--- a/include/flamegpu/runtime/utility/AgentRandom.cuh
+++ b/include/flamegpu/runtime/utility/AgentRandom.cuh
@@ -5,6 +5,7 @@
 #include <cassert>
 
 #include "flamegpu/exception/FGPUStaticAssert.h"
+#include "flamegpu/exception/FGPUDeviceException.h"
 
 /**
  * Utility for accessing random generation within agent functions
@@ -99,14 +100,29 @@ __forceinline__ __device__ double AgentRandom::logNormal(const double& mean, con
 template<typename T>
 __forceinline__ __device__ T AgentRandom::uniform(const T& min, const T& max) const {
     static_assert(FGPU_SA::_Is_IntType<T>::value, "Invalid template argument for AgentRandom::uniform(const T& lowerBound, const T& max)");
+#ifndef NO_SEATBELTS
+    if (min > max) {
+        DTHROW("Invalid arguments passed to AgentRandom::uniform(), %lld > %lld\n", static_cast<int64_t>(min), static_cast<int64_t>(max));
+    }
+#endif
     return static_cast<T>(min + (max - min) * uniform<float>());
 }
 template<>
 __forceinline__ __device__ int64_t AgentRandom::uniform(const int64_t& min, const int64_t& max) const {
+#ifndef NO_SEATBELTS
+    if (min > max) {
+        DTHROW("Invalid arguments passed to AgentRandom::uniform(), %lld > %lld\n", static_cast<int64_t>(min), static_cast<int64_t>(max));
+    }
+#endif
     return static_cast<int64_t>(min + (max - min) * uniform<double>());
 }
 template<>
 __forceinline__ __device__ uint64_t AgentRandom::uniform(const uint64_t& min, const uint64_t& max) const {
+#ifndef NO_SEATBELTS
+    if (min > max) {
+        DTHROW("Invalid arguments passed to AgentRandom::uniform(), %lld > %lld\n", static_cast<int64_t>(min), static_cast<int64_t>(max));
+    }
+#endif
     return static_cast<uint64_t>(min + (max - min) * uniform<double>());
 }
 #endif  // INCLUDE_FLAMEGPU_RUNTIME_UTILITY_AGENTRANDOM_CUH_

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,10 @@ endif()
 # Name the project and set languages
 project(flamegpu2 CUDA CXX)
 
+# Option to enable/disable runtime checks which may impact performance
+# This will primarily prevent device code from reporting errors
+option(NO_SEATBELTS "Disable runtime checks which harm performance for release/profile builds.\nThis should only be enabled after a model is known to be correct." OFF)
+
 # Include common rules.
 include(${FLAMEGPU_ROOT}/cmake/common.cmake)
 include(${FLAMEGPU_ROOT}/cmake/doxygen.cmake)
@@ -70,6 +74,8 @@ SET(SRC_INCLUDE
     ${FLAMEGPU_ROOT}/include/flamegpu/io/xmlWriter.h
     ${FLAMEGPU_ROOT}/include/flamegpu/io/factory.h
     ${FLAMEGPU_ROOT}/include/flamegpu/exception/FGPUException.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/exception/FGPUDeviceException.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/exception/FGPUDeviceException_device.h
     ${FLAMEGPU_ROOT}/include/flamegpu/exception/FGPUStaticAssert.h
     ${FLAMEGPU_ROOT}/include/flamegpu/model/LayerDescription.h
     ${FLAMEGPU_ROOT}/include/flamegpu/model/ModelData.h
@@ -138,6 +144,7 @@ SET(SRC_INCLUDE
 )
 SET(SRC_FLAMEGPU2
     ${FLAMEGPU_ROOT}/src/flamegpu/exception/FGPUException.cpp
+    ${FLAMEGPU_ROOT}/src/flamegpu/exception/FGPUDeviceException.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/model/LayerDescription.cpp
     ${FLAMEGPU_ROOT}/src/flamegpu/model/ModelData.cpp
     ${FLAMEGPU_ROOT}/src/flamegpu/model/AgentData.cpp
@@ -217,6 +224,12 @@ source_group(TREE ${FLAMEGPU_ROOT}/src/flamegpu PREFIX headers FILES ${T_SRC})
 set(T_SRC "${SRC_FLAMEGPU2}")
 list(FILTER T_SRC EXCLUDE REGEX ".*\.(h|hpp|cuh)$")
 source_group(TREE ${FLAMEGPU_ROOT}/src/flamegpu PREFIX src FILES ${T_SRC})
+set(T_SRC "${SRC_EXTERNAL}")
+list(FILTER T_SRC INCLUDE REGEX ".*\.(h|hpp|cuh)$")
+source_group(TREE ${FLAMEGPU_ROOT}/include PREFIX external FILES ${T_SRC})
+set(T_SRC "${SRC_EXTERNAL}")
+list(FILTER T_SRC EXCLUDE REGEX ".*\.(h|hpp|cuh)$")
+source_group(TREE ${FLAMEGPU_ROOT}/include PREFIX external FILES ${T_SRC})
 
 # Define which source files are required for the target executable
 add_flamegpu_library("${PROJECT_NAME}" "${ALL_SRC}" "${FLAMEGPU_ROOT}")

--- a/src/flamegpu/exception/FGPUDeviceException.cu
+++ b/src/flamegpu/exception/FGPUDeviceException.cu
@@ -1,0 +1,205 @@
+// This define forces the header to include the DeviceException::subformat() template specialisation for const char *
+// It needs to be in the header so that RTC can also use it
+#define FGPUDEVICEEXCEPTION_CU
+#include "flamegpu/exception/FGPUDeviceException.h"
+
+#include "flamegpu/gpu/CUDAErrorChecking.h"
+#ifndef NO_SEATBELTS
+
+DeviceExceptionManager::DeviceExceptionManager()
+    : d_buffer()
+    , hd_buffer() {
+    memset (&d_buffer, 0, sizeof(d_buffer));
+    memset (&hd_buffer, 0, sizeof(hd_buffer));
+}
+DeviceExceptionManager::~DeviceExceptionManager() {
+    for (auto &i : d_buffer) {
+        gpuErrchk(cudaFree(i));
+    }
+}
+DeviceExceptionBuffer *DeviceExceptionManager::getDevicePtr(const unsigned int &streamId) {
+    if (streamId >= CUDAScanCompaction::MAX_STREAMS) {
+        THROW OutOfBoundsException("Stream id %u is out of bounds, %u >= %u, "
+        "in FGPUDeviceException::getDevicePtr()\n", streamId, streamId, CUDAScanCompaction::MAX_STREAMS);
+    }
+    if (!d_buffer[streamId]) {
+        gpuErrchk(cudaMalloc(&d_buffer[streamId], sizeof(DeviceExceptionBuffer)));
+    }
+    // Memset and return buffer
+    gpuErrchk(cudaMemset(d_buffer[streamId], 0, sizeof(DeviceExceptionBuffer)));
+    memset(&hd_buffer[streamId], 0, sizeof(DeviceExceptionBuffer));
+    return d_buffer[streamId];
+}
+void DeviceExceptionManager::checkError(const std::string &function, const unsigned int &streamId) {
+    if (streamId >= CUDAScanCompaction::MAX_STREAMS) {
+        THROW OutOfBoundsException("Stream id %u is out of bounds, %u >= %u, "
+        "in FGPUDeviceException::checkError()\n", streamId, streamId, CUDAScanCompaction::MAX_STREAMS);
+    }
+    if (d_buffer[streamId]) {
+        // Grab buffer from device
+        cudaMemcpy(&hd_buffer[streamId], d_buffer[streamId], sizeof(DeviceExceptionBuffer), cudaMemcpyDeviceToHost);
+        // If there is a reported error count
+        if (hd_buffer[streamId].error_count) {
+            std::string location_string = getLocationString(hd_buffer[streamId]);
+            std::string error_string = getErrorString(hd_buffer[streamId]);
+            throw DeviceError(
+            "Device function '%s' reported %u errors.\nFirst error:\n%s:\n%s",
+            function.c_str(), hd_buffer[streamId].error_count, location_string.c_str(), error_string.c_str());
+        }
+    } else {
+        THROW OutOfBoundsException("FGPUDeviceExceptionBuffer for stream %u has not been allocated, "
+        "in FGPUDeviceException::checkError()\n", streamId, streamId, CUDAScanCompaction::MAX_STREAMS);
+    }
+}
+std::string DeviceExceptionManager::getLocationString(const DeviceExceptionBuffer &b) {
+    char buff[DeviceExceptionBuffer::OUT_STRING_LEN];
+    snprintf(buff, DeviceExceptionBuffer::OUT_STRING_LEN, "%s(%u)[%u,%u,%u][%u,%u,%u]",
+        b.file_path, b.line_no,
+        b.block_id[0], b.block_id[1], b.block_id[2],
+        b.thread_id[0], b.thread_id[1], b.thread_id[2]);
+    return buff;
+}
+std::string DeviceExceptionManager::getErrorString(const DeviceExceptionBuffer &b) {
+    /**
+     * This buffer is used to copy sub-format strings into before we send them to snprintf
+     * This saves us needing to set the final+1 char to '\0'
+     */
+    char temp_buffer[DeviceExceptionBuffer::FORMAT_BUFF_LEN];
+    /**
+     * This is the buffer into which we construct the string to be returned
+     */
+    char out_buffer[DeviceExceptionBuffer::OUT_STRING_LEN];
+    memset(out_buffer, 0, DeviceExceptionBuffer::FORMAT_BUFF_LEN);
+    // Progress through b.format_string
+    unsigned int format_buffer_index = 0;
+    // Progress through out_buffer
+    unsigned int out_index = 0;
+    // Progress through b.format_args_sizes
+    unsigned int arg_no = 0;
+    // Progress through b.format_args
+    unsigned int arg_offset = 0;
+    // Whilst there is still work to be done, we are still in range of format string and all other structures used
+    while (b.format_string[format_buffer_index] != '\0' &&
+           format_buffer_index < DeviceExceptionBuffer::FORMAT_BUFF_LEN &&
+           out_index < DeviceExceptionBuffer::FORMAT_BUFF_LEN &&
+           arg_no < DeviceExceptionBuffer::MAX_ARGS) {
+        // If we find the start of a sub format string
+        if (b.format_string[format_buffer_index] == '%') {
+            // Find the next sub format start, or end of entire format string
+            unsigned int format_end = format_buffer_index + 1;
+            char format_type = '\0';
+            while (b.format_string[format_end] != '%' &&
+                  b.format_string[format_end] != '\0' &&
+                  format_end < DeviceExceptionBuffer::FORMAT_BUFF_LEN) {
+                // Detect the format type, we will use this later
+                if (format_type == '\0') {
+                    switch (b.format_string[format_end]) {
+                        // This is every format specifier supported by the printf family of functions
+                        case 'd':
+                        case 'i':
+                        case 'u':
+                        case 'o':
+                        case 'x':
+                        case 'X':
+                        case 'f':
+                        case 'e':
+                        case 'g':
+                        case 'G':
+                        case 'a':
+                        case 'A':
+                        case 'c':
+                        case 's':
+                        case 'p':
+                        case 'n':
+                            format_type = b.format_string[format_end];
+                            break;
+                    }
+                }
+                ++format_end;
+            }
+            // Sub format string bounds have been found
+            // Copy the sub format string into a temporary buffer
+            memset(temp_buffer, 0, DeviceExceptionBuffer::FORMAT_BUFF_LEN);
+            memcpy(temp_buffer, b.format_string + format_buffer_index, format_end - format_buffer_index);
+            // Now send this substring to the formatter to process
+            // Cast it to the correct type first
+            // (This assumes snprintf never returns negative)
+            switch (format_type) {
+                case 'd':
+                case 'i': {
+                    // Signed integer
+                    if (b.format_args_sizes[arg_no] == 4) {
+                        out_index += snprintf(out_buffer + out_index, DeviceExceptionBuffer::OUT_STRING_LEN - out_index, temp_buffer, *reinterpret_cast<const int32_t*>(b.format_args+arg_offset));
+                    } else {
+                        out_index += snprintf(out_buffer + out_index, DeviceExceptionBuffer::OUT_STRING_LEN - out_index, temp_buffer, *reinterpret_cast<const int64_t*>(b.format_args+arg_offset));
+                    }
+                    break;
+                }
+                case 'u':
+                case 'o':
+                case 'x':
+                case 'X': {
+                    // Unsigned integer
+                    if (b.format_args_sizes[arg_no] == 4) {
+                        out_index += snprintf(out_buffer + out_index, DeviceExceptionBuffer::OUT_STRING_LEN - out_index, temp_buffer, *reinterpret_cast<const uint32_t*>(b.format_args+arg_offset));
+                    } else {
+                        out_index += snprintf(out_buffer + out_index, DeviceExceptionBuffer::OUT_STRING_LEN - out_index, temp_buffer, *reinterpret_cast<const uint64_t*>(b.format_args+arg_offset));
+                    }
+                    break;
+                }
+                case 'f':
+                case 'e':
+                case 'g':
+                case 'G':
+                case 'a':
+                case 'A': {
+                    // Floating point
+                    if (b.format_args_sizes[arg_no] == 4) {
+                        out_index += snprintf(out_buffer + out_index, DeviceExceptionBuffer::OUT_STRING_LEN - out_index, temp_buffer, *reinterpret_cast<const float*>(b.format_args+arg_offset));
+                    } else {
+                        out_index += snprintf(out_buffer + out_index, DeviceExceptionBuffer::OUT_STRING_LEN - out_index, temp_buffer, *reinterpret_cast<const double*>(b.format_args+arg_offset));
+                    }
+                    break;
+                }
+                case 'c': {
+                    // Char
+                    out_index += snprintf(out_buffer + out_index, DeviceExceptionBuffer::OUT_STRING_LEN - out_index, temp_buffer, *reinterpret_cast<const char*>(b.format_args+arg_offset));
+                    break;
+                }
+                case 's': {
+                    // Char string
+                    out_index += snprintf(out_buffer + out_index, DeviceExceptionBuffer::OUT_STRING_LEN - out_index, temp_buffer, reinterpret_cast<const char*>(b.format_args+arg_offset));
+                    break;
+                }
+                case 'p': {
+                    // Pointer
+                    out_index += snprintf(out_buffer + out_index, DeviceExceptionBuffer::OUT_STRING_LEN - out_index, temp_buffer, reinterpret_cast<const void*>(b.format_args+arg_offset));
+                    break;
+                }
+                case 'n': {
+                    // No of chars written (signed pointer to have value written back to)
+                    if (b.format_args_sizes[arg_no] == 4) {
+                        out_index += snprintf(out_buffer + out_index, DeviceExceptionBuffer::OUT_STRING_LEN - out_index, temp_buffer, reinterpret_cast<const int32_t*>(b.format_args+arg_offset));
+                    } else {
+                        out_index += snprintf(out_buffer + out_index, DeviceExceptionBuffer::OUT_STRING_LEN - out_index, temp_buffer, reinterpret_cast<const int64_t*>(b.format_args+arg_offset));
+                    }
+                    break;
+                }
+            }
+            // Update arg counters
+            arg_offset += b.format_args_sizes[arg_no];
+            ++arg_no;
+            // Update pointer into main format string and continue loop
+            format_buffer_index = format_end;
+        } else {
+            // Copy the single char
+            // This will only happen until we hit first sub format string
+            out_buffer[out_index] = b.format_string[format_buffer_index];
+            ++out_index;
+            ++format_buffer_index;
+        }
+    }
+    return out_buffer;
+}
+
+#endif  // NO_SEATBELTS

--- a/src/flamegpu/io/xmlWriter.cpp
+++ b/src/flamegpu/io/xmlWriter.cpp
@@ -100,6 +100,7 @@ int xmlWriter::writeStates(bool prettyPrint) {
             // Verbose output
             pListElement = doc.NewElement("verbose");
             pListElement->SetText(sim_cfg.verbose);
+            pSimCfg->InsertEndChild(pListElement);
             // Verbose output
             pListElement = doc.NewElement("console_mode");
             pListElement->SetText(sim_cfg.console_mode);

--- a/src/flamegpu/runtime/messaging/Array.cu
+++ b/src/flamegpu/runtime/messaging/Array.cu
@@ -9,7 +9,11 @@
 __device__ void MsgArray::Out::setIndex(const size_type &id) const {
     unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
 
-    // Todo: checking if the output message type is single or optional?  (d_message_type)
+#ifndef NO_SEATBELTS
+    if (id >= metadata->length) {
+        DTHROW("MsgArray index [%u] is out of bounds [%u]\n", id, metadata->length);
+    }
+#endif
 
     // set the variable using curve
     Curve::setVariable<size_type>("___INDEX", combined_hash, id, index);

--- a/src/flamegpu/runtime/messaging/Array3D.cu
+++ b/src/flamegpu/runtime/messaging/Array3D.cu
@@ -2,6 +2,7 @@
 #include "flamegpu/model/AgentDescription.h"  // Used by Move-Assign
 #include "flamegpu/gpu/CUDAMessage.h"
 #include "flamegpu/gpu/CUDAScatter.h"
+#include "flamegpu/exception/FGPUDeviceException_device.h"
 
 /**
 * Sets the array index to store the message in
@@ -12,11 +13,13 @@ __device__ void MsgArray3D::Out::setIndex(const size_type &x, const size_type &y
         z * metadata->dimensions[0] * metadata->dimensions[1] +
         y * metadata->dimensions[0] +
         x;
+#ifndef NO_SEATBELTS
     if (x >= metadata->dimensions[0] ||
         y >= metadata->dimensions[1] ||
         z >= metadata->dimensions[2]) {
-        index_1d = metadata->length;  // Put message in invalid bin, will be caught during sort
+        DTHROW("MsgArray3D index [%u, %u, %u] is out of bounds [%u, %u, %u]\n", x, y, z, metadata->dimensions[0], metadata->dimensions[1], metadata->dimensions[2]);
     }
+#endif
 
     // set the variable using curve
     Curve::setVariable<size_type>("___INDEX", combined_hash, index_1d, index);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 # Prepare list of source files
 SET(TEST_CASE_SRC
     # ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_func_pointer.cu # Does not currently build
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/exception/test_device_exception.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/gpu/test_cuda_agent_model.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/gpu/test_gpu_validation.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/gpu/test_cuda_subagent.cu
@@ -100,6 +101,7 @@ SET(TEST_CASE_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/util/test_nvtx.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/util/test_dependency_versions.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_rtc_device_api.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/exception/test_rtc_device_exception.cu
 )
 SET(DEV_TEST_CASE_SRC
 )

--- a/tests/test_cases/exception/test_device_exception.cu
+++ b/tests/test_cases/exception/test_device_exception.cu
@@ -1,0 +1,1095 @@
+
+#include "gtest/gtest.h"
+
+#include "flamegpu/flame_api.h"
+#include "flamegpu/runtime/flamegpu_api.h"
+
+// These tests wont work if built with NO_SEATBELTS, so mark them all as disabled instead
+#ifdef NO_SEATBELTS
+#undef TEST_F
+#define TEST_F(test_fixture, test_name)\
+  GTEST_TEST_(test_fixture, DISABLED_ ## test_name, test_fixture, \
+              ::testing::internal::GetTypeId<test_fixture>())
+#endif
+
+namespace {
+
+class MiniSim {
+ public:
+    MiniSim() :
+        model("model"),
+        agent(model.newAgent("agent")) {
+        agent.newVariable<int>("int");
+        agent.newVariable<int, 2>("array");
+        model.Environment().add<int>("int", 12);
+        model.Environment().add<int, 2>("array", {12, 13});
+    }
+    void run(int steps = 2) {
+        // CudaModel must be declared here
+        // As the initial call to constructor fixes the agent population
+        // This means if we haven't called model.newAgent(agent) first
+        CUDAAgentModel cuda_model(model);
+        cuda_model.SimulationConfig().steps = steps;
+        // This fails as agentMap is empty
+        AgentPopulation population(agent, 1);
+        population.getNextInstance();  // Default init 1st and only agent
+        cuda_model.setPopulationData(population);
+        EXPECT_THROW(cuda_model.simulate(), DeviceError);
+    }
+    template<typename T>
+    void addFunc(T func) {
+        agent.newFunction("name", func);
+        model.newLayer().addAgentFunction(func);
+    }
+    template<typename T, typename C>
+    void addFuncCdn(T func, C cdn) {
+        auto &fn = agent.newFunction("name", func);
+        fn.setFunctionCondition(cdn);
+        model.newLayer().addAgentFunction(fn);
+    }
+    template<typename T>
+    void addAgentOutFunc(T func) {
+        auto &fn = agent.newFunction("name", func);
+        fn.setAgentOutput("agent");
+        model.newLayer().addAgentFunction(func);
+    }
+    template<typename Msg, typename T>
+    void addMsgOutFunc(T func) {
+        typename Msg::Description &msg = model.newMessage<Msg>("message");
+        msg.template newVariable<int>("int");
+        auto &fn = agent.newFunction("name", func);
+        fn.setMessageOutput("message");
+        model.newLayer().addAgentFunction(func);
+    }
+    template<typename T>
+    void addMsgS2DOutFunc(T func) {
+        MsgSpatial2D::Description &msg = model.newMessage<MsgSpatial2D>("message");
+        msg.setMin(-1, -1);
+        msg.setMax(1, 1);
+        msg.setRadius(1);
+        msg.newVariable<int>("int");
+        auto &fn = agent.newFunction("name", func);
+        fn.setMessageOutput("message");
+        model.newLayer().addAgentFunction(func);
+    }
+    template<typename T>
+    void addMsgS3DOutFunc(T func) {
+        MsgSpatial3D::Description &msg = model.newMessage<MsgSpatial3D>("message");
+        msg.setMin(-1, -1, -2);
+        msg.setMax(1, 1, 1);
+        msg.setRadius(1);
+        msg.newVariable<int>("int");
+        auto &fn = agent.newFunction("name", func);
+        fn.setMessageOutput("message");
+        model.newLayer().addAgentFunction(func);
+    }
+    template<typename T>
+    void addMsgA1DOutFunc(T func) {
+        MsgArray::Description &msg = model.newMessage<MsgArray>("message");
+        msg.setLength(10);
+        msg.newVariable<int>("int");
+        auto &fn = agent.newFunction("name", func);
+        fn.setMessageOutput("message");
+        model.newLayer().addAgentFunction(func);
+    }
+    template<typename T>
+    void addMsgA2DOutFunc(T func) {
+        MsgArray2D::Description &msg = model.newMessage<MsgArray2D>("message");
+        msg.setDimensions(10, 10);
+        msg.newVariable<int>("int");
+        auto &fn = agent.newFunction("name", func);
+        fn.setMessageOutput("message");
+        model.newLayer().addAgentFunction(func);
+    }
+    template<typename T>
+    void addMsgA3DOutFunc(T func) {
+        MsgArray3D::Description &msg = model.newMessage<MsgArray3D>("message");
+        msg.setDimensions(10, 10, 10);
+        msg.newVariable<int>("int");
+        auto &fn = agent.newFunction("name", func);
+        fn.setMessageOutput("message");
+        model.newLayer().addAgentFunction(func);
+    }
+    template<typename T>
+    void addMsgBucketOutFunc(T func) {
+        MsgBucket::Description &msg = model.newMessage<MsgBucket>("message");
+        msg.setBounds(0, 1023);
+        msg.newVariable<int>("int");
+        auto &fn = agent.newFunction("name", func);
+        fn.setMessageOutput("message");
+        model.newLayer().addAgentFunction(func);
+    }
+
+    template<typename Msg, typename T1, typename T2>
+    void addMsgInFunc(T1 out_func, T2 in_func) {
+        auto &msg = model.newMessage<Msg>("message");
+        msg.template newVariable<int>("int");
+        {
+            auto &fn = agent.newFunction("out_name", out_func);
+            fn.setMessageOutput("message");
+            model.newLayer().addAgentFunction(out_func);
+        }
+        {
+            auto &fn = agent.newFunction("in_name", in_func);
+            fn.setMessageInput("message");
+            model.newLayer().addAgentFunction(in_func);
+        }
+    }
+    template<typename T1, typename T2>
+    void addMsgS2DInFunc(T1 out_func, T2 in_func) {
+        MsgSpatial2D::Description &msg = model.newMessage<MsgSpatial2D>("message");
+        msg.setMin(-1, -1);
+        msg.setMax(1, 1);
+        msg.setRadius(1);
+        msg.template newVariable<int>("int");
+        {
+            auto &fn = agent.newFunction("out_name", out_func);
+            fn.setMessageOutput("message");
+            model.newLayer().addAgentFunction(out_func);
+        }
+        {
+            auto &fn = agent.newFunction("in_name", in_func);
+            fn.setMessageInput("message");
+            model.newLayer().addAgentFunction(in_func);
+        }
+    }
+    template<typename T1, typename T2>
+    void addMsgS3DInFunc(T1 out_func, T2 in_func) {
+        MsgSpatial3D::Description &msg = model.newMessage<MsgSpatial3D>("message");
+        msg.setMin(-1, -1, -1);
+        msg.setMax(1, 1, 1);
+        msg.setRadius(1);
+        msg.template newVariable<int>("int");
+        {
+            auto &fn = agent.newFunction("out_name", out_func);
+            fn.setMessageOutput("message");
+            model.newLayer().addAgentFunction(out_func);
+        }
+        {
+            auto &fn = agent.newFunction("in_name", in_func);
+            fn.setMessageInput("message");
+            model.newLayer().addAgentFunction(in_func);
+        }
+    }
+    template<typename T1, typename T2>
+    void addMsgA1DInFunc(T1 out_func, T2 in_func) {
+        MsgArray::Description &msg = model.newMessage<MsgArray>("message");
+        msg.setLength(10);
+        msg.template newVariable<int>("int");
+        {
+            auto &fn = agent.newFunction("out_name", out_func);
+            fn.setMessageOutput("message");
+            model.newLayer().addAgentFunction(out_func);
+        }
+        {
+            auto &fn = agent.newFunction("in_name", in_func);
+            fn.setMessageInput("message");
+            model.newLayer().addAgentFunction(in_func);
+        }
+    }
+    template<typename T1, typename T2>
+    void addMsgA2DInFunc(T1 out_func, T2 in_func) {
+        MsgArray2D::Description &msg = model.newMessage<MsgArray2D>("message");
+        msg.setDimensions(10, 10);
+        msg.template newVariable<int>("int");
+        {
+            auto &fn = agent.newFunction("out_name", out_func);
+            fn.setMessageOutput("message");
+            model.newLayer().addAgentFunction(out_func);
+        }
+        {
+            auto &fn = agent.newFunction("in_name", in_func);
+            fn.setMessageInput("message");
+            model.newLayer().addAgentFunction(in_func);
+        }
+    }
+    template<typename T1, typename T2>
+    void addMsgA3DInFunc(T1 out_func, T2 in_func) {
+        MsgArray3D::Description &msg = model.newMessage<MsgArray3D>("message");
+        msg.setDimensions(10, 10, 10);
+        msg.template newVariable<int>("int");
+        {
+            auto &fn = agent.newFunction("out_name", out_func);
+            fn.setMessageOutput("message");
+            model.newLayer().addAgentFunction(out_func);
+        }
+        {
+            auto &fn = agent.newFunction("in_name", in_func);
+            fn.setMessageInput("message");
+            model.newLayer().addAgentFunction(in_func);
+        }
+    }
+    template<typename T1, typename T2>
+    void addMsgBucketInFunc(T1 out_func, T2 in_func) {
+        MsgBucket::Description &msg = model.newMessage<MsgBucket>("message");
+        msg.setBounds(0, 1023);
+        msg.template newVariable<int>("int");
+        {
+            auto &fn = agent.newFunction("out_name", out_func);
+            fn.setMessageOutput("message");
+            model.newLayer().addAgentFunction(out_func);
+        }
+        {
+            auto &fn = agent.newFunction("in_name", in_func);
+            fn.setMessageInput("message");
+            model.newLayer().addAgentFunction(in_func);
+        }
+    }
+    ModelDescription model;
+    AgentDescription &agent;
+};
+/**
+* This defines a common fixture used as a base for all test cases in the file
+* @see https://github.com/google/googletest/blob/master/googletest/samples/sample5_unittest.cc
+*/
+class DeviceExceptionTest : public testing::Test {
+ protected:
+    void SetUp() override {
+        ms = new MiniSim();
+    }
+    void TearDown() override {
+        delete ms;
+    }
+
+    MiniSim *ms = nullptr;
+};
+}  // namespace
+//
+// FLAMEGPU_READ_ONLY_DEVICE_API::getVariable<T, N>()
+FLAMEGPU_AGENT_FUNCTION(GetUnknownAgentVariable, MsgNone, MsgNone) {
+    FLAMEGPU->getVariable<int>("nope");
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, GetUnknownAgentVariable) {
+    // Add required agent function
+    ms->addFunc(GetUnknownAgentVariable);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(GetAgentVariableBadType, MsgNone, MsgNone) {
+    FLAMEGPU->getVariable<double>("int");   // Note type checking only confirms size currently
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, GetAgentVariableBadType) {
+    // Add required agent function
+    ms->addFunc(GetAgentVariableBadType);
+    // Test Something
+    ms->run(1);
+}
+
+// FLAMEGPU_READ_ONLY_DEVICE_API::getVariable<T, N, M>()
+FLAMEGPU_AGENT_FUNCTION(GetUnknownAgentVariableArray, MsgNone, MsgNone) {
+    FLAMEGPU->getVariable<int, 3>("nope", 0);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, GetUnknownAgentVariableArray) {
+    // Add required agent function
+    ms->addFunc(GetUnknownAgentVariableArray);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(GetAgentVariableArrayBadType, MsgNone, MsgNone) {
+    FLAMEGPU->getVariable<double, 3>("array", 0);   // Note type checking only confirms size currently
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, GetAgentVariableArrayBadType) {
+    // Add required agent function
+    ms->addFunc(GetAgentVariableArrayBadType);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(GetAgentVariableArrayOutOfRange, MsgNone, MsgNone) {
+    FLAMEGPU->getVariable<int, 2>("array", 2);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, GetAgentVariableArrayOutOfRange) {
+    // Add required agent function
+    ms->addFunc(GetAgentVariableArrayOutOfRange);
+    // Test Something
+    ms->run(1);
+}
+
+// FLAMEGPU_DEVICE_API::setVariable<T, N>()
+FLAMEGPU_AGENT_FUNCTION(SetUnknownAgentVariable, MsgNone, MsgNone) {
+    FLAMEGPU->setVariable<int>("nope", 2);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, SetUnknownAgentVariable) {
+    // Add required agent function
+    ms->addFunc(SetUnknownAgentVariable);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(SetAgentVariableBadType, MsgNone, MsgNone) {
+    FLAMEGPU->setVariable<double>("int", 12.0);  // Note type checking only confirms size currently
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, SetAgentVariableBadType) {
+    // Add required agent function
+    ms->addFunc(SetAgentVariableBadType);
+    // Test Something
+    ms->run(1);
+}
+
+// FLAMEGPU_DEVICE_API::setVariable<T, N, M>()
+FLAMEGPU_AGENT_FUNCTION(SetUnknownAgentVariableArray, MsgNone, MsgNone) {
+    FLAMEGPU->setVariable<int, 3>("nope", 0, 2);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, SetUnknownAgentVariableArray) {
+    // Add required agent function
+    ms->addFunc(SetUnknownAgentVariableArray);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(SetAgentVariableArrayBadType, MsgNone, MsgNone) {
+    FLAMEGPU->setVariable<double, 3>("array", 0, 12.0);  // Note type checking only confirms size currently
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, SetAgentVariableArrayBadType) {
+    // Add required agent function
+    ms->addFunc(SetAgentVariableArrayBadType);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(SetAgentVariableArrayOutOfRange, MsgNone, MsgNone) {
+    FLAMEGPU->setVariable<int, 2>("array", 2, 12.0);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, SetAgentVariableArrayOutOfRange) {
+    // Add required agent function
+    ms->addFunc(SetAgentVariableArrayOutOfRange);
+    // Test Something
+    ms->run(1);
+}
+
+// AgentRandom::uniform<T>(T, T)
+FLAMEGPU_AGENT_FUNCTION(AgentRandomUniformInvalidRange1, MsgNone, MsgNone) {
+    FLAMEGPU->random.uniform<int>(5, 4);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, AgentRandomUniformInvalidRange1) {
+    // Add required agent function
+    ms->addFunc(AgentRandomUniformInvalidRange1);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(AgentRandomUniformInvalidRange2, MsgNone, MsgNone) {
+    FLAMEGPU->random.uniform<int64_t>(5, 4);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, AgentRandomUniformInvalidRange2) {
+    // Add required agent function
+    ms->addFunc(AgentRandomUniformInvalidRange2);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(AgentRandomUniformInvalidRange3, MsgNone, MsgNone) {
+    FLAMEGPU->random.uniform<uint64_t>(5, 4);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, AgentRandomUniformInvalidRange3) {
+    // Add required agent function
+    ms->addFunc(AgentRandomUniformInvalidRange3);
+    // Test Something
+    ms->run(1);
+}
+
+// DeviceEnvironment::get<T, N>()
+FLAMEGPU_AGENT_FUNCTION(DeviceEnvironmentGetUnknownProperty, MsgNone, MsgNone) {
+    FLAMEGPU->environment.get<int>("nope");
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, DeviceEnvironmentGetUnknownProperty) {
+    // Add required agent function
+    ms->addFunc(DeviceEnvironmentGetUnknownProperty);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(DeviceEnvironmentGetBadType, MsgNone, MsgNone) {
+    FLAMEGPU->environment.get<double>("int");
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, DeviceEnvironmentGetBadType) {
+    // Add required agent function
+    ms->addFunc(DeviceEnvironmentGetBadType);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(DeviceEnvironmentGetOutOfRange, MsgNone, MsgNone) {
+    FLAMEGPU->environment.get<int>("array", 2);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, DeviceEnvironmentGetOutOfRange) {
+    // Add required agent function
+    ms->addFunc(DeviceEnvironmentGetOutOfRange);
+    // Test Something
+    ms->run(1);
+}
+
+// AgentOut::setVariable<T, N>()
+FLAMEGPU_AGENT_FUNCTION(AgentOutVariableUnknown, MsgNone, MsgNone) {
+    FLAMEGPU->agent_out.setVariable<int>("nope", 2);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, AgentOutVariableUnknown) {
+    // Add required agent function
+    ms->addAgentOutFunc(AgentOutVariableUnknown);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(AgentOutVariableBadType, MsgNone, MsgNone) {
+    FLAMEGPU->agent_out.setVariable<double>("int", 2.0);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, AgentOutVariableBadType) {
+    // Add required agent function
+    ms->addAgentOutFunc(AgentOutVariableBadType);
+    // Test Something
+    ms->run(1);
+}
+
+// AgentOut::setVariable<T, N, M>()
+FLAMEGPU_AGENT_FUNCTION(AgentOutVariableArrayUnknown, MsgNone, MsgNone) {
+    FLAMEGPU->agent_out.setVariable<int, 2>("nope", 0, 2);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, AgentOutVariableArrayUnknown) {
+    // Add required agent function
+    ms->addAgentOutFunc(AgentOutVariableArrayUnknown);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(AgentOutVariableArrayBadType, MsgNone, MsgNone) {
+    FLAMEGPU->agent_out.setVariable<double, 2>("array", 0, 2);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, AgentOutVariableArrayBadType) {
+    // Add required agent function
+    ms->addAgentOutFunc(AgentOutVariableArrayBadType);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(AgentOutVariableArrayOutOfRange1, MsgNone, MsgNone) {
+    FLAMEGPU->agent_out.setVariable<int, 2>("array", 2, 2);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, AgentOutVariableArrayOutOfRange1) {
+    // Add required agent function
+    ms->addAgentOutFunc(AgentOutVariableArrayOutOfRange1);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(AgentOutVariableArrayOutOfRange2, MsgNone, MsgNone) {
+    FLAMEGPU->agent_out.setVariable<int, 3>("array", 2, 2);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, AgentOutVariableArrayOutOfRange2) {
+    // Add required agent function
+    ms->addAgentOutFunc(AgentOutVariableArrayOutOfRange2);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgBruteForce::Out::setVariable<T, N>()
+FLAMEGPU_AGENT_FUNCTION(MsgBruteForceOutVariableUnknown, MsgNone, MsgBruteForce) {
+    FLAMEGPU->message_out.setVariable<int>("nope", 2);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgBruteForceOutVariableUnknown) {
+    // Add required agent function
+    ms->addMsgOutFunc<MsgBruteForce>(MsgBruteForceOutVariableUnknown);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(MsgBruteForceOutVariableBadType, MsgNone, MsgBruteForce) {
+    FLAMEGPU->message_out.setVariable<double>("int", 2);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgBruteForceOutVariableBadType) {
+    // Add required agent function
+    ms->addMsgOutFunc<MsgBruteForce>(MsgBruteForceOutVariableBadType);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgBruteForce::Message::getVariable<T, N>()
+FLAMEGPU_AGENT_FUNCTION(MsgBruteForceDefaultOut, MsgNone, MsgBruteForce) {
+    FLAMEGPU->message_out.setVariable<int>("int", 12);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(MsgBruteForceInVariableUnknown, MsgBruteForce, MsgNone) {
+    for (auto m : FLAMEGPU->message_in) {
+        m.getVariable<int>("nope");
+    }
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgBruteForceInVariableUnknown) {
+    // Add required agent function
+    ms->addMsgInFunc<MsgBruteForce>(MsgBruteForceDefaultOut, MsgBruteForceInVariableUnknown);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(MsgBruteForceInVariableBadType, MsgBruteForce, MsgNone) {
+    for (auto m : FLAMEGPU->message_in) {
+        m.getVariable<double>("int");
+    }
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgBruteForceInVariableBadType) {
+    // Add required agent function
+    ms->addMsgInFunc<MsgBruteForce>(MsgBruteForceDefaultOut, MsgBruteForceInVariableBadType);
+    // Test Something
+    ms->run(1);
+}
+
+
+// MsgSpatial2D::Out::setVariable<T, N>() (These should be identical to MsgBruteForce due to the object being inherited)
+FLAMEGPU_AGENT_FUNCTION(MsgSpatial2DOutVariableUnknown, MsgNone, MsgSpatial2D) {
+    FLAMEGPU->message_out.setVariable<int>("nope", 2);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgSpatial2DOutVariableUnknown) {
+    // Add required agent function
+    ms->addMsgS2DOutFunc(MsgSpatial2DOutVariableUnknown);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(MsgSpatial2DOutVariableBadType, MsgNone, MsgSpatial2D) {
+    FLAMEGPU->message_out.setVariable<double>("int", 2);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgSpatial2DOutVariableBadType) {
+    // Add required agent function
+    ms->addMsgS2DOutFunc(MsgSpatial2DOutVariableBadType);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgSpatial2D::In::Filter::Message::getVariable<T, N>()
+FLAMEGPU_AGENT_FUNCTION(MsgSpatial2DDefaultOut, MsgNone, MsgSpatial2D) {
+    FLAMEGPU->message_out.setVariable<int>("int", 12);
+    FLAMEGPU->message_out.setLocation(0, 0);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(MsgSpatial2DInVariableUnknown, MsgSpatial2D, MsgNone) {
+    for (auto m : FLAMEGPU->message_in(0 , 0)) {
+        m.getVariable<int>("nope");
+    }
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgSpatial2DInVariableUnknown) {
+    // Add required agent function
+    ms->addMsgS2DInFunc(MsgSpatial2DDefaultOut, MsgSpatial2DInVariableUnknown);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(MsgSpatial2DInVariableBadType, MsgSpatial2D, MsgNone) {
+    for (auto m : FLAMEGPU->message_in(0 , 0)) {
+        m.getVariable<double>("int");
+    }
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgSpatial2DInVariableBadType) {
+    // Add required agent function
+    ms->addMsgS2DInFunc(MsgSpatial2DDefaultOut, MsgSpatial2DInVariableBadType);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgSpatial3D::Out::setVariable<T, N>() (These should be identical to MsgBruteForce due to the object being inherited)
+FLAMEGPU_AGENT_FUNCTION(MsgSpatial3DOutVariableUnknown, MsgNone, MsgSpatial3D) {
+    FLAMEGPU->message_out.setVariable<int>("nope", 2);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgSpatial3DOutVariableUnknown) {
+    // Add required agent function
+    ms->addMsgS3DOutFunc(MsgSpatial3DOutVariableUnknown);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(MsgSpatial3DOutVariableBadType, MsgNone, MsgSpatial3D) {
+    FLAMEGPU->message_out.setVariable<double>("int", 2);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgSpatial3DOutVariableBadType) {
+    // Add required agent function
+    ms->addMsgS3DOutFunc(MsgSpatial3DOutVariableBadType);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgSpatial3D::In::Filter::Message::getVariable<T, N>()
+FLAMEGPU_AGENT_FUNCTION(MsgSpatial3DDefaultOut, MsgNone, MsgSpatial3D) {
+    FLAMEGPU->message_out.setVariable<int>("int", 12);
+    FLAMEGPU->message_out.setLocation(0, 0, 0);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(MsgSpatial3DInVariableUnknown, MsgSpatial3D, MsgNone) {
+    for (auto m : FLAMEGPU->message_in(0 , 0, 0)) {
+        m.getVariable<int>("nope");
+    }
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgSpatial3DInVariableUnknown) {
+    // Add required agent function
+    ms->addMsgS3DInFunc(MsgSpatial3DDefaultOut, MsgSpatial3DInVariableUnknown);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(MsgSpatial3DInVariableBadType, MsgSpatial3D, MsgNone) {
+    for (auto m : FLAMEGPU->message_in(0 , 0, 0)) {
+        m.getVariable<double>("int");
+    }
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgSpatial3DInVariableBadType) {
+    // Add required agent function
+    ms->addMsgS3DInFunc(MsgSpatial3DDefaultOut, MsgSpatial3DInVariableBadType);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgArray::Out::setIndex()
+FLAMEGPU_AGENT_FUNCTION(MsgArrayOutIndexOutOfRange, MsgNone, MsgArray) {
+    FLAMEGPU->message_out.setIndex(10);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArrayOutIndexOutOfRange) {
+    // Add required agent function
+    ms->addMsgA1DOutFunc(MsgArrayOutIndexOutOfRange);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgArray::Out::setVariable<T, N>()
+FLAMEGPU_AGENT_FUNCTION(MsgArrayOutUnknownVariable, MsgNone, MsgArray) {
+    FLAMEGPU->message_out.setVariable<int>("nope", 11);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArrayOutUnknownVariable) {
+    // Add required agent function
+    ms->addMsgA1DOutFunc(MsgArrayOutUnknownVariable);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(MsgArrayVariableBadType, MsgNone, MsgArray) {
+    FLAMEGPU->message_out.setVariable<double>("int", 11);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArrayVariableBadType) {
+    // Add required agent function
+    ms->addMsgA1DOutFunc(MsgArrayVariableBadType);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgArray::Message::getVariable<T, N>()
+FLAMEGPU_AGENT_FUNCTION(MsgArrayDefaultOut, MsgNone, MsgArray) {
+    FLAMEGPU->message_out.setVariable<int>("int", 12);
+    FLAMEGPU->message_out.setIndex(0);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(MsgArrayInVariableUnknown, MsgArray, MsgNone) {
+    FLAMEGPU->message_in.at(0).getVariable<int>("nope");
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArrayInVariableUnknown) {
+    // Add required agent function
+    ms->addMsgA1DInFunc(MsgArrayDefaultOut, MsgArrayInVariableUnknown);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(MsgArrayInVariableBadType, MsgArray, MsgNone) {
+    FLAMEGPU->message_in.at(0).getVariable<double>("int");
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArrayInVariableBadType) {
+    // Add required agent function
+    ms->addMsgA1DInFunc(MsgArrayDefaultOut, MsgArrayInVariableBadType);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgArray::In::operator()()
+FLAMEGPU_AGENT_FUNCTION(MsgArrayInVariableBadRadius, MsgArray, MsgNone) {
+    for (auto m : FLAMEGPU->message_in(0, 0)) {
+        m.getVariable<int>("int");
+    }
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArrayInVariableBadRadius) {
+    // Add required agent function
+    ms->addMsgA1DInFunc(MsgArrayDefaultOut, MsgArrayInVariableBadRadius);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgArray::In::at()
+FLAMEGPU_AGENT_FUNCTION(MsgArrayInVariableIndexOutOfBounds, MsgArray, MsgNone) {
+    FLAMEGPU->message_in.at(10);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArrayInVariableIndexOutOfBounds) {
+    // Add required agent function
+    ms->addMsgA1DInFunc(MsgArrayDefaultOut, MsgArrayInVariableIndexOutOfBounds);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgArray2D::Out::setIndex()
+FLAMEGPU_AGENT_FUNCTION(MsgArray2DOutIndexOutOfRange, MsgNone, MsgArray2D) {
+    FLAMEGPU->message_out.setIndex(10, 0);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArray2DOutIndexOutOfRange) {
+    // Add required agent function
+    ms->addMsgA2DOutFunc(MsgArray2DOutIndexOutOfRange);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgArray2D::Out::setVariable<T, N>()
+FLAMEGPU_AGENT_FUNCTION(MsgArray2DOutUnknownVariable, MsgNone, MsgArray2D) {
+    FLAMEGPU->message_out.setVariable<int>("nope", 11);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArray2DOutUnknownVariable) {
+    // Add required agent function
+    ms->addMsgA2DOutFunc(MsgArray2DOutUnknownVariable);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(MsgArray2DVariableBadType, MsgNone, MsgArray2D) {
+    FLAMEGPU->message_out.setVariable<double>("int", 11);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArray2DVariableBadType) {
+    // Add required agent function
+    ms->addMsgA2DOutFunc(MsgArray2DVariableBadType);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgArray2D::Message::getVariable<T, N>()
+FLAMEGPU_AGENT_FUNCTION(MsgArray2DDefaultOut, MsgNone, MsgArray2D) {
+    FLAMEGPU->message_out.setVariable<int>("int", 12);
+    FLAMEGPU->message_out.setIndex(0, 0);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(MsgArray2DInVariableUnknown, MsgArray2D, MsgNone) {
+    FLAMEGPU->message_in.at(0, 0).getVariable<int>("nope");
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArray2DInVariableUnknown) {
+    // Add required agent function
+    ms->addMsgA2DInFunc(MsgArray2DDefaultOut, MsgArray2DInVariableUnknown);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(MsgArray2DInVariableBadType, MsgArray2D, MsgNone) {
+    FLAMEGPU->message_in.at(0, 0).getVariable<double>("int");
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArray2DInVariableBadType) {
+    // Add required agent function
+    ms->addMsgA2DInFunc(MsgArray2DDefaultOut, MsgArray2DInVariableBadType);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgArray2D::In::operator()()
+FLAMEGPU_AGENT_FUNCTION(MsgArray2DInVariableBadRadius, MsgArray2D, MsgNone) {
+    for (auto m : FLAMEGPU->message_in(0, 0, 0)) {
+        m.getVariable<int>("int");
+    }
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArray2DInVariableBadRadius) {
+    // Add required agent function
+    ms->addMsgA2DInFunc(MsgArray2DDefaultOut, MsgArray2DInVariableBadRadius);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgArray2D::In::at()
+FLAMEGPU_AGENT_FUNCTION(MsgArray2DInVariableIndexOutOfBoundsX, MsgArray2D, MsgNone) {
+    FLAMEGPU->message_in.at(10, 0);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArray2DInVariableIndexOutOfBoundsX) {
+    // Add required agent function
+    ms->addMsgA2DInFunc(MsgArray2DDefaultOut, MsgArray2DInVariableIndexOutOfBoundsX);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(MsgArray2DInVariableIndexOutOfBoundsY, MsgArray2D, MsgNone) {
+    FLAMEGPU->message_in.at(0, 10);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArray2DInVariableIndexOutOfBoundsY) {
+    // Add required agent function
+    ms->addMsgA2DInFunc(MsgArray2DDefaultOut, MsgArray2DInVariableIndexOutOfBoundsY);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgArray3D::Out::setIndex()
+FLAMEGPU_AGENT_FUNCTION(MsgArray3DOutIndexOutOfRange, MsgNone, MsgArray3D) {
+    FLAMEGPU->message_out.setIndex(10, 0, 0);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArray3DOutIndexOutOfRange) {
+    // Add required agent function
+    ms->addMsgA3DOutFunc(MsgArray3DOutIndexOutOfRange);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgArray3D::Out::setVariable<T, N>()
+FLAMEGPU_AGENT_FUNCTION(MsgArray3DOutUnknownVariable, MsgNone, MsgArray3D) {
+    FLAMEGPU->message_out.setVariable<int>("nope", 11);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArray3DOutUnknownVariable) {
+    // Add required agent function
+    ms->addMsgA3DOutFunc(MsgArray3DOutUnknownVariable);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(MsgArray3DVariableBadType, MsgNone, MsgArray3D) {
+    FLAMEGPU->message_out.setVariable<double>("int", 11);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArray3DVariableBadType) {
+    // Add required agent function
+    ms->addMsgA3DOutFunc(MsgArray3DVariableBadType);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgArray3D::Message::getVariable<T, N>()
+FLAMEGPU_AGENT_FUNCTION(MsgArray3DDefaultOut, MsgNone, MsgArray3D) {
+    FLAMEGPU->message_out.setVariable<int>("int", 12);
+    FLAMEGPU->message_out.setIndex(0, 0, 0);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(MsgArray3DInVariableUnknown, MsgArray3D, MsgNone) {
+    FLAMEGPU->message_in.at(0, 0, 0).getVariable<int>("nope");
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArray3DInVariableUnknown) {
+    // Add required agent function
+    ms->addMsgA3DInFunc(MsgArray3DDefaultOut, MsgArray3DInVariableUnknown);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(MsgArray3DInVariableBadType, MsgArray3D, MsgNone) {
+    FLAMEGPU->message_in.at(0, 0, 0).getVariable<double>("int");
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArray3DInVariableBadType) {
+    // Add required agent function
+    ms->addMsgA3DInFunc(MsgArray3DDefaultOut, MsgArray3DInVariableBadType);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgArray3D::In::operator()()
+FLAMEGPU_AGENT_FUNCTION(MsgArray3DInVariableBadRadius, MsgArray3D, MsgNone) {
+    for (auto m : FLAMEGPU->message_in(0, 0, 0, 0)) {
+        m.getVariable<int>("int");
+    }
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArray3DInVariableBadRadius) {
+    // Add required agent function
+    ms->addMsgA3DInFunc(MsgArray3DDefaultOut, MsgArray3DInVariableBadRadius);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgArray3D::In::at()
+FLAMEGPU_AGENT_FUNCTION(MsgArray3DInVariableIndexOutOfBoundsX, MsgArray3D, MsgNone) {
+    FLAMEGPU->message_in.at(10, 0, 0);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArray3DInVariableIndexOutOfBoundsX) {
+    // Add required agent function
+    ms->addMsgA3DInFunc(MsgArray3DDefaultOut, MsgArray3DInVariableIndexOutOfBoundsX);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(MsgArray3DInVariableIndexOutOfBoundsY, MsgArray3D, MsgNone) {
+    FLAMEGPU->message_in.at(0, 10, 0);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArray3DInVariableIndexOutOfBoundsY) {
+    // Add required agent function
+    ms->addMsgA3DInFunc(MsgArray3DDefaultOut, MsgArray3DInVariableIndexOutOfBoundsY);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(MsgArray3DInVariableIndexOutOfBoundsZ, MsgArray3D, MsgNone) {
+    FLAMEGPU->message_in.at(0, 0, 10);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgArray3DInVariableIndexOutOfBoundsZ) {
+    // Add required agent function
+    ms->addMsgA3DInFunc(MsgArray3DDefaultOut, MsgArray3DInVariableIndexOutOfBoundsZ);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgBucket::Out::setVariable<T, N>()
+FLAMEGPU_AGENT_FUNCTION(MsgBucketOutUnknownVariable, MsgNone, MsgBucket) {
+    FLAMEGPU->message_out.setVariable<int>("nope", 11);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgBucketOutUnknownVariable) {
+    // Add required agent function
+    ms->addMsgBucketOutFunc(MsgBucketOutUnknownVariable);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(MsgBucketVariableBadType, MsgNone, MsgBucket) {
+    FLAMEGPU->message_out.setVariable<double>("int", 11);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgBucketVariableBadType) {
+    // Add required agent function
+    ms->addMsgBucketOutFunc(MsgBucketVariableBadType);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgBucket::Out::setKey()
+FLAMEGPU_AGENT_FUNCTION(MsgBucketOutBadKey1, MsgNone, MsgBucket) {
+    FLAMEGPU->message_out.setKey(-1);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(MsgBucketOutBadKey2, MsgNone, MsgBucket) {
+    FLAMEGPU->message_out.setKey(1024);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgBucketOutBadKey1) {
+    // Add required agent function
+    ms->addMsgBucketOutFunc(MsgBucketOutBadKey1);
+    // Test Something
+    ms->run(1);
+}
+TEST_F(DeviceExceptionTest, MsgBucketOutBadKey2) {
+    // Add required agent function
+    ms->addMsgBucketOutFunc(MsgBucketOutBadKey2);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgBucket::Message::getVariable<T, N>()
+FLAMEGPU_AGENT_FUNCTION(MsgBucketDefaultOut, MsgNone, MsgBucket) {
+    FLAMEGPU->message_out.setVariable<int>("int", 12);
+    FLAMEGPU->message_out.setKey(0);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(MsgBucketInVariableUnknown, MsgBucket, MsgNone) {
+    for (auto m : FLAMEGPU->message_in(0)) {
+        m.getVariable<int>("nope");
+    }
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgBucketInVariableUnknown) {
+    // Add required agent function
+    ms->addMsgBucketInFunc(MsgBucketDefaultOut, MsgBucketInVariableUnknown);
+    // Test Something
+    ms->run(1);
+}
+FLAMEGPU_AGENT_FUNCTION(MsgBucketInVariableBadType, MsgBucket, MsgNone) {
+    for (auto m : FLAMEGPU->message_in(0)) {
+        m.getVariable<double>("int");
+    }
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgBucketInVariableBadType) {
+    // Add required agent function
+    ms->addMsgBucketInFunc(MsgBucketDefaultOut, MsgBucketInVariableBadType);
+    // Test Something
+    ms->run(1);
+}
+
+// MsgBucket::In::operator()(key)
+// MsgBucket::In::operator()(beginKey, endKey)
+FLAMEGPU_AGENT_FUNCTION(MsgBucketInBadKey1, MsgBucket, MsgNone) {
+    FLAMEGPU->message_in(-1);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(MsgBucketInBadKey2, MsgBucket, MsgNone) {
+    FLAMEGPU->message_in(1024);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(MsgBucketInBadKey3, MsgBucket, MsgNone) {
+    FLAMEGPU->message_in(-1, 1023);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(MsgBucketInBadKey4, MsgBucket, MsgNone) {
+    FLAMEGPU->message_in(0, 1025);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(MsgBucketInBadKey5, MsgBucket, MsgNone) {
+    FLAMEGPU->message_in(100, 5);
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, MsgBucketInBadKey1) {
+    // Add required agent function
+    ms->addMsgBucketInFunc(MsgBucketDefaultOut, MsgBucketInBadKey1);
+    // Test Something
+    ms->run(1);
+}
+TEST_F(DeviceExceptionTest, MsgBucketInBadKey2) {
+    // Add required agent function
+    ms->addMsgBucketInFunc(MsgBucketDefaultOut, MsgBucketInBadKey2);
+    // Test Something
+    ms->run(1);
+}
+TEST_F(DeviceExceptionTest, MsgBucketInBadKey3) {
+    // Add required agent function
+    ms->addMsgBucketInFunc(MsgBucketDefaultOut, MsgBucketInBadKey3);
+    // Test Something
+    ms->run(1);
+}
+TEST_F(DeviceExceptionTest, MsgBucketInBadKey4) {
+    // Add required agent function
+    ms->addMsgBucketInFunc(MsgBucketDefaultOut, MsgBucketInBadKey4);
+    // Test Something
+    ms->run(1);
+}
+TEST_F(DeviceExceptionTest, MsgBucketInBadKey5) {
+    // Add required agent function
+    ms->addMsgBucketInFunc(MsgBucketDefaultOut, MsgBucketInBadKey5);
+    // Test Something
+    ms->run(1);
+}
+
+// Test error in agent function condition
+FLAMEGPU_AGENT_FUNCTION_CONDITION(AgentFunctionConditionError1) {
+    FLAMEGPU->getVariable<int>("nope");
+    return true;
+}FLAMEGPU_AGENT_FUNCTION_CONDITION(AgentFunctionConditionError2) {
+    FLAMEGPU->getVariable<int>("nope");
+    return false;
+}
+FLAMEGPU_AGENT_FUNCTION(GetAgentVariable, MsgNone, MsgNone) {
+    FLAMEGPU->getVariable<int>("int");
+    return ALIVE;
+}
+TEST_F(DeviceExceptionTest, AgentFunctionConditionError1) {
+    // Add required agent function
+    ms->addFuncCdn(GetAgentVariable, AgentFunctionConditionError1);
+    // Test Something
+    ms->run(1);
+}
+TEST_F(DeviceExceptionTest, AgentFunctionConditionError2) {
+    // Add required agent function
+    ms->addFuncCdn(GetAgentVariable, AgentFunctionConditionError2);
+    // Test Something
+    ms->run(1);
+}

--- a/tests/test_cases/exception/test_rtc_device_exception.cu
+++ b/tests/test_cases/exception/test_rtc_device_exception.cu
@@ -1,0 +1,483 @@
+#include "gtest/gtest.h"
+
+#include "flamegpu/flame_api.h"
+#include "flamegpu/runtime/flamegpu_api.h"
+
+// These tests wont work if built with NO_SEATBELTS, so mark them all as disabled instead
+#ifdef NO_SEATBELTS
+#undef TEST
+#define TEST(test_suite_name, test_name) GTEST_TEST(test_suite_name, DISABLED_ ## test_name)
+#endif
+
+namespace test_rtc_device_exception {
+const unsigned int AGENT_COUNT = 64;
+
+/**
+ * Test that exceptions on getVariable() work
+ */
+const char* rtc_dthrow_agent_func_getAgentVar = R"###(
+FLAMEGPU_AGENT_FUNCTION(rtc_test_func, MsgNone, MsgNone) {
+    FLAMEGPU->getVariable<int>("nope");
+    return ALIVE;
+}
+)###";
+TEST(RTCDeviceExceptionTest, getAgentVar_name) {
+    ModelDescription model("model");
+    AgentDescription& agent = model.newAgent("agent_name");
+    agent.newVariable<int>("id");
+    // add RTC agent function
+    AgentFunctionDescription& func = agent.newRTCFunction("rtc_test_func", rtc_dthrow_agent_func_getAgentVar);
+    model.newLayer().addAgentFunction(func);
+    // Init pop
+    AgentPopulation init_population(agent, AGENT_COUNT);
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = init_population.getNextInstance("default");
+        instance.setVariable<int>("id", i);
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(init_population);
+    // Run 1 step to ensure data is pushed to device
+    EXPECT_THROW(cuda_model.step(), DeviceError);
+}
+const char* rtc_dthrow_agent_func_getAgentVarType = R"###(
+FLAMEGPU_AGENT_FUNCTION(rtc_test_func, MsgNone, MsgNone) {
+    FLAMEGPU->getVariable<double>("id");
+    return ALIVE;
+}
+)###";
+TEST(RTCDeviceExceptionTest, getAgentVar_typesize) {
+    ModelDescription model("model");
+    AgentDescription& agent = model.newAgent("agent_name");
+    agent.newVariable<int>("id");
+    // add RTC agent function
+    AgentFunctionDescription& func = agent.newRTCFunction("rtc_test_func", rtc_dthrow_agent_func_getAgentVarType);
+    model.newLayer().addAgentFunction(func);
+    // Init pop
+    AgentPopulation init_population(agent, AGENT_COUNT);
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = init_population.getNextInstance("default");
+        instance.setVariable<int>("id", i);
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(init_population);
+    // Run 1 step to ensure data is pushed to device
+    EXPECT_THROW(cuda_model.step(), DeviceError);
+}
+/**
+ * Test that exceptions on getArrayVariable() works
+ */
+const char* rtc_dthrow_agent_func_getAgentArrayVar = R"###(
+FLAMEGPU_AGENT_FUNCTION(rtc_test_func, MsgNone, MsgNone) {
+    FLAMEGPU->getVariable<int, 2>("nope", 0);
+    return ALIVE;
+}
+)###";
+TEST(RTCDeviceExceptionTest, getAgentArrayVar_name) {
+    ModelDescription model("model");
+    AgentDescription& agent = model.newAgent("agent_name");
+    agent.newVariable<int, 2>("id");
+    // add RTC agent function
+    AgentFunctionDescription& func = agent.newRTCFunction("rtc_test_func", rtc_dthrow_agent_func_getAgentArrayVar);
+    model.newLayer().addAgentFunction(func);
+    // Init pop
+    AgentPopulation init_population(agent, AGENT_COUNT);
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = init_population.getNextInstance("default");
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(init_population);
+    // Run 1 step to ensure data is pushed to device
+    EXPECT_THROW(cuda_model.step(), DeviceError);
+}
+const char* rtc_dthrow_agent_func_getAgentArrayVar1 = R"###(
+FLAMEGPU_AGENT_FUNCTION(rtc_test_func, MsgNone, MsgNone) {
+    FLAMEGPU->getVariable<double, 2>("id", 0);
+    return ALIVE;
+}
+)###";
+TEST(RTCDeviceExceptionTest, getAgentArrayVar_typesize) {
+    ModelDescription model("model");
+    AgentDescription& agent = model.newAgent("agent_name");
+    agent.newVariable<int, 2>("id");
+    // add RTC agent function
+    AgentFunctionDescription& func = agent.newRTCFunction("rtc_test_func", rtc_dthrow_agent_func_getAgentArrayVar1);
+    model.newLayer().addAgentFunction(func);
+    // Init pop
+    AgentPopulation init_population(agent, AGENT_COUNT);
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = init_population.getNextInstance("default");
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(init_population);
+    // Run 1 step to ensure data is pushed to device
+    EXPECT_THROW(cuda_model.step(), DeviceError);
+}
+const char* rtc_dthrow_agent_func_getAgentArrayVar2 = R"###(
+FLAMEGPU_AGENT_FUNCTION(rtc_test_func, MsgNone, MsgNone) {
+    FLAMEGPU->getVariable<int, 3>("id", 0);
+    return ALIVE;
+}
+)###";
+TEST(RTCDeviceExceptionTest, getAgentArrayVar_length) {
+    ModelDescription model("model");
+    AgentDescription& agent = model.newAgent("agent_name");
+    agent.newVariable<int, 2>("id");
+    // add RTC agent function
+    AgentFunctionDescription& func = agent.newRTCFunction("rtc_test_func", rtc_dthrow_agent_func_getAgentArrayVar2);
+    model.newLayer().addAgentFunction(func);
+    // Init pop
+    AgentPopulation init_population(agent, AGENT_COUNT);
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = init_population.getNextInstance("default");
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(init_population);
+    // Run 1 step to ensure data is pushed to device
+    EXPECT_THROW(cuda_model.step(), DeviceError);
+}
+const char* rtc_dthrow_agent_func_getAgentArrayVar3 = R"###(
+FLAMEGPU_AGENT_FUNCTION(rtc_test_func, MsgNone, MsgNone) {
+    FLAMEGPU->getVariable<int, 2>("id", 2);
+    return ALIVE;
+}
+)###";
+TEST(RTCDeviceExceptionTest, getAgentArrayVar_bounds) {
+    ModelDescription model("model");
+    AgentDescription& agent = model.newAgent("agent_name");
+    agent.newVariable<int, 2>("id");
+    // add RTC agent function
+    AgentFunctionDescription& func = agent.newRTCFunction("rtc_test_func", rtc_dthrow_agent_func_getAgentArrayVar3);
+    model.newLayer().addAgentFunction(func);
+    // Init pop
+    AgentPopulation init_population(agent, AGENT_COUNT);
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = init_population.getNextInstance("default");
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(init_population);
+    // Run 1 step to ensure data is pushed to device
+    EXPECT_THROW(cuda_model.step(), DeviceError);
+}
+/**
+ * Test that exceptions on setVariable() works
+ */
+const char* rtc_dthrow_agent_func_setAgentVar = R"###(
+FLAMEGPU_AGENT_FUNCTION(rtc_test_func, MsgNone, MsgNone) {
+    FLAMEGPU->setVariable<int>("nope", 12);
+    return ALIVE;
+}
+)###";
+TEST(RTCDeviceExceptionTest, setAgentVar_name) {
+    ModelDescription model("model");
+    AgentDescription& agent = model.newAgent("agent_name");
+    agent.newVariable<int>("id");
+    // add RTC agent function
+    AgentFunctionDescription& func = agent.newRTCFunction("rtc_test_func", rtc_dthrow_agent_func_setAgentVar);
+    model.newLayer().addAgentFunction(func);
+    // Init pop
+    AgentPopulation init_population(agent, AGENT_COUNT);
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = init_population.getNextInstance("default");
+        instance.setVariable<int>("id", i);
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(init_population);
+    // Run 1 step to ensure data is pushed to device
+    EXPECT_THROW(cuda_model.step(), DeviceError);
+}
+const char* rtc_dthrow_agent_func_setAgentVar2 = R"###(
+FLAMEGPU_AGENT_FUNCTION(rtc_test_func, MsgNone, MsgNone) {
+    FLAMEGPU->setVariable<double>("id", 12);
+    return ALIVE;
+}
+)###";
+TEST(RTCDeviceExceptionTest, setAgentVar_typesize) {
+    ModelDescription model("model");
+    AgentDescription& agent = model.newAgent("agent_name");
+    agent.newVariable<int>("id");
+    // add RTC agent function
+    AgentFunctionDescription& func = agent.newRTCFunction("rtc_test_func", rtc_dthrow_agent_func_setAgentVar2);
+    model.newLayer().addAgentFunction(func);
+    // Init pop
+    AgentPopulation init_population(agent, AGENT_COUNT);
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = init_population.getNextInstance("default");
+        instance.setVariable<int>("id", i);
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(init_population);
+    // Run 1 step to ensure data is pushed to device
+    EXPECT_THROW(cuda_model.step(), DeviceError);
+}
+/**
+ * Test that exceptions on setVariable() work
+ */
+const char* rtc_dthrow_agent_func_setAgentArrayVar = R"###(
+FLAMEGPU_AGENT_FUNCTION(rtc_test_func, MsgNone, MsgNone) {
+    FLAMEGPU->setVariable<int, 2>("nope", 0, 12);
+    return ALIVE;
+}
+)###";
+TEST(RTCDeviceExceptionTest, setAgentArrayVar_name) {
+    ModelDescription model("model");
+    AgentDescription& agent = model.newAgent("agent_name");
+    agent.newVariable<int, 2>("id");
+    // add RTC agent function
+    AgentFunctionDescription& func = agent.newRTCFunction("rtc_test_func", rtc_dthrow_agent_func_setAgentArrayVar);
+    model.newLayer().addAgentFunction(func);
+    // Init pop
+    AgentPopulation init_population(agent, AGENT_COUNT);
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = init_population.getNextInstance("default");
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(init_population);
+    // Run 1 step to ensure data is pushed to device
+    EXPECT_THROW(cuda_model.step(), DeviceError);
+}
+const char* rtc_dthrow_agent_func_setAgentArrayVar1 = R"###(
+FLAMEGPU_AGENT_FUNCTION(rtc_test_func, MsgNone, MsgNone) {
+    FLAMEGPU->setVariable<double, 2>("id", 0, 12);
+    return ALIVE;
+}
+)###";
+TEST(RTCDeviceExceptionTest, setAgentArrayVar_typesize) {
+    ModelDescription model("model");
+    AgentDescription& agent = model.newAgent("agent_name");
+    agent.newVariable<int, 2>("id");
+    // add RTC agent function
+    AgentFunctionDescription& func = agent.newRTCFunction("rtc_test_func", rtc_dthrow_agent_func_setAgentArrayVar1);
+    model.newLayer().addAgentFunction(func);
+    // Init pop
+    AgentPopulation init_population(agent, AGENT_COUNT);
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = init_population.getNextInstance("default");
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(init_population);
+    // Run 1 step to ensure data is pushed to device
+    EXPECT_THROW(cuda_model.step(), DeviceError);
+}
+const char* rtc_dthrow_agent_func_setAgentArrayVar2 = R"###(
+FLAMEGPU_AGENT_FUNCTION(rtc_test_func, MsgNone, MsgNone) {
+    FLAMEGPU->setVariable<int, 3>("id", 0, 12);
+    return ALIVE;
+}
+)###";
+TEST(RTCDeviceExceptionTest, setAgentArrayVar_length) {
+    ModelDescription model("model");
+    AgentDescription& agent = model.newAgent("agent_name");
+    agent.newVariable<int, 2>("id");
+    // add RTC agent function
+    AgentFunctionDescription& func = agent.newRTCFunction("rtc_test_func", rtc_dthrow_agent_func_setAgentArrayVar2);
+    model.newLayer().addAgentFunction(func);
+    // Init pop
+    AgentPopulation init_population(agent, AGENT_COUNT);
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = init_population.getNextInstance("default");
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(init_population);
+    // Run 1 step to ensure data is pushed to device
+    EXPECT_THROW(cuda_model.step(), DeviceError);
+}
+const char* rtc_dthrow_agent_func_setAgentArrayVar3 = R"###(
+FLAMEGPU_AGENT_FUNCTION(rtc_test_func, MsgNone, MsgNone) {
+    FLAMEGPU->setVariable<int, 2>("id", 2, 12);
+    return ALIVE;
+}
+)###";
+TEST(RTCDeviceExceptionTest, setAgentArrayVar_bounds) {
+    ModelDescription model("model");
+    AgentDescription& agent = model.newAgent("agent_name");
+    agent.newVariable<int, 2>("id");
+    // add RTC agent function
+    AgentFunctionDescription& func = agent.newRTCFunction("rtc_test_func", rtc_dthrow_agent_func_setAgentArrayVar3);
+    model.newLayer().addAgentFunction(func);
+    // Init pop
+    AgentPopulation init_population(agent, AGENT_COUNT);
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = init_population.getNextInstance("default");
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(init_population);
+    // Run 1 step to ensure data is pushed to device
+    EXPECT_THROW(cuda_model.step(), DeviceError);
+}
+/**
+ * Test that exceptions on environment.getProperty() work
+ */
+const char* rtc_dthrow_agent_func_getEnvironmentProp = R"###(
+FLAMEGPU_AGENT_FUNCTION(rtc_test_func, MsgNone, MsgNone) {
+    FLAMEGPU->environment.get<int>("nope");
+    return ALIVE;
+}
+)###";
+TEST(RTCDeviceExceptionTest, getEnvironmentProp_name) {
+    ModelDescription model("model");
+    AgentDescription& agent = model.newAgent("agent_name");
+    agent.newVariable<int>("id");
+    model.Environment().add<int>("test", 12);
+    // add RTC agent function
+    AgentFunctionDescription& func = agent.newRTCFunction("rtc_test_func", rtc_dthrow_agent_func_getEnvironmentProp);
+    model.newLayer().addAgentFunction(func);
+    // Init pop
+    AgentPopulation init_population(agent, AGENT_COUNT);
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = init_population.getNextInstance("default");
+        instance.setVariable<int>("id", i);
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(init_population);
+    // Run 1 step to ensure data is pushed to device
+    EXPECT_THROW(cuda_model.step(), DeviceError);
+}
+const char* rtc_dthrow_agent_func_getEnvironmentProp1 = R"###(
+FLAMEGPU_AGENT_FUNCTION(rtc_test_func, MsgNone, MsgNone) {
+    FLAMEGPU->environment.get<double>("test");
+    return ALIVE;
+}
+)###";
+TEST(RTCDeviceExceptionTest, getEnvironmentProp_typesize) {
+    ModelDescription model("model");
+    AgentDescription& agent = model.newAgent("agent_name");
+    agent.newVariable<int>("id");
+    model.Environment().add<int>("test", 12);
+    // add RTC agent function
+    AgentFunctionDescription& func = agent.newRTCFunction("rtc_test_func", rtc_dthrow_agent_func_getEnvironmentProp1);
+    model.newLayer().addAgentFunction(func);
+    // Init pop
+    AgentPopulation init_population(agent, AGENT_COUNT);
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = init_population.getNextInstance("default");
+        instance.setVariable<int>("id", i);
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(init_population);
+    // Run 1 step to ensure data is pushed to device
+    EXPECT_THROW(cuda_model.step(), DeviceError);
+}
+/**
+ * Test that exceptions on environment.getArrayProperty() work
+ */
+const char* rtc_dthrow_agent_func_getEnvironmentArrayProp = R"###(
+FLAMEGPU_AGENT_FUNCTION(rtc_test_func, MsgNone, MsgNone) {
+    FLAMEGPU->environment.get<int>("nope", 0);
+    return ALIVE;
+}
+)###";
+TEST(RTCDeviceExceptionTest, getEnvironmentArrayProp_name) {
+    ModelDescription model("model");
+    AgentDescription& agent = model.newAgent("agent_name");
+    agent.newVariable<int>("id");
+    model.Environment().add<int>("test", 12);
+    // add RTC agent function
+    AgentFunctionDescription& func = agent.newRTCFunction("rtc_test_func", rtc_dthrow_agent_func_getEnvironmentArrayProp);
+    model.newLayer().addAgentFunction(func);
+    // Init pop
+    AgentPopulation init_population(agent, AGENT_COUNT);
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = init_population.getNextInstance("default");
+        instance.setVariable<int>("id", i);
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(init_population);
+    // Run 1 step to ensure data is pushed to device
+    EXPECT_THROW(cuda_model.step(), DeviceError);
+}
+const char* rtc_dthrow_agent_func_getEnvironmentArrayProp1 = R"###(
+FLAMEGPU_AGENT_FUNCTION(rtc_test_func, MsgNone, MsgNone) {
+    FLAMEGPU->environment.get<double>("test", 0);
+    return ALIVE;
+}
+)###";
+TEST(RTCDeviceExceptionTest, getEnvironmentArrayProp_typesize) {
+    ModelDescription model("model");
+    AgentDescription& agent = model.newAgent("agent_name");
+    agent.newVariable<int>("id");
+    model.Environment().add<int, 2>("test", {11, 12});
+    // add RTC agent function
+    AgentFunctionDescription& func = agent.newRTCFunction("rtc_test_func", rtc_dthrow_agent_func_getEnvironmentArrayProp1);
+    model.newLayer().addAgentFunction(func);
+    // Init pop
+    AgentPopulation init_population(agent, AGENT_COUNT);
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = init_population.getNextInstance("default");
+        instance.setVariable<int>("id", i);
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(init_population);
+    // Run 1 step to ensure data is pushed to device
+    EXPECT_THROW(cuda_model.step(), DeviceError);
+}
+// Device environment does not currently require user to specify length of array
+// const char* rtc_dthrow_agent_func_getEnvironmentArrayProp2 = R"###(
+// FLAMEGPU_AGENT_FUNCTION(rtc_test_func, MsgNone, MsgNone) {
+//     FLAMEGPU->environment.get<int>("test", 0);
+//     return ALIVE;
+// }
+// )###";
+// TEST(RTCDeviceExceptionTest, getEnvironmentArrayProp_length) {
+//     ModelDescription model("model");
+//     AgentDescription& agent = model.newAgent("agent_name");
+//     agent.newVariable<int>("id");
+//     model.Environment().add<int, 2>("test", {11, 12});
+//     // add RTC agent function
+//     AgentFunctionDescription& func = agent.newRTCFunction("rtc_test_func", rtc_dthrow_agent_func_getEnvironmentArrayProp2);
+//     model.newLayer().addAgentFunction(func);
+//     // Init pop
+//     AgentPopulation init_population(agent, AGENT_COUNT);
+//     for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
+//         AgentInstance instance = init_population.getNextInstance("default");
+//         instance.setVariable<int>("id", i);
+//     }
+//     // Setup Model
+//     CUDAAgentModel cuda_model(model);
+//     cuda_model.setPopulationData(init_population);
+//     // Run 1 step to ensure data is pushed to device
+//     EXPECT_THROW(cuda_model.step(), DeviceError);
+// }
+const char* rtc_dthrow_agent_func_getEnvironmentArrayProp3 = R"###(
+FLAMEGPU_AGENT_FUNCTION(rtc_test_func, MsgNone, MsgNone) {
+    FLAMEGPU->environment.get<int>("test", 2);
+    return ALIVE;
+}
+)###";
+TEST(RTCDeviceExceptionTest, getEnvironmentArrayProp_bounds) {
+    ModelDescription model("model");
+    AgentDescription& agent = model.newAgent("agent_name");
+    agent.newVariable<int>("id");
+    model.Environment().add<int, 2>("test", {11, 12});
+    // add RTC agent function
+    AgentFunctionDescription& func = agent.newRTCFunction("rtc_test_func", rtc_dthrow_agent_func_getEnvironmentArrayProp3);
+    model.newLayer().addAgentFunction(func);
+    // Init pop
+    AgentPopulation init_population(agent, AGENT_COUNT);
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
+        AgentInstance instance = init_population.getNextInstance("default");
+        instance.setVariable<int>("id", i);
+    }
+    // Setup Model
+    CUDAAgentModel cuda_model(model);
+    cuda_model.setPopulationData(init_population);
+    // Run 1 step to ensure data is pushed to device
+    EXPECT_THROW(cuda_model.step(), DeviceError);
+}
+
+}  // namespace test_rtc_device_exception

--- a/tests/test_cases/runtime/messaging/test_array.cu
+++ b/tests/test_cases/runtime/messaging/test_array.cu
@@ -255,7 +255,11 @@ TEST(TestMessage_Array, Moore2) {
     }
 }
 // Exception tests
+#ifndef NO_SEATBELTS
 TEST(TestMessage_Array, DuplicateOutputException) {
+#else
+TEST(TestMessage_Array, DISABLED_DuplicateOutputException) {
+#endif
     ModelDescription m(MODEL_NAME);
     MsgArray::Description &msg = m.newMessage<MsgArray>(MESSAGE_NAME);
     msg.setLength(AGENT_COUNT);
@@ -321,6 +325,7 @@ TEST(TestMessage_Array, ReadEmpty) {
         MsgArray::Description &message = model.newMessage<MsgArray>("location");
         message.setLength(2);
         message.newVariable<int>("id");  // unused by current test
+        message.newVariable<unsigned int>("value");
     }
     {   // Circle agent
         AgentDescription &agent = model.newAgent("agent");

--- a/tests/test_cases/runtime/messaging/test_array_2d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_2d.cu
@@ -279,10 +279,14 @@ TEST(TestMessage_Array2D, Moore2) {
 }
 
 // Exception tests
+#ifndef NO_SEATBELTS
 TEST(TestMessage_Array2D, DuplicateOutputException) {
+#else
+TEST(TestMessage_Array2D, DISABLED_DuplicateOutputException) {
+#endif
     ModelDescription m(MODEL_NAME);
     MsgArray2D::Description &msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
-    msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT);
+    msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT + 1);
     msg.newVariable<unsigned int>("index_times_3");
     AgentDescription &a = m.newAgent(AGENT_NAME);
     a.newVariable<unsigned int>("index");
@@ -348,6 +352,7 @@ TEST(TestMessage_Array2D, ReadEmpty) {
         MsgArray2D::Description &message = model.newMessage<MsgArray2D>("location");
         message.setDimensions(2, 2);
         message.newVariable<int>("id");  // unused by current test
+        message.newVariable<unsigned int>("value");  // unused by current test
     }
     {   // Circle agent
         AgentDescription &agent = model.newAgent("agent");

--- a/tests/test_cases/runtime/messaging/test_array_3d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_3d.cu
@@ -292,7 +292,11 @@ TEST(TestMessage_Array3D, Moore2) {
 }
 
 // Exception tests
+#ifndef NO_SEATBELTS
 TEST(TestMessage_Array3D, DuplicateOutputException) {
+#else
+TEST(TestMessage_Array3D, DISABLED_DuplicateOutputException) {
+#endif
     ModelDescription m(MODEL_NAME);
     MsgArray3D::Description &msg = m.newMessage<MsgArray3D>(MESSAGE_NAME);
     msg.setDimensions(CBRT_AGENT_COUNT, CBRT_AGENT_COUNT + 1, CBRT_AGENT_COUNT + 2);
@@ -363,6 +367,7 @@ TEST(TestMessage_Array3D, ReadEmpty) {
         MsgArray3D::Description &message = model.newMessage<MsgArray3D>("location");
         message.setDimensions(2, 2, 2);
         message.newVariable<int>("id");  // unused by current test
+        message.newVariable<unsigned int>("value");  // unused by current test
     }
     {   // Circle agent
         AgentDescription &agent = model.newAgent("agent");

--- a/tests/test_cases/runtime/test_device_agent_creation.cu
+++ b/tests/test_cases/runtime/test_device_agent_creation.cu
@@ -1190,32 +1190,4 @@ TEST(DeviceAgentCreationTest, DeviceAgentBirth_DefaultWorks) {
         EXPECT_EQ(instance.getVariable<float>("y"), 14.0f);
     }
 }
-TEST(DeviceAgentCreationTest, DeviceAgentBirth_ArrayUnsuitable) {
-    // Curve will error, however agent creation will go through, agent will have default value
-    const std::array<int, 4> TEST_REFERENCE = { 3, 5, 9, 17 };
-    ModelDescription model("model");
-    AgentDescription &agent = model.newAgent("agent_name");
-    agent.newVariable<int, 4>("array_var", TEST_REFERENCE);
-    auto &fn = agent.newFunction("out", ArrayVarDeviceBirth_ArrayUnsuitable);
-    fn.setAllowAgentDeath(true);
-    fn.setAgentOutput(agent);
-    model.newLayer().addAgentFunction(fn);
-    // Run the init function
-    AgentPopulation population(agent, AGENT_COUNT);
-    for (unsigned int i = 0; i < AGENT_COUNT; i++) {
-        auto in = population.getNextInstance();
-    }
-    CUDAAgentModel sim(model);
-    sim.setPopulationData(population);
-    sim.step();
-    sim.getPopulationData(population);
-    // Check data is correct
-    EXPECT_EQ(population.getCurrentListSize(), AGENT_COUNT);
-    for (unsigned int i = 0; i < population.getCurrentListSize(); i++) {
-        AgentInstance instance = population.getInstanceAt(i);
-        // Check array sets are correct
-        auto array1 = instance.getVariable<int, 4>("array_var");
-        EXPECT_EQ(array1, TEST_REFERENCE);
-    }
-}
 }  // namespace test_device_agent_creation

--- a/tests/test_cases/runtime/test_host_api.cu
+++ b/tests/test_cases/runtime/test_host_api.cu
@@ -1,8 +1,6 @@
 #include "gtest/gtest.h"
 
 #include "flamegpu/flame_api.h"
-#include "flamegpu/runtime/flamegpu_api.h"
-
 
 namespace test_host_api {
 

--- a/tests/test_cases/runtime/test_rtc_device_api.cu
+++ b/tests/test_cases/runtime/test_rtc_device_api.cu
@@ -241,7 +241,7 @@ const char* rtc_array_set_agent_func = R"###(
 FLAMEGPU_AGENT_FUNCTION(rtc_test_func, MsgNone, MsgNone) {
     // Read variables a1 to a4
     // Store as array in array_var
-    int a0 = FLAMEGPU->getVariable<int, 2>("a1", 1);   // should not be able to read scalar value as array (expecting 0)
+    int a0 = 0;
     int a1 = FLAMEGPU->getVariable<int>("a1");
     int a2 = FLAMEGPU->getVariable<int>("a2");
     int a3 = FLAMEGPU->getVariable<int>("a3");
@@ -251,7 +251,6 @@ FLAMEGPU_AGENT_FUNCTION(rtc_test_func, MsgNone, MsgNone) {
     FLAMEGPU->setVariable<int, 5>("array_var", 2, a2);
     FLAMEGPU->setVariable<int, 5>("array_var", 3, a3);
     FLAMEGPU->setVariable<int, 5>("array_var", 4, a4);
-    FLAMEGPU->setVariable<int, 2>("a0", 0, 10);           // should not be possible (no value should be written)
     return ALIVE;
 }
 )###";
@@ -756,6 +755,5 @@ TEST(DeviceRTCAPITest, getStepCounter) {
         }
     }
 }
-
 
 }  // namespace test_rtc_device_api


### PR DESCRIPTION
Closes #88 

RTC functionality has been added too, it should have full parity with non-rtc.

Might be worth adding a warning, if module path does not align with fgpu include dir (an issue already exists for this, but it caught me out for a couple of hours).

**To Do:**
* Go through device API and use error reporting throughout
    - [x] `FLAMEGPU_READ_ONLY_DEVICE_API::getVariable<T, N>()` (bad var name, var type mismatch)
    - [x] `FLAMEGPU_READ_ONLY_DEVICE_API::getVariable<T, N, M>()` (bad var name, var type/len mismatch)
    - [x] `FLAMEGPU_DEVICE_API::setVariable<T, N>()` (bad var name, var type mismatch)
    - [x] `FLAMEGPU_DEVICE_API::setVariable<T, N, M>()` (bad var name, var type/len mismatch)
    - [x] `AgentRandom::uniform<T>(T, T)` x3 (if max <= min)
    - [x] `DeviceEnvironment::get<T, N>()` x2 (bad var name, var type/len mismatch)
    - [x] `AgentOut::setVariable<T, N>()` (bad var name, var type mismatch)
    - [x] `AgentOut::setVariable<T, N, M>()` (bad var name, var type/len mismatch)
    - [x] `MsgBruteForce::Out::setVariable<T, N>()` (bad var name, var type mismatch)
    - [x] `MsgBruteForce::Message::getVariable<T, N>()` (bad var name, var type mismatch)
    * ~~`MsgSpatial2D::Out::setLocation()` (out of bounds?)~~
    - [x] `MsgSpatial2D::In::Filter::Message::getVariable<T, N>()` (bad var name, var type mismatch)
    * ~~`MsgSpatial3D::Out::setLocation()` (out of bounds?)~~
    - [x] `MsgSpatial3D::In::Filter::Message::getVariable<T, N>()` (bad var name, var type mismatch)
    - [x] `MsgArray::Out::setIndex()` (out of bounds)
    - [x] `MsgArray::Out::setVariable<T, N>()` (bad var name, var type mismatch)
    - [x] `MsgArray::Message::getVariable<T, N>()` (bad var name, var type mismatch)
    - [x] `MsgArray::In::operator()()` (Bad radius)
    - [x] `MsgArray::In::at()` (Index out of bounds)
    - [x] `MsgArray2D::Out::setIndex()` (out of bounds?)
    - [x] `MsgArray2D::Out::setVariable<T, N>()` (bad var name, var type mismatch)
    - [x] `MsgArray2D::Message::getVariable<T, N>()` (bad var name, var type mismatch)
    - [x] `MsgArray2D::In::operator()()` (Bad radius)
    - [x] `MsgArray2D::In::at()` (Index out of bounds)
    * [x] `MsgArray3D::Out::setIndex()` (out of bounds)
    - [x] `MsgArray3D::Out::setVariable<T, N>()` (bad var name, var type mismatch)
    - [x] `MsgArray3D::Message::getVariable<T, N>()` (bad var name, var type mismatch)
    - [x] `MsgArray3D::In::operator()()` (Bad radius)
    - [x] `MsgArray3D::In::at()` (Index out of bounds)
    - [x] `MsgBucket::Out::setVariable<T, N>()` (bad var name, var type mismatch)
    - [x] `MsgBucket::Out::setKey()` (out of bounds)
    - [x] `MsgBucket::In::operator()()` (Out of range bucket)
    - [x] `MsgBucket::In::operator()(,)` (Out of range start/end bucket, end < start)
- [x] ? Add support for `%s` formatter.
- [x] Add tests that it works for both agent function and agent function condition (but not when `NO_SEATBELTS`).
- [x] Test it works nicely with RTC (e.g. will need to split the include in host/device, and check curve additions are ok with RTC).
- [x] Remove demo from circles_spatial3D
- [x] Add/test RTC support.
- [x] Modify Curve to not check typesize/length when not using `NO_SEATBELTS`.
- [x] Modify RTC Curve dynamic header to include type/length checks (but not when `NO_SEATBELTS`).