### PR TITLE
Fix 0 thread launch for optional message scattering

### DIFF
--- a/src/flamegpu/gpu/CUDAScatter.cu
+++ b/src/flamegpu/gpu/CUDAScatter.cu
@@ -268,6 +268,11 @@ void CUDAScatter::pbm_reorder(
     const unsigned int *d_bin_index,
     const unsigned int *d_bin_sub_index,
     const unsigned int *d_pbm) {
+    // If itemCount is 0, then there is no work to be done.
+    if (itemCount == 0) {
+        return;
+    }
+
     int blockSize = 0;  // The launch configurator returned block size
     int minGridSize = 0;  // The minimum grid size needed to achieve the // maximum occupancy for a full device // launch
     int gridSize = 0;  // The actual grid size needed, based on input size
@@ -508,6 +513,11 @@ void CUDAScatter::arrayMessageReorder(
     const unsigned int &itemCount,
     const unsigned int &array_length,
     unsigned int *d_write_flag) {
+    // If itemCount is 0, then there is no work to be done.
+    if (itemCount == 0) {
+        return;
+    }
+
     if (itemCount > array_length) {
         THROW ArrayMessageWriteConflict("Too many messages output for array message structure (%u > %u).\n", itemCount, array_length);
     }

--- a/tests/test_cases/runtime/messaging/test_array.cu
+++ b/tests/test_cases/runtime/messaging/test_array.cu
@@ -29,6 +29,9 @@ FLAMEGPU_AGENT_FUNCTION(OutOptionalFunction, MsgNone, MsgArray) {
     }
     return ALIVE;
 }
+FLAMEGPU_AGENT_FUNCTION(OutOptionalNoneFunction, MsgNone, MsgArray) {
+    return ALIVE;
+}
 FLAMEGPU_AGENT_FUNCTION(OutBad, MsgNone, MsgArray) {
     const unsigned int index = FLAMEGPU->getVariable<unsigned int>("message_write");
     FLAMEGPU->message_out.setVariable<unsigned int>("index_times_3", index * 3);
@@ -134,6 +137,48 @@ TEST(TestMessage_Array, Optional) {
         const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
         index = index % 2 == 0 ? index : 0;
         EXPECT_EQ(index * 3, message_read);
+    }
+}
+
+// Test optional message output, wehre no messages are output.
+TEST(TestMessage_Array, OptionalNone) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray::Description &msg = m.newMessage<MsgArray>(MESSAGE_NAME);
+    msg.setLength(AGENT_COUNT);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutOptionalNoneFunction);
+    fo.setMessageOutput(msg);
+    fo.setMessageOutputOptional(true);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, InFunction);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+
+    // Generate an arbitrary population.
+    AgentPopulation pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getNextInstance();
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+    }
+    // Set pop in model
+    CUDAAgentModel c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getInstanceAt(i);
+        unsigned int index = ai.getVariable<unsigned int>("index");
+        const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
+        // no messages should have been read.
+        EXPECT_EQ(0, message_read);
     }
 }
 

--- a/tests/test_cases/runtime/messaging/test_array_2d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_2d.cu
@@ -35,6 +35,9 @@ FLAMEGPU_AGENT_FUNCTION(OutOptionalFunction, MsgNone, MsgArray2D) {
     }
     return ALIVE;
 }
+FLAMEGPU_AGENT_FUNCTION(OutOptionalNoneFunction, MsgNone, MsgArray2D) {
+    return ALIVE;
+}
 FLAMEGPU_AGENT_FUNCTION(OutBad, MsgNone, MsgArray2D) {
     unsigned int index = FLAMEGPU->getVariable<unsigned int>("message_write");
     FLAMEGPU->message_out.setVariable<unsigned int>("index_times_3", index * 3);
@@ -145,6 +148,48 @@ TEST(TestMessage_Array2D, Optional) {
         const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
         index = index % 2 == 0 ? index : 0;
         EXPECT_EQ(index * 3, message_read);
+    }
+}
+
+// Test optional message output, wehre no messages are output.
+TEST(TestMessage_Array3D, OptionalNone) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray2D::Description &msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
+    msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT + 1);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutOptionalNoneFunction);
+    fo.setMessageOutput(msg);
+    fo.setMessageOutputOptional(true);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, InFunction);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+
+    // Generate an arbitrary population.
+    AgentPopulation pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getNextInstance();
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+    }
+    // Set pop in model
+    CUDAAgentModel c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = pop.getInstanceAt(i);
+        unsigned int index = ai.getVariable<unsigned int>("index");
+        const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
+        // no messages should have been read.
+        EXPECT_EQ(0, message_read);
     }
 }
 

--- a/tests/test_cases/runtime/messaging/test_spatial_2d.cu
+++ b/tests/test_cases/runtime/messaging/test_spatial_2d.cu
@@ -29,6 +29,9 @@ FLAMEGPU_AGENT_FUNCTION(out_optional2D, MsgNone, MsgSpatial2D) {
     }
     return ALIVE;
 }
+FLAMEGPU_AGENT_FUNCTION(out_optional2DNone, MsgNone, MsgSpatial2D) {
+    return ALIVE;
+}
 FLAMEGPU_AGENT_FUNCTION(in2D, MsgSpatial2D, MsgNone) {
     const float x1 = FLAMEGPU->getVariable<float>("x");
     const float y1 = FLAMEGPU->getVariable<float>("y");
@@ -320,6 +323,100 @@ TEST(Spatial2DMsgTest, Optional) {
     }
     EXPECT_EQ(badCountWrong, 0u);
 }
+TEST(Spatial2DMsgTest, OptionalNone) {
+    /**
+     * This test is same as Mandatory, however extra flag has been added to block certain agents from outputting messages
+     * Look for NEW!
+     */
+    std::unordered_map<int, unsigned int> bin_counts;
+    std::unordered_map<int, unsigned int> bin_counts_optional;
+    // Construct model
+    ModelDescription model("Spatial2DMsgTestModel");
+    {   // Location message
+        MsgSpatial2D::Description &message = model.newMessage<MsgSpatial2D>("location");
+        message.setMin(0, 0);
+        message.setMax(11, 11);
+        message.setRadius(1);
+        // 11x11 bins, total 121
+        message.newVariable<int>("id");  // unused by current test
+    }
+    {   // Circle agent
+        AgentDescription &agent = model.newAgent("agent");
+        agent.newVariable<int>("id");
+        agent.newVariable<float>("x");
+        agent.newVariable<float>("y");
+        agent.newVariable<int>("do_output");  // NEW!
+        agent.newVariable<unsigned int>("myBin");  // This will be presumed bin index of the agent, might not use this
+        agent.newVariable<unsigned int>("count");  // Store the distance moved here, for validation
+        agent.newVariable<unsigned int>("badCount");  // Store how many messages are out of range
+        auto &af = agent.newFunction("out", out_optional2DNone);  // NEW!
+        af.setMessageOutput("location");
+        af.setMessageOutputOptional(true);  // NEW!
+        agent.newFunction("in", in2D).setMessageInput("location");
+    }
+    {   // Layer #1
+        LayerDescription &layer = model.newLayer();
+        layer.addAgentFunction(out_optional2DNone);  // NEW!
+    }
+    {   // Layer #2
+        LayerDescription &layer = model.newLayer();
+        layer.addAgentFunction(in2D);
+    }
+    CUDAAgentModel cuda_model(model);
+
+    const int AGENT_COUNT = 2049;
+    AgentPopulation population(model.Agent("agent"), AGENT_COUNT);
+    // Initialise agents (TODO)
+    {
+        // Currently population has not been init, so generate an agent population on the fly
+        std::default_random_engine rng;
+        std::uniform_real_distribution<float> dist(0.0f, 11.0f);
+        std::uniform_real_distribution<float> dist5(0.0f, 5.0f);
+        for (unsigned int i = 0; i < AGENT_COUNT; i++) {
+            AgentInstance instance = population.getNextInstance();
+            instance.setVariable<int>("id", i);
+            float pos[3] = { dist(rng), dist(rng), dist(rng) };
+            int do_output = dist5(rng) < 4 ? 1 : 0;  // 80% chance of output  // NEW!
+            instance.setVariable<float>("x", pos[0]);
+            instance.setVariable<float>("y", pos[1]);
+            instance.setVariable<int>("do_output", do_output);  // NEW!
+            // Solve the bin index
+            const unsigned int bin_pos[2] = {
+                (unsigned int)(pos[0] / 1),
+                (unsigned int)(pos[1] / 1)
+            };
+            const unsigned int bin_index =
+                bin_pos[1] * 11 +
+                bin_pos[0];
+            instance.setVariable<unsigned int>("myBin", bin_index);
+            // Create it if it doesn't already exist
+            bin_counts[bin_index] += 1;
+            if (do_output) {  // NEW!
+                bin_counts_optional[bin_index] += 1;  // NEW!
+            }
+        }
+        cuda_model.setPopulationData(population);
+    }
+
+    // Execute a single step of the model
+    cuda_model.step();
+
+    // Recover the results and check they match what was expected
+
+    cuda_model.getPopulationData(population);
+    // Validate each agent has same result
+    unsigned int badCountWrong = 0;
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentInstance ai = population.getInstanceAt(i);
+        unsigned int myBin = ai.getVariable<unsigned int>("myBin");
+        unsigned int myResult = ai.getVariable<unsigned int>("count");
+        if (ai.getVariable<unsigned int>("badCount"))
+            badCountWrong++;
+        EXPECT_EQ(myResult, 0);  // NEW!
+    }
+    EXPECT_EQ(badCountWrong, 0u);
+}
+
 TEST(Spatial2DMsgTest, BadRadius) {
     ModelDescription model("Spatial2DMsgTestModel");
     MsgSpatial2D::Description &message = model.newMessage<MsgSpatial2D>("location");


### PR DESCRIPTION
Adds tests to check for optional messages leading to 0 messages being output for each type of messaging.

Fixes the issue by checking for 0 items to scatter prior to kernel launch. 