### PR TITLE
In-Layer Concurrency

### DIFF
--- a/include/flamegpu/exception/FGPUDeviceException.h
+++ b/include/flamegpu/exception/FGPUDeviceException.h
@@ -22,8 +22,8 @@ class DeviceExceptionManager {
      * Free all device memory
      */
     ~DeviceExceptionManager();
-    DeviceExceptionBuffer *getDevicePtr(const unsigned int &streamId);
-    void checkError(const std::string &function, const unsigned int &streamId);
+    DeviceExceptionBuffer *getDevicePtr(const unsigned int &streamId, const cudaStream_t &stream);
+    void checkError(const std::string &function, const unsigned int &streamId, const cudaStream_t &stream);
 
  private:
     /**

--- a/include/flamegpu/exception/FGPUException.h
+++ b/include/flamegpu/exception/FGPUException.h
@@ -419,5 +419,9 @@ DERIVED_FGPUException(VersionMismatch, "Versions do not match");
  * Defines an error reported when the expect input/output file path does not exist
  */
 DERIVED_FGPUException(InvalidFilePath, "File does not exist.");
+/*
+ * Defines an error indicating that a CUDAEventTimer was queried without being synced.
+ */
+DERIVED_FGPUException(UnsycnedCUDAEventTimer, "Elapsed time requested for Un-synced CUDAEventTimer");
 
 #endif  // INCLUDE_FLAMEGPU_EXCEPTION_FGPUEXCEPTION_H_

--- a/include/flamegpu/gpu/CUDAAgent.h
+++ b/include/flamegpu/gpu/CUDAAgent.h
@@ -78,7 +78,7 @@ class CUDAAgent : public AgentInterface {
      * @param population An AgentPopulation object with the same internal AgentData description, to provide the input data
      * @note Scatter is required for initialising submodel vars
      */
-    void setPopulationData(const AgentPopulation& population, CUDAScatter &scatter, const unsigned int &streamId);
+    void setPopulationData(const AgentPopulation& population, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Copies population data the device buffers held by this object
      * To the hosts object (overwriting any existing agent data)
@@ -113,7 +113,7 @@ class CUDAAgent : public AgentInterface {
      * @param streamId The index of the agent function within the current layer
      * @see CUDAFatAgent::processDeath(const unsigned int &, const std::string &, const unsigned int &)
      */
-    void processDeath(const AgentFunctionData& func, CUDAScatter &scatter, const unsigned int &streamId);
+    void processDeath(const AgentFunctionData& func, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Transitions all active agents from the source state to the destination state
      * @param _src The source state
@@ -122,7 +122,7 @@ class CUDAAgent : public AgentInterface {
      * @param streamId The index of the agent function within the current layer
      * @see CUDAFatAgent::transitionState(const unsigned int &, const std::string &, const std::string &, const unsigned int &)
      */
-    void transitionState(const std::string &_src, const std::string &_dest, CUDAScatter &scatter, const unsigned int &streamId);
+    void transitionState(const std::string &_src, const std::string &_dest, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Scatters agents based on their output of the agent function condition
      * Agents which failed the condition are scattered to the front and marked as disabled
@@ -134,7 +134,7 @@ class CUDAAgent : public AgentInterface {
      * @note Named state must not already contain disabled agents
      * @note The disabled agents are re-enabled using clearFunctionCondition(const std::string &)
      */
-    void processFunctionCondition(const AgentFunctionData& func, CUDAScatter &scatter, const unsigned int &streamId);
+    void processFunctionCondition(const AgentFunctionData& func, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Scatters agents from the provided device buffer, this is used for host agent creation
      * The device buffer must be packed according to the param offsets
@@ -145,7 +145,7 @@ class CUDAAgent : public AgentInterface {
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId This is required for scan compaction arrays and async
      */
-    void scatterHostCreation(const std::string &state_name, const unsigned int &newSize, char *const d_inBuff, const VarOffsetStruct &offsets, CUDAScatter &scatter, const unsigned int &streamId);
+    void scatterHostCreation(const std::string &state_name, const unsigned int &newSize, char *const d_inBuff, const VarOffsetStruct &offsets, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Sorts all agent variables according to the positions stored inside Message Output scan buffer
      * @param state_name The state agents are scattered into
@@ -153,7 +153,7 @@ class CUDAAgent : public AgentInterface {
      * @param streamId The stream in which the corresponding agent function has executed
      * @see HostAgentInstance::sort(const std::string &, HostAgentInstance::Order, int, int)
      */
-    void scatterSort(const std::string &state_name, CUDAScatter &scatter, const unsigned int &streamId);
+    void scatterSort(const std::string &state_name, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Allocates a buffer for storing new agents into and
      * uses the cuRVE runtime to map variables for use with an agent function that has device agent birth
@@ -180,7 +180,7 @@ class CUDAAgent : public AgentInterface {
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId This is required for scan compaction arrays and async
      */
-    void scatterNew(const AgentFunctionData& func, const unsigned int &newSize, CUDAScatter &scatter, const unsigned int &streamId);
+    void scatterNew(const AgentFunctionData& func, const unsigned int &newSize, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Reenables all disabled agents within the named state
      * @param state The named state to enable all agents within
@@ -210,7 +210,7 @@ class CUDAAgent : public AgentInterface {
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId This is required for scan compaction arrays and async
      */
-    void initUnmappedVars(CUDAScatter &scatter, const unsigned int &streamId);
+    void initUnmappedVars(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Resets the number of agents in every statelist to 0
      */

--- a/include/flamegpu/gpu/CUDAAgentStateList.h
+++ b/include/flamegpu/gpu/CUDAAgentStateList.h
@@ -75,7 +75,7 @@ class CUDAAgentStateList {
      * @param scatter Scatter instance and scan arrays to be used
      * @param streamId This is required for scan compaction arrays and async
      */
-    void setAgentData(const AgentStateMemory &data, CUDAScatter &scatter, const unsigned int &streamId);
+    void setAgentData(const AgentStateMemory &data, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Retrieve agent data from the agent state list into agent state memory
      * @data data Destination for agent data
@@ -91,13 +91,13 @@ class CUDAAgentStateList {
      * @param scatter Scatter instance and scan arrays to be used
      * @param streamId This is required for scan compaction arrays and async
      */
-    void scatterHostCreation(const unsigned int &newSize, char *const d_inBuff, const VarOffsetStruct &offsets, CUDAScatter &scatter, const unsigned int &streamId);
+    void scatterHostCreation(const unsigned int &newSize, char *const d_inBuff, const VarOffsetStruct &offsets, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Sorts all agent variables according to the positions stored inside Message Output scan buffer
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId The stream in which the corresponding agent function has executed
      */
-    void scatterSort(CUDAScatter &scatter, const unsigned int &streamId);
+    void scatterSort(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Scatters agents from the currently assigned device agent birth buffer (see member variable newBuffs)
      * The device buffer must be packed in the same format as CUDAAgent::mapNewRuntimeVariables(const AgentFunctionData&, const unsigned int &, const unsigned int &)
@@ -106,7 +106,7 @@ class CUDAAgentStateList {
      * @param scatter Scatter instance and scan arrays to be used
      * @param streamId This is required for scan compaction arrays and async
      */
-    void scatterNew(void * d_newBuff, const unsigned int &newSize, CUDAScatter &scatter, const unsigned int &streamId);
+    void scatterNew(void * d_newBuff, const unsigned int &newSize, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Returns true if the state list is not the primary statelist (and is mapped to a master agent state)
      */
@@ -116,7 +116,7 @@ class CUDAAgentStateList {
      * @param scatter Scatter instance and scan arrays to be used
      * @param streamId This is required for scan compaction arrays and async
      */
-    void initUnmappedVars(CUDAScatter &scatter, const unsigned int &streamId);
+    void initUnmappedVars(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Returns the statelist to an empty state
      * This resets the size to 0.

--- a/include/flamegpu/gpu/CUDAEnsemble.h
+++ b/include/flamegpu/gpu/CUDAEnsemble.h
@@ -77,9 +77,8 @@ class CUDAEnsemble {
     void setExitLog(const LoggingConfig &exitConfig);
     /**
      * Get the duration of the last call to simulate() in milliseconds. 
-     * With a resolution of around 0.5 microseconds (cudaEventElapsedtime)
      */
-    int64_t getEnsembleElapsedTime() const { return ensemble_elapsed_time; }
+    float getEnsembleElapsedTime() const { return ensemble_elapsed_time; }
     /**
      * Return the list of logs collected from the last call to simulate()
      */
@@ -117,7 +116,7 @@ class CUDAEnsemble {
     /**
      * Runtime of previous call to simulate() in milliseconds, initially 0
      */
-    int64_t ensemble_elapsed_time = 0;
+    float ensemble_elapsed_time = 0.f;
 };
 
 #endif  // INCLUDE_FLAMEGPU_GPU_CUDAENSEMBLE_H_

--- a/include/flamegpu/gpu/CUDAFatAgent.h
+++ b/include/flamegpu/gpu/CUDAFatAgent.h
@@ -90,7 +90,7 @@ class CUDAFatAgent {
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId Index of the stream used for scan compaction flags (and async cuda ops)
      */
-    void processDeath(const unsigned int &agent_fat_id, const std::string &state_name, CUDAScatter &scatter, const unsigned int &streamId);
+    void processDeath(const unsigned int &agent_fat_id, const std::string &state_name, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Transitions all active agents from the source state to the destination state
      * @param agent_fat_id The index of the CUDAAgent within this CUDAFatAgent
@@ -99,7 +99,7 @@ class CUDAFatAgent {
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId Index of the stream used for scan compaction flags (and async cuda ops)
      */
-    void transitionState(const unsigned int &agent_fat_id, const std::string &_src, const std::string &_dest, CUDAScatter &scatter, const unsigned int &streamId);
+    void transitionState(const unsigned int &agent_fat_id, const std::string &_src, const std::string &_dest, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Reads the flags set by an agent function condition in order to sort agents according to whether they passed or failed
      * Failed agents are sorted to the front and marked as disabled, passing agents are then sorted to the back
@@ -108,7 +108,7 @@ class CUDAFatAgent {
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId Index of the stream used for scan compaction flags (and async cuda ops)
      */
-    void processFunctionCondition(const unsigned int &agent_fat_id, const std::string &state_name, CUDAScatter &scatter, const unsigned int &streamId);
+    void processFunctionCondition(const unsigned int &agent_fat_id, const std::string &state_name, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Marks the specified number of agents within the specified statelist as disabled
      * @param agent_fat_id The index of the CUDAAgent within this CUDAFatAgent

--- a/include/flamegpu/gpu/CUDAFatAgentStateList.h
+++ b/include/flamegpu/gpu/CUDAFatAgentStateList.h
@@ -195,7 +195,7 @@ class CUDAFatAgentStateList {
      * @param streamId The stream in which the corresponding agent function has executed
      * @return The number of agents that are still alive (this includes temporarily disabled agents due to agent function condition)
      */
-    unsigned int scatterDeath(CUDAScatter &scatter, const unsigned int &streamId);
+    unsigned int scatterDeath(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Scatters all living agents which failed the agent function condition into the swap buffer (there should be no disabled at this time)
      * This does not swap buffers or update disabledAgent)
@@ -204,7 +204,7 @@ class CUDAFatAgentStateList {
      * @return The number of agents that were scattered (the number of agents which failed the condition)
      * @see scatterAgentFunctionConditionTrue(const unsigned int &, const unsigned int &)
      */
-    unsigned int scatterAgentFunctionConditionFalse(CUDAScatter &scatter, const unsigned int &streamId);
+    unsigned int scatterAgentFunctionConditionFalse(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Scatters all living agents which passed the agent function condition into the swap buffer (there should be no disabled at this time)
      * Also swaps the buffers and sets the number of disabled agents
@@ -215,13 +215,13 @@ class CUDAFatAgentStateList {
      * @see scatterAgentFunctionConditionFalse(const unsigned int &)
      * @see setConditionState(const unsigned int &)
      */
-    unsigned int scatterAgentFunctionConditionTrue(const unsigned int &conditionFailCount, CUDAScatter &scatter, const unsigned int &streamId);
+    unsigned int scatterAgentFunctionConditionTrue(const unsigned int &conditionFailCount, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Sorts all agent variables according to the positions stored inside Message Output scan buffer
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId The stream in which the corresponding agent function has executed
      */
-    void scatterSort(CUDAScatter &scatter, const unsigned int &streamId);
+    void scatterSort(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Set the number of disabled agents within the state list
      * Updates member var disabledAgents and data_condition for every item inside variables_unique
@@ -231,7 +231,7 @@ class CUDAFatAgentStateList {
     /**
      * Resets the value of all variables not present in exclusionSet to their defaults
      */
-    void initVariables(std::set<std::shared_ptr<VariableBuffer>> &exclusionSet, const unsigned int initCount, const unsigned initOffset, CUDAScatter &scatter, const unsigned int &streamId);
+    void initVariables(std::set<std::shared_ptr<VariableBuffer>> &exclusionSet, const unsigned int initCount, const unsigned initOffset, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
      * Returns the collection of unique variable buffers held by this CUDAFatAgentStateList
      */

--- a/include/flamegpu/gpu/CUDAMessage.h
+++ b/include/flamegpu/gpu/CUDAMessage.h
@@ -125,7 +125,7 @@ class CUDAMessage {
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId Index of stream specific structures used
      */
-    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId);
+    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     const void *getMetaDataDevicePtr() const;
 
  protected:

--- a/include/flamegpu/model/ModelData.h
+++ b/include/flamegpu/model/ModelData.h
@@ -152,6 +152,11 @@ struct ModelData : std::enable_shared_from_this<ModelData>{
      */
     bool operator!=(const ModelData& rhs) const;
 
+    /**
+     * @return The maximum layer width within the model's hierarchy
+     */
+    ModelData::size_type getMaxLayerWidth() const;
+
  protected:
     friend SubModelData;  // Uses private copy constructor
     /**

--- a/include/flamegpu/runtime/messaging/Array/ArrayHost.h
+++ b/include/flamegpu/runtime/messaging/Array/ArrayHost.h
@@ -39,7 +39,7 @@ class MsgArray::CUDAModelHandler : public MsgSpecialisationHandler {
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId Index of stream specific structures used
      */
-    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId) override;
+    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) override;
     /**
      * Allocates memory for the constructed index.
      * The memory allocation is checked by build index.

--- a/include/flamegpu/runtime/messaging/Array2D/Array2DHost.h
+++ b/include/flamegpu/runtime/messaging/Array2D/Array2DHost.h
@@ -41,7 +41,7 @@ class MsgArray2D::CUDAModelHandler : public MsgSpecialisationHandler {
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId Index of stream specific structures used
      */
-    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId) override;
+    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) override;
     /**
      * Allocates memory for the constructed index.
      * The memory allocation is checked by build index.

--- a/include/flamegpu/runtime/messaging/Array3D/Array3DHost.h
+++ b/include/flamegpu/runtime/messaging/Array3D/Array3DHost.h
@@ -40,7 +40,7 @@ class MsgArray3D::CUDAModelHandler : public MsgSpecialisationHandler {
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId Index of stream specific structures used
      */
-    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId) override;
+    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) override;
     /**
      * Allocates memory for the constructed index.
      * The memory allocation is checked by build index.

--- a/include/flamegpu/runtime/messaging/BruteForce/BruteForceHost.h
+++ b/include/flamegpu/runtime/messaging/BruteForce/BruteForceHost.h
@@ -52,7 +52,7 @@ class MsgBruteForce::CUDAModelHandler : public MsgSpecialisationHandler {
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId Index of stream specific structures used
      */
-    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId) override;
+    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) override;
     /**
      * Allocates memory for the constructed index.
      * The memory allocation is checked by build index.

--- a/include/flamegpu/runtime/messaging/Bucket/BucketHost.h
+++ b/include/flamegpu/runtime/messaging/Bucket/BucketHost.h
@@ -40,7 +40,7 @@ class MsgBucket::CUDAModelHandler : public MsgSpecialisationHandler {
     * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
     * @param streamId Index of stream specific structures used
     */
-    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId) override;
+    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) override;
     /**
     * Allocates memory for the constructed index.
     * The memory allocation is checked by build index.

--- a/include/flamegpu/runtime/messaging/None/NoneHost.h
+++ b/include/flamegpu/runtime/messaging/None/NoneHost.h
@@ -31,7 +31,7 @@ class MsgSpecialisationHandler {
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId Index of stream specific structures used
      */
-    virtual void buildIndex(CUDAScatter &, const unsigned int &) { }
+    virtual void buildIndex(CUDAScatter &, const unsigned int &streamId, const cudaStream_t &stream) { }
     /**
      * Allocates memory for the constructed index.
      * The memory allocation is checked by build index.

--- a/include/flamegpu/runtime/messaging/Spatial2D/Spatial2DHost.h
+++ b/include/flamegpu/runtime/messaging/Spatial2D/Spatial2DHost.h
@@ -42,7 +42,7 @@ class MsgSpatial2D::CUDAModelHandler : public MsgSpecialisationHandler {
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId Index of stream specific structures used
      */
-    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId) override;
+    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) override;
     /**
      * Allocates memory for the constructed index.
      * The memory allocation is checked by build index.

--- a/include/flamegpu/runtime/messaging/Spatial3D/Spatial3DHost.h
+++ b/include/flamegpu/runtime/messaging/Spatial3D/Spatial3DHost.h
@@ -43,7 +43,7 @@ class MsgSpatial3D::CUDAModelHandler : public MsgSpecialisationHandler {
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId Index of stream specific structures used
      */
-    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId) override;
+    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) override;
     /**
      * Allocates memory for the constructed index.
      * The memory allocation is checked by build index.

--- a/include/flamegpu/sim/Simulation.h
+++ b/include/flamegpu/sim/Simulation.h
@@ -81,7 +81,9 @@ class Simulation {
  public:
     void initialise(int argc, const char** argv);
 
+    virtual void initFunctions() = 0;
     virtual bool step() = 0;
+    virtual void exitFunctions() = 0;
     virtual void simulate() = 0;
     /**
      * Returns the simulation to a clean state
@@ -143,6 +145,13 @@ class Simulation {
      * @note This value is used internally for environment property storage
      */
     unsigned int getInstanceID() const { return instance_id; }
+
+    /**
+     * returns the width of the widest layer in model.
+     * @return the width of the widest layer.
+     */
+    unsigned int getMaximumLayerWidth() const { return maxLayerWidth; }
+
     const std::shared_ptr<const ModelData> model;
 
     /**
@@ -168,6 +177,10 @@ class Simulation {
      * Initial environment items if they have been loaded from file, prior to device selection
      */
     std::unordered_map<std::pair<std::string, unsigned int>, Any> env_init;
+    /**
+     * the width of the widest layer in the concrete version of the model (calculated once)
+     */
+    unsigned int maxLayerWidth;
 
  private:
     /**

--- a/include/flamegpu/util/CUDAEventTimer.cuh
+++ b/include/flamegpu/util/CUDAEventTimer.cuh
@@ -1,0 +1,94 @@
+#ifndef INCLUDE_FLAMEGPU_UTIL_CUDAEVENTTIMER_CUH_
+#define INCLUDE_FLAMEGPU_UTIL_CUDAEVENTTIMER_CUH_
+
+#include "flamegpu/exception/FGPUException.h"
+#include "flamegpu/gpu/CUDAErrorChecking.h"
+
+namespace util {
+
+/**
+ * Class to simplify the use of CUDAEvents for timing.
+ * Timing between CUDAEvent_t is only accurate in the default stream, hence streams cannot be passed.
+ * @todo - this appears unreliable on WDDM devices
+ * @todo - make this device aware (cudaGetDevice, cudaSetDevice)?
+ */
+class CUDAEventTimer {
+ public:
+    /** 
+     * Default constructor, creates the cudaEvents and initialises values.
+     */
+    CUDAEventTimer() :
+    startEvent(NULL),
+    stopEvent(NULL),
+    ms(0.),
+    synced(false) {
+        gpuErrchk(cudaEventCreate(&this->startEvent));
+        gpuErrchk(cudaEventCreate(&this->stopEvent));
+    }
+    /** 
+     * Destroys the cudaEvents created by this instance
+     */
+    ~CUDAEventTimer() {
+        gpuErrchk(cudaEventDestroy(this->startEvent));
+        gpuErrchk(cudaEventDestroy(this->stopEvent));
+        this->startEvent = NULL;
+        this->startEvent = NULL;
+    }
+    /**
+     * Record the start event, resetting the syncronisation flag.
+     */
+    void start() {
+        gpuErrchk(cudaEventRecord(this->startEvent));
+        synced = false;
+    }
+    /**
+     * Record the stop event, resetting the syncronisation flag.
+     */
+    void stop() {
+        gpuErrchk(cudaEventRecord(this->stopEvent));
+        synced = false;
+    }
+    /**
+     * Syncrhonize the cudaEvent(s), calcualting the elapsed time in ms between the two events.
+     * this is only accurate if used for the default stream (hence streams are not used)
+     * Sets the flag indicating syncronisation has occured, and therefore the elapsed time can be queried.
+     * @return elapsed time in milliseconds
+     */
+    float sync() {
+        gpuErrchk(cudaEventSynchronize(this->stopEvent));
+        gpuErrchk(cudaEventElapsedTime(&this->ms, this->startEvent, this->stopEvent));
+        synced = true;
+        return ms;
+    }
+    /**
+     * Get the elapsed time between the start event being issued and the stop event occuring.
+     * @return elapsed time in milliseconds
+     */
+    float getElapsedMilliseconds() {
+        if (!synced) {
+            THROW UnsycnedCUDAEventTimer();
+        }
+        return ms;
+    }
+
+ private:
+    /**
+     * CUDA Event for the start event
+     */
+    cudaEvent_t startEvent;
+    /**
+     * CUDA Event for the stop event
+     */
+    cudaEvent_t stopEvent;
+    /**
+     * Elapsed times between start and stop in milliseconds
+     */
+    float ms;
+    /**
+     * Flag to return whether events have been synced or not.
+     */
+    bool synced;
+};
+
+}  // namespace util
+#endif  // INCLUDE_FLAMEGPU_UTIL_CUDAEVENTTIMER_CUH_

--- a/include/flamegpu/util/SteadyClockTimer.h
+++ b/include/flamegpu/util/SteadyClockTimer.h
@@ -1,0 +1,39 @@
+#ifndef INCLUDE_FLAMEGPU_UTIL_STEADYCLOCKTIMER_H_
+#define INCLUDE_FLAMEGPU_UTIL_STEADYCLOCKTIMER_H_
+
+#include <chrono>
+
+namespace util {
+
+/** 
+ * Class to simplify the finding of elapsed time using a chrono::steady_clock timer.
+ */
+class SteadyClockTimer {
+ public:
+    SteadyClockTimer() :
+        _start(),
+        _stop() { }
+
+    ~SteadyClockTimer() { }
+
+    void start() {
+        _start = std::chrono::steady_clock::now();
+    }
+
+    void stop() {
+        _stop = std::chrono::steady_clock::now();
+    }
+
+    float getElapsedMilliseconds() {
+        std::chrono::duration<double> elapsed = this->_stop - this->_start;
+        float ms = static_cast<float>(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count());
+        return ms;
+    }
+
+ private:
+    std::chrono::time_point<std::chrono::steady_clock> _start;
+    std::chrono::time_point<std::chrono::steady_clock> _stop;
+};
+
+}  // namespace util
+#endif  // INCLUDE_FLAMEGPU_UTIL_STEADYCLOCKTIMER_H_

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -169,6 +169,8 @@ SET(SRC_INCLUDE
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/utility/RandomManager.cuh    
     ${FLAMEGPU_ROOT}/include/flamegpu/util/Any.h
     ${FLAMEGPU_ROOT}/include/flamegpu/util/nvtx.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/util/CUDAEventTimer.cuh
+    ${FLAMEGPU_ROOT}/include/flamegpu/util/SteadyClockTimer.h
     ${FLAMEGPU_ROOT}/include/flamegpu/util/SignalHandlers.h
     ${FLAMEGPU_ROOT}/include/flamegpu/util/compute_capability.cuh
     ${FLAMEGPU_ROOT}/include/flamegpu/util/JitifyCache.h

--- a/src/flamegpu/gpu/CUDAMessage.cu
+++ b/src/flamegpu/gpu/CUDAMessage.cu
@@ -302,10 +302,10 @@ void CUDAMessage::swap() {
     message_list->swap();
 }
 
-void CUDAMessage::buildIndex(CUDAScatter &scatter, const unsigned int &streamId) {
+void CUDAMessage::buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
     // Build the index if required.
     if (pbm_construction_required) {
-        specialisation_handler->buildIndex(scatter, streamId);
+        specialisation_handler->buildIndex(scatter, streamId, stream);
         pbm_construction_required = false;
     }
 }

--- a/src/flamegpu/gpu/CUDAMessageList.cu
+++ b/src/flamegpu/gpu/CUDAMessageList.cu
@@ -23,12 +23,12 @@ CUDAMessageList::CUDAMessageList(CUDAMessage& cuda_message, CUDAScatter &scatter
         {
             auto &a = cuda_message.getReadList();
             auto &_a = d_list;
-            scatter.scatterAll(streamId, message.getMessageDescription().variables, a, _a, message.getMessageCount(), 0);
+            scatter.scatterAll(streamId, 0, message.getMessageDescription().variables, a, _a, message.getMessageCount(), 0);
         }
         {  // Is copying writelist redundant?
             auto &a = cuda_message.getWriteList();
             auto &_a = d_swap_list;
-            scatter.scatterAll(streamId, message.getMessageDescription().variables, a, _a, message.getMessageCount(), 0);
+            scatter.scatterAll(streamId, 0, message.getMessageDescription().variables, a, _a, message.getMessageCount(), 0);
         }
     }
 }
@@ -142,6 +142,7 @@ unsigned int CUDAMessageList::scatter(const unsigned int &newCount, CUDAScatter 
     if (append) {
         unsigned int oldCount = message.getMessageCount();
         return oldCount + scatter.scatter(streamId,
+            0,
             CUDAScatter::Type::MESSAGE_OUTPUT,
             message.getMessageDescription().variables,
             d_swap_list, d_list,
@@ -149,6 +150,7 @@ unsigned int CUDAMessageList::scatter(const unsigned int &newCount, CUDAScatter 
             oldCount);
     } else {
         return scatter.scatter(streamId,
+            0,
             CUDAScatter::Type::MESSAGE_OUTPUT,
             message.getMessageDescription().variables,
             d_swap_list, d_list,
@@ -159,6 +161,7 @@ unsigned int CUDAMessageList::scatter(const unsigned int &newCount, CUDAScatter 
 unsigned int CUDAMessageList::scatterAll(const unsigned int &newCount, CUDAScatter &scatter, const unsigned int &streamId) {
     unsigned int oldCount = message.getMessageCount();
     return oldCount + scatter.scatterAll(streamId,
+        0,
         message.getMessageDescription().variables,
         d_swap_list, d_list,
         newCount,

--- a/src/flamegpu/gpu/CUDAScanCompaction.cu
+++ b/src/flamegpu/gpu/CUDAScanCompaction.cu
@@ -48,10 +48,10 @@ void CUDAScanCompactionConfig::free_scan_flag() {
 
 void CUDAScanCompactionConfig::zero_scan_flag() {
     if (d_ptrs.position) {
-        gpuErrchk(cudaMemset(d_ptrs.position, 0, scan_flag_len * sizeof(unsigned int)));
+        gpuErrchk(cudaMemset(d_ptrs.position, 0, scan_flag_len * sizeof(unsigned int)));  // @todo - make this async + streamSync for less ensbemble blocking.
     }
     if (d_ptrs.scan_flag) {
-        gpuErrchk(cudaMemset(d_ptrs.scan_flag, 0, scan_flag_len * sizeof(unsigned int)));
+        gpuErrchk(cudaMemset(d_ptrs.scan_flag, 0, scan_flag_len * sizeof(unsigned int)));  // @todo - make this async + streamSync for less ensbemble blocking.
     }
 }
 

--- a/src/flamegpu/model/ModelData.cpp
+++ b/src/flamegpu/model/ModelData.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <algorithm>
 
 #include "flamegpu/model/ModelData.h"
 
@@ -172,3 +173,10 @@ bool ModelData::hasSubModelRecursive(const std::shared_ptr<const ModelData> &sub
     return false;
 }
 
+ModelData::size_type ModelData::getMaxLayerWidth() const {
+    unsigned int maxWidth = 0u;
+    for (auto &layer : layers) {
+        maxWidth = (std::max)(maxWidth, static_cast<ModelData::size_type>(layer->agent_functions.size()));
+    }
+    return maxWidth;
+}

--- a/src/flamegpu/runtime/flamegpu_host_agent_api.cu
+++ b/src/flamegpu/runtime/flamegpu_host_agent_api.cu
@@ -7,8 +7,8 @@ __global__ void initToThreadIndex(unsigned int *output, unsigned int threadCount
     }
 }
 
-void HostAgentInstance::fillTIDArray(unsigned int *buffer, const unsigned int &threadCount) {
-    initToThreadIndex<<<(threadCount/512)+1, 512 >>>(buffer, threadCount);
+void HostAgentInstance::fillTIDArray(unsigned int *buffer, const unsigned int &threadCount, const cudaStream_t &stream) {
+    initToThreadIndex<<<(threadCount/512)+1, 512, 0, stream>>>(buffer, threadCount);
     gpuErrchkLaunch();
 }
 
@@ -19,7 +19,7 @@ __global__ void sortBuffer_kernel(char *dest, char*src, unsigned int *position, 
     }
 }
 
-void HostAgentInstance::sortBuffer(void *dest, void*src, unsigned int *position, const size_t &typeLen, const unsigned int &threadCount) {
-    sortBuffer_kernel<<<(threadCount/512)+1, 512 >>>(static_cast<char*>(dest), static_cast<char*>(src), position, typeLen, threadCount);
+void HostAgentInstance::sortBuffer(void *dest, void*src, unsigned int *position, const size_t &typeLen, const unsigned int &threadCount, const cudaStream_t &stream) {
+    sortBuffer_kernel<<<(threadCount/512)+1, 512, 0, stream >>>(static_cast<char*>(dest), static_cast<char*>(src), position, typeLen, threadCount);
     gpuErrchkLaunch();
 }

--- a/src/flamegpu/runtime/messaging/Array.cu
+++ b/src/flamegpu/runtime/messaging/Array.cu
@@ -55,7 +55,7 @@ void MsgArray::CUDAModelHandler::freeMetaDataDevicePtr() {
     d_write_flag = nullptr;
     d_write_flag_len = 0;
 }
-void MsgArray::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const unsigned int &streamId) {
+void MsgArray::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
     const unsigned int MESSAGE_COUNT = this->sim_message.getMessageCount();
     // Zero the output arrays
     auto &read_list = this->sim_message.getReadList();
@@ -80,7 +80,7 @@ void MsgArray::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const unsigned
         }
         t_d_write_flag = d_write_flag;
     }
-    scatter.arrayMessageReorder(streamId, this->sim_message.getMessageDescription().variables, read_list, write_list, MESSAGE_COUNT, hd_metadata.length, t_d_write_flag);
+    scatter.arrayMessageReorder(streamId, stream, this->sim_message.getMessageDescription().variables, read_list, write_list, MESSAGE_COUNT, hd_metadata.length, t_d_write_flag);
     this->sim_message.swap();
     // Reset message count back to full array length
     // Array message exposes not output messages as 0

--- a/src/flamegpu/runtime/messaging/Array2D.cu
+++ b/src/flamegpu/runtime/messaging/Array2D.cu
@@ -56,7 +56,7 @@ void MsgArray2D::CUDAModelHandler::freeMetaDataDevicePtr() {
     d_write_flag = nullptr;
     d_write_flag_len = 0;
 }
-void MsgArray2D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const unsigned int &streamId) {
+void MsgArray2D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
     const unsigned int MESSAGE_COUNT = this->sim_message.getMessageCount();
     // Zero the output arrays
     auto &read_list = this->sim_message.getReadList();
@@ -81,7 +81,7 @@ void MsgArray2D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const unsign
         }
         t_d_write_flag = d_write_flag;
     }
-    scatter.arrayMessageReorder(streamId, this->sim_message.getMessageDescription().variables, read_list, write_list, MESSAGE_COUNT, hd_metadata.length, t_d_write_flag);
+    scatter.arrayMessageReorder(streamId, stream, this->sim_message.getMessageDescription().variables, read_list, write_list, MESSAGE_COUNT, hd_metadata.length, t_d_write_flag);
     this->sim_message.swap();
     // Reset message count back to full array length
     // Array message exposes not output messages as 0

--- a/src/flamegpu/runtime/messaging/Array3D.cu
+++ b/src/flamegpu/runtime/messaging/Array3D.cu
@@ -56,7 +56,7 @@ void MsgArray3D::CUDAModelHandler::freeMetaDataDevicePtr() {
     d_write_flag = nullptr;
     d_write_flag_len = 0;
 }
-void MsgArray3D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const unsigned int &streamId) {
+void MsgArray3D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
     const unsigned int MESSAGE_COUNT = this->sim_message.getMessageCount();
     // Zero the output arrays
     auto &read_list = this->sim_message.getReadList();
@@ -81,7 +81,7 @@ void MsgArray3D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const unsign
         }
         t_d_write_flag = d_write_flag;
     }
-    scatter.arrayMessageReorder(streamId, this->sim_message.getMessageDescription().variables, read_list, write_list, MESSAGE_COUNT, hd_metadata.length, t_d_write_flag);
+    scatter.arrayMessageReorder(streamId, stream, this->sim_message.getMessageDescription().variables, read_list, write_list, MESSAGE_COUNT, hd_metadata.length, t_d_write_flag);
     this->sim_message.swap();
     // Reset message count back to full array length
     // Array message exposes not output messages as 0

--- a/src/flamegpu/runtime/messaging/BruteForce.cu
+++ b/src/flamegpu/runtime/messaging/BruteForce.cu
@@ -23,7 +23,7 @@ void MsgBruteForce::CUDAModelHandler::freeMetaDataDevicePtr() {
     d_metadata = nullptr;
 }
 
-void MsgBruteForce::CUDAModelHandler::buildIndex(CUDAScatter &, const unsigned int &) {
+void MsgBruteForce::CUDAModelHandler::buildIndex(CUDAScatter &, const unsigned int &, const cudaStream_t &) {
     unsigned int newLength = this->sim_message.getMessageCount();
     if (newLength != hd_metadata.length) {
         hd_metadata.length = newLength;

--- a/src/flamegpu/runtime/messaging/Bucket.cu
+++ b/src/flamegpu/runtime/messaging/Bucket.cu
@@ -83,26 +83,28 @@ void MsgBucket::CUDAModelHandler::freeMetaDataDevicePtr() {
     }
 }
 
-void MsgBucket::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const unsigned int &streamId) {
+void MsgBucket::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
+    NVTX_RANGE("MsgBucket::CUDAModelHandler::buildIndex");
+    // Cuda operations all occur within the stream, so only a final sync is required.s
     const unsigned int MESSAGE_COUNT = this->sim_message.getMessageCount();
     resizeKeysVals(this->sim_message.getMaximumListSize());  // Resize based on allocated amount rather than message count
     {  // Build atomic histogram
-        gpuErrchk(cudaMemset(d_histogram, 0x00000000, (bucketCount + 1) * sizeof(unsigned int)));
+        gpuErrchk(cudaMemsetAsync(d_histogram, 0x00000000, (bucketCount + 1) * sizeof(unsigned int), stream));
         int blockSize;  // The launch configurator returned block size
         gpuErrchk(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&blockSize, atomicHistogram1D, 32, 0));  // Randomly 32
                                                                                                          // Round up according to array size
         int gridSize = (MESSAGE_COUNT + blockSize - 1) / blockSize;
-        atomicHistogram1D << <gridSize, blockSize >> >(d_data, d_keys, d_vals, d_histogram, MESSAGE_COUNT,
+        atomicHistogram1D <<<gridSize, blockSize, 0, stream >>>(d_data, d_keys, d_vals, d_histogram, MESSAGE_COUNT,
             reinterpret_cast<IntT*>(this->sim_message.getReadPtr("_key")));
-        gpuErrchk(cudaDeviceSynchronize());
     }
     {  // Scan (sum), to finalise PBM
-        gpuErrchk(cub::DeviceScan::ExclusiveSum(d_CUB_temp_storage, d_CUB_temp_storage_bytes, d_histogram, hd_data.PBM, bucketCount + 1));
+        gpuErrchk(cub::DeviceScan::ExclusiveSum(d_CUB_temp_storage, d_CUB_temp_storage_bytes, d_histogram, hd_data.PBM, bucketCount + 1, stream));
     }
     {  // Reorder messages
        // Copy messages from d_messages to d_messages_swap, in hash order
-        scatter.pbm_reorder(streamId, this->sim_message.getMessageDescription().variables, this->sim_message.getReadList(), this->sim_message.getWriteList(), MESSAGE_COUNT, d_keys, d_vals, hd_data.PBM);
+        scatter.pbm_reorder(streamId, stream, this->sim_message.getMessageDescription().variables, this->sim_message.getReadList(), this->sim_message.getWriteList(), MESSAGE_COUNT, d_keys, d_vals, hd_data.PBM);
         this->sim_message.swap();
+        gpuErrchk(cudaStreamSynchronize(stream));  // Not striclty neceesary while pbm_reorder is synchronous.
     }
     {  // Fill PBM and Message Texture Buffers
        // gpuErrchk(cudaBindTexture(nullptr, d_texMessages, d_agents, sizeof(glm::vec4) * MESSAGE_COUNT));

--- a/src/flamegpu/runtime/messaging/Spatial2D.cu
+++ b/src/flamegpu/runtime/messaging/Spatial2D.cu
@@ -93,27 +93,28 @@ void MsgSpatial2D::CUDAModelHandler::freeMetaDataDevicePtr() {
     }
 }
 
-void MsgSpatial2D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const unsigned int &streamId) {
+void MsgSpatial2D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
+    NVTX_RANGE("MsgSpatial2D::CUDAModelHandler::buildIndex");
     const unsigned int MESSAGE_COUNT = this->sim_message.getMessageCount();
     resizeKeysVals(this->sim_message.getMaximumListSize());  // Resize based on allocated amount rather than message count
     {  // Build atomic histogram
-        gpuErrchk(cudaMemset(d_histogram, 0x00000000, (binCount + 1) * sizeof(unsigned int)));
+        gpuErrchk(cudaMemsetAsync(d_histogram, 0x00000000, (binCount + 1) * sizeof(unsigned int), stream));
         int blockSize;  // The launch configurator returned block size
         gpuErrchk(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&blockSize, atomicHistogram2D, 32, 0));  // Randomly 32
                                                                                                          // Round up according to array size
         int gridSize = (MESSAGE_COUNT + blockSize - 1) / blockSize;
-        atomicHistogram2D << <gridSize, blockSize >> >(d_data, d_keys, d_vals, d_histogram, MESSAGE_COUNT,
+        atomicHistogram2D <<<gridSize, blockSize, 0, stream >>>(d_data, d_keys, d_vals, d_histogram, MESSAGE_COUNT,
             reinterpret_cast<float*>(this->sim_message.getReadPtr("x")),
             reinterpret_cast<float*>(this->sim_message.getReadPtr("y")));
-        gpuErrchk(cudaDeviceSynchronize());
     }
     {  // Scan (sum), to finalise PBM
-        gpuErrchk(cub::DeviceScan::ExclusiveSum(d_CUB_temp_storage, d_CUB_temp_storage_bytes, d_histogram, hd_data.PBM, binCount + 1));
+        gpuErrchk(cub::DeviceScan::ExclusiveSum(d_CUB_temp_storage, d_CUB_temp_storage_bytes, d_histogram, hd_data.PBM, binCount + 1, stream));
     }
     {  // Reorder messages
        // Copy messages from d_messages to d_messages_swap, in hash order
-        scatter.pbm_reorder(streamId, this->sim_message.getMessageDescription().variables, this->sim_message.getReadList(), this->sim_message.getWriteList(), MESSAGE_COUNT, d_keys, d_vals, hd_data.PBM);
+        scatter.pbm_reorder(streamId, stream, this->sim_message.getMessageDescription().variables, this->sim_message.getReadList(), this->sim_message.getWriteList(), MESSAGE_COUNT, d_keys, d_vals, hd_data.PBM);
         this->sim_message.swap();
+        gpuErrchk(cudaStreamSynchronize(stream));  // Not striclty neceesary while pbm_reorder is synchronous.
     }
     {  // Fill PBM and Message Texture Buffers
        // gpuErrchk(cudaBindTexture(nullptr, d_texMessages, d_agents, sizeof(glm::vec4) * MESSAGE_COUNT));

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -18,12 +18,16 @@ Simulation::Simulation(const std::shared_ptr<const ModelData> &_model)
     : model(_model->clone())
     , submodel(nullptr)
     , mastermodel(nullptr)
-    , instance_id(get_instance_id()) { }
+    , instance_id(get_instance_id())
+    , maxLayerWidth((*model).getMaxLayerWidth()) { }
+
 Simulation::Simulation(const std::shared_ptr<SubModelData> &submodel_desc, CUDASimulation *master_model)
     : model(submodel_desc->submodel)
     , submodel(submodel_desc)
     , mastermodel(master_model)
-    , instance_id(get_instance_id()) { }
+    , instance_id(get_instance_id())
+    , maxLayerWidth(submodel_desc->submodel->getMaxLayerWidth()) { }
+
 void Simulation::initialise(int argc, const char** argv) {
     NVTX_RANGE("Simulation::initialise");
     config = Config();  // Reset to defaults

--- a/src/flamegpu/util/JitifyCache.cu
+++ b/src/flamegpu/util/JitifyCache.cu
@@ -6,6 +6,7 @@
 #include "flamegpu/version.h"
 #include "flamegpu/exception/FGPUException.h"
 #include "flamegpu/util/compute_capability.cuh"
+#include "flamegpu/util/nvtx.h"
 
 // If MSVC earlier than VS 2019
 #if defined(_MSC_VER) && _MSC_VER < 1920
@@ -81,6 +82,7 @@ std::string loadFile(const path &filepath) {
 std::mutex JitifyCache::instance_mutex;
 
 std::unique_ptr<KernelInstantiation> JitifyCache::compileKernel(const std::string &func_name, const std::vector<std::string> &template_args, const std::string &kernel_src, const std::string &dynamic_header) {
+    NVTX_RANGE("JitifyCache::compileKernel");
     // Init runtime compilation constants
     static std::string env_inc_fgp2 = std::getenv("FLAMEGPU2_INC_DIR") ? std::getenv("FLAMEGPU2_INC_DIR") : "";
     static bool header_version_confirmed = false;
@@ -208,6 +210,7 @@ std::unique_ptr<KernelInstantiation> JitifyCache::compileKernel(const std::strin
 }
 
 std::unique_ptr<KernelInstantiation> JitifyCache::loadKernel(const std::string &func_name, const std::vector<std::string> &template_args, const std::string &kernel_src, const std::string &dynamic_header) {
+    NVTX_RANGE("JitifyCache::loadKernel");
     std::lock_guard<std::mutex> lock(cache_mutex);
     // Detect current compute capability=
     int currentDeviceIdx = 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ SET(TEST_CASE_SRC
     # ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_func_pointer.cu # Does not currently build
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/exception/test_device_exception.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/gpu/test_cuda_simulation.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/gpu/test_cuda_simulation_concurrency.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/gpu/test_gpu_validation.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/gpu/test_cuda_subagent.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/io/test_io.cu
@@ -104,8 +105,10 @@ SET(TEST_CASE_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/util/test_nvtx.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/util/test_dependency_versions.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/util/test_multi_thread_device.cu
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/util/test_rtc_multi_thread_device.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/util/test_CUDAEventTimer.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/util/test_SteadyClockTimer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_rtc_device_api.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/util/test_rtc_multi_thread_device.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/exception/test_rtc_device_exception.cu
 )
 SET(DEV_TEST_CASE_SRC

--- a/tests/swig/python/gpu/test_cuda_simulation.py
+++ b/tests/swig/python/gpu/test_cuda_simulation.py
@@ -282,3 +282,15 @@ class TestSimulation(TestCase):
         for i in range(pop.getCurrentListSize()):
             ai = pop.getInstanceAt(i)
             assert ai.getVariableInt("x") == expected_output[i]
+
+    def test_config_inLayerConcurrency(self):
+        m = pyflamegpu.ModelDescription("test_config_inLayerConcurrency")
+        c = pyflamegpu.CUDASimulation(m)
+        argv = []
+        # Check it's enabled by deafault
+        assert c.getCUDAConfig().inLayerConcurrency == True
+        c.initialise(argv)
+        # disable concurrency
+        c.CUDAConfig().inLayerConcurrency = False
+        # Assert that it is disabled.
+        assert c.getCUDAConfig().inLayerConcurrency == False

--- a/tests/test_cases/gpu/test_cuda_simulation_concurrency.cu
+++ b/tests/test_cases/gpu/test_cuda_simulation_concurrency.cu
@@ -1,0 +1,1288 @@
+#include "flamegpu/flame_api.h"
+#include "flamegpu/runtime/flamegpu_api.h"
+#include "flamegpu/util/compute_capability.cuh"
+#include "helpers/device_initialisation.h"
+
+#include "gtest/gtest.h"
+
+
+// Tests for detecting concurrency within CUDASimulation.
+
+// @todo - Get information about the current device, in order to (accurately) determine a sensible population size. Doing this accuratly without using the occupancy calculator for the kernel(s) might be a touch awkward.
+// @todo - switch to per-layer timing - this might not actually be required if the test case has been constructed in a way that leads to net simulation step speedup.
+// @todo - modify all tests to actually verify that agent functions executed? Probably just set an int which is incremented each time an agent executes a function, reduce and check for positive values.
+
+// These tests are only meaningful in release builds (measure performance), so use a macro to disable them in non-release builds.
+// @todo - expand RTC variant coverage, although this will dramatically increase runtime.
+
+
+#ifndef _DEBUG
+#define RELEASE_ONLY_TEST(TestSuiteName, TestName)\
+    TEST(TestSuiteName, TestName)
+#else
+#define RELEASE_ONLY_TEST(TestSuiteName, TestName)\
+    TEST(TestSuiteName, DISABLED_ ## TestName)
+#endif
+
+// if seatbelts and not debug, run the test, otherwise disable.
+#if !defined(NO_SEATBELTS) && !defined(_DEBUG)
+#define RELEASE_ONLY_SEATBELTS_TEST(TestSuiteName, TestName)\
+    TEST(TestSuiteName, TestName)
+#else
+#define RELEASE_ONLY_SEATBELTS_TEST(TestSuiteName, TestName)\
+    TEST(TestSuiteName, DISABLED_ ## TestName)
+#endif
+
+
+namespace test_cuda_simulation_concurrency {
+
+// Threshold speedup to determine if concurrency was achieved.
+const float SPEEDUP_THRESHOLD = 1.5;
+
+// Number of repetitions to time, to improve accuracy of time evaluation. More is better (within reason)
+const int TIMING_REPETITIONS = 3;
+
+// Number of conccurent agent functions
+const int CONCURRENCY_DEGREE = 4;
+
+// Number of agents per population - i.e how many threads should be used per concurreny kernel.
+// This needs to be sufficiently small that streams will actually be concurrent.
+const unsigned int POPULATION_SIZES = 512;
+
+
+/** 
+ * Utility function to time N repetitions of a simulation, returning the mean (but skipping the first)
+ */
+float meanSimulationTime(const int REPETITIONS, CUDASimulation &s, std::vector<AgentPopulation *> const &populations) {
+    float total_time = 0.f;
+    for (int r = 0; r < REPETITIONS + 1; r++) {
+        // re-set each population
+        for (AgentPopulation * pop : populations) {
+            s.setPopulationData(*pop);
+        }
+        // Run and time the simulation
+        s.simulate();
+        // Store the time if not the 0th rep of the model.
+        if (r > 0) {
+            total_time += s.getElapsedTimeSimulation();
+        }
+    }
+    return total_time / REPETITIONS;
+}
+
+/** 
+ * Utility function checking for a speedup after running a sim with and without concurrency.
+ */
+float concurrentLayerSpeedup(const int REPETITIONS, CUDASimulation &s, std::vector<AgentPopulation *> const &populations) {
+    // Set a single step.
+    s.SimulationConfig().steps = 1;
+
+    // Set the flag saying don't use concurrency.
+    s.CUDAConfig().inLayerConcurrency = false;
+    s.applyConfig();
+    EXPECT_EQ(s.CUDAConfig().inLayerConcurrency, false);
+
+    // Time the simulation multiple times to get an average
+    float mean_sequential_time = meanSimulationTime(REPETITIONS, s, populations);
+
+    // set the flag saying to use streams for agnet function concurrency.
+    s.CUDAConfig().inLayerConcurrency = true;
+    s.applyConfig();
+    EXPECT_EQ(s.CUDAConfig().inLayerConcurrency, true);
+
+    float mean_concurrent_time = meanSimulationTime(REPETITIONS, s, populations);
+
+    // Calculate a speedup value.
+    float speedup = mean_sequential_time / mean_concurrent_time;
+    return speedup;
+}
+
+
+
+/**
+ * Slow and uninteresting agent function which will take a while to run for accurate timing
+ */
+FLAMEGPU_AGENT_FUNCTION(SlowAgentFunction, MsgNone, MsgNone) {
+    // Repeatedly do some pointless maths on the value in register
+    const int INTERNAL_REPETITIONS = 65536;
+    for (int i = 0; i < INTERNAL_REPETITIONS; i++) {
+        // Read and write all the way to global mem each time to make this intentionally slow
+        float v = FLAMEGPU->getVariable<float>("v");
+        FLAMEGPU->setVariable("v", v + v);
+    }
+    return ALIVE;
+}
+
+/**
+ * Agent function which outputs to a message list + some slow work.
+ */
+FLAMEGPU_AGENT_FUNCTION(SlowMessageOutputAgentFunction, MsgNone, MsgBruteForce) {
+    // Repeatedly do some pointless maths on the value in register
+    const int INTERNAL_REPETITIONS = 65536;
+    for (int i = 0; i < INTERNAL_REPETITIONS; i++) {
+        // Read and write all the way to global mem each time to make this intentionally slow
+        float v = FLAMEGPU->getVariable<float>("v");
+        FLAMEGPU->setVariable("v", v + v);
+    }
+    FLAMEGPU->message_out.setVariable("v", FLAMEGPU->getVariable<float>("v"));
+    return ALIVE;
+}
+
+/**
+ * Agent function which inputs from a message list + some slow work.
+ */
+FLAMEGPU_AGENT_FUNCTION(SlowMessageInputAgentFunction, MsgBruteForce, MsgNone) {
+    // Repeatedly do some pointless maths on the value in register
+    const int INTERNAL_REPETITIONS = 65536;
+    for (int i = 0; i < INTERNAL_REPETITIONS; i++) {
+        // Read and write all the way to global mem each time to make this intentionally slow
+        float v = FLAMEGPU->getVariable<float>("v");
+        FLAMEGPU->setVariable("v", v + v);
+    }
+    float vSum = 0.f;
+    for (const auto &message : FLAMEGPU->message_in) {
+        vSum += message.getVariable<float>("v");
+    }
+    FLAMEGPU->setVariable("v", vSum);
+    return ALIVE;
+}
+
+/**
+ * Agent function which outputs to an optional message list + some slow work.
+ */
+FLAMEGPU_AGENT_FUNCTION(SlowOptionalMessageOutputAgentFunction, MsgNone, MsgBruteForce) {
+    // Repeatedly do some pointless maths on the value in register
+    const int INTERNAL_REPETITIONS = 65536;
+    for (int i = 0; i < INTERNAL_REPETITIONS; i++) {
+        // Read and write all the way to global mem each time to make this intentionally slow
+        float v = FLAMEGPU->getVariable<float>("v");
+        FLAMEGPU->setVariable("v", v + v);
+    }
+    if (FLAMEGPU->getVariable<unsigned int>("id") % 2 == 0) {
+        FLAMEGPU->message_out.setVariable("v", FLAMEGPU->getVariable<float>("v"));
+    }
+    return ALIVE;
+}
+
+/**
+ * Agent function which inputs from an optional message list + some slow work.
+ */
+FLAMEGPU_AGENT_FUNCTION(SlowOptionalMessageInputAgentFunction, MsgBruteForce, MsgNone) {
+    // Repeatedly do some pointless maths on the value in register
+    const int INTERNAL_REPETITIONS = 65536;
+    for (int i = 0; i < INTERNAL_REPETITIONS; i++) {
+        // Read and write all the way to global mem each time to make this intentionally slow
+        float v = FLAMEGPU->getVariable<float>("v");
+        FLAMEGPU->setVariable("v", v + v);
+    }
+    float vSum = 0.f;
+    unsigned int count = 0;
+    for (const auto &message : FLAMEGPU->message_in) {
+        vSum += message.getVariable<float>("v");
+        count += 1;
+    }
+    // if(FLAMEGPU->getVariable<unsigned int>("id") == 0) {
+    //     printf("agent 0 read %u messages\n", count);
+    // }
+    FLAMEGPU->setVariable("v", vSum);
+    return ALIVE;
+}
+
+/**
+ * Agent function which outputs to a Spatial2D message list + some slow work.
+ */
+FLAMEGPU_AGENT_FUNCTION(SlowMessageOutputAgentFunctionSpatial2D, MsgNone, MsgSpatial2D) {
+    // Repeatedly do some pointless maths on the value in register
+    const int INTERNAL_REPETITIONS = 65536;
+    for (int i = 0; i < INTERNAL_REPETITIONS; i++) {
+        // Read and write all the way to global mem each time to make this intentionally slow
+        float v = FLAMEGPU->getVariable<float>("v");
+        FLAMEGPU->setVariable("v", v + v);
+    }
+    FLAMEGPU->message_out.setVariable("v", FLAMEGPU->getVariable<float>("v"));
+    FLAMEGPU->message_out.setLocation(
+        FLAMEGPU->getVariable<float>("x"),
+        FLAMEGPU->getVariable<float>("y"));
+    return ALIVE;
+}
+
+/**
+ * Agent function which inputs from a Spatial2D message list + some slow work.
+ */
+FLAMEGPU_AGENT_FUNCTION(SlowMessageInputAgentFunctionSpatial2D, MsgSpatial2D, MsgNone) {
+    // Repeatedly do some pointless maths on the value in register
+    const int INTERNAL_REPETITIONS = 65536;
+    for (int i = 0; i < INTERNAL_REPETITIONS; i++) {
+        // Read and write all the way to global mem each time to make this intentionally slow
+        float v = FLAMEGPU->getVariable<float>("v");
+        FLAMEGPU->setVariable("v", v + v);
+    }
+    float vSum = 0.f;
+    float agent_x = FLAMEGPU->getVariable<float>("x");
+    float agent_y = FLAMEGPU->getVariable<float>("y");
+    for (const auto &message : FLAMEGPU->message_in(agent_x, agent_y)) {
+        vSum += message.getVariable<float>("v");
+    }
+    FLAMEGPU->setVariable("v", vSum);
+    return ALIVE;
+}
+
+/**
+ * Agent function which outputs to a Spatial3D message list + some slow work.
+ */
+FLAMEGPU_AGENT_FUNCTION(SlowMessageOutputAgentFunctionSpatial3D, MsgNone, MsgSpatial3D) {
+    // Repeatedly do some pointless maths on the value in register
+    const int INTERNAL_REPETITIONS = 65536;
+    for (int i = 0; i < INTERNAL_REPETITIONS; i++) {
+        // Read and write all the way to global mem each time to make this intentionally slow
+        float v = FLAMEGPU->getVariable<float>("v");
+        FLAMEGPU->setVariable("v", v + v);
+    }
+    FLAMEGPU->message_out.setVariable("v", FLAMEGPU->getVariable<float>("v"));
+    FLAMEGPU->message_out.setLocation(
+        FLAMEGPU->getVariable<float>("x"),
+        FLAMEGPU->getVariable<float>("y"),
+        FLAMEGPU->getVariable<float>("z"));
+    return ALIVE;
+}
+
+/**
+ * Agent function which inputs from a Spatial3D message list + some slow work.
+ */
+FLAMEGPU_AGENT_FUNCTION(SlowMessageInputAgentFunctionSpatial3D, MsgSpatial3D, MsgNone) {
+    // Repeatedly do some pointless maths on the value in register
+    const int INTERNAL_REPETITIONS = 65536;
+    for (int i = 0; i < INTERNAL_REPETITIONS; i++) {
+        // Read and write all the way to global mem each time to make this intentionally slow
+        float v = FLAMEGPU->getVariable<float>("v");
+        FLAMEGPU->setVariable("v", v + v);
+    }
+    float vSum = 0.f;
+    float agent_x = FLAMEGPU->getVariable<float>("x");
+    float agent_y = FLAMEGPU->getVariable<float>("y");
+    float agent_z = FLAMEGPU->getVariable<float>("z");
+    for (const auto &message : FLAMEGPU->message_in(agent_x, agent_y, agent_z)) {
+        vSum += message.getVariable<float>("v");
+    }
+    FLAMEGPU->setVariable("v", vSum);
+    return ALIVE;
+}
+
+/**
+ * Slow and uninteresting agent function which will take a while to run for accurate timing.
+ * Agents birth an agent of the same type.
+ */
+FLAMEGPU_AGENT_FUNCTION(SlowAgentFunctionBirth, MsgNone, MsgNone) {
+    // Repeatedly do some pointless maths on the value in register
+    const int INTERNAL_REPETITIONS = 65536;
+    for (int i = 0; i < INTERNAL_REPETITIONS; i++) {
+        // Read and write all the way to global mem each time to make this intentionally slow
+        float v = FLAMEGPU->getVariable<float>("v");
+        FLAMEGPU->setVariable("v", v + v);
+    }
+    // A new agent is born.
+    FLAMEGPU->agent_out.setVariable<float>("v", 1.0f);
+    return ALIVE;
+}
+
+/**
+ * Slow and uninteresting agent function which will take a while to run for accurate timing.
+ * Agents die.
+ */
+FLAMEGPU_AGENT_FUNCTION(SlowAgentFunctionDeath, MsgNone, MsgNone) {
+    // Repeatedly do some pointless maths on the value in register
+    const int INTERNAL_REPETITIONS = 65536;
+    for (int i = 0; i < INTERNAL_REPETITIONS; i++) {
+        // Read and write all the way to global mem each time to make this intentionally slow
+        float v = FLAMEGPU->getVariable<float>("v");
+        FLAMEGPU->setVariable("v", v + v);
+    }
+    // Agents all die.
+    return DEAD;
+}
+
+/**
+ * Agent function condition which disabled all agents
+ */
+FLAMEGPU_AGENT_FUNCTION_CONDITION(SlowConditionAllFalse) {
+    // Repeatedly do some pointless maths on the value in register
+    const int INTERNAL_REPETITIONS = 65536;
+    float v = 1.f;
+    for (int i = 0; i < INTERNAL_REPETITIONS; i++) {
+        // Can't write, so just read and increment locally
+        v = v + FLAMEGPU->getVariable<float>("v");
+    }
+    // Use v in the return val so the loop doesn't get optimised out.
+    return v < 0.f;
+}
+
+
+/**
+ * Agent function condition which enables all agents
+ */
+FLAMEGPU_AGENT_FUNCTION_CONDITION(SlowConditionAllTrue) {
+    // Repeatedly do some pointless maths on the value in register
+    const int INTERNAL_REPETITIONS = 65536;
+    float v = 1.f;
+    for (int i = 0; i < INTERNAL_REPETITIONS; i++) {
+        // Can't write, so just read and increment locally
+        v = v + FLAMEGPU->getVariable<float>("v");
+    }
+    // Use v in the return val so the loop doesn't get optimised out.
+    return v > 0.0f;
+}
+
+/**
+ * Agent function condition which enables all agents
+ */
+FLAMEGPU_AGENT_FUNCTION_CONDITION(SlowCondition5050) {
+    // Repeatedly do some pointless maths on the value in register
+    const int INTERNAL_REPETITIONS = 65536;
+    float v = 1.f;
+    for (int i = 0; i < INTERNAL_REPETITIONS; i++) {
+        // Can't write, so just read and increment locally
+        v = v + FLAMEGPU->getVariable<float>("v");
+    }
+    const int fifytfifty = threadIdx.x + blockIdx.x * blockDim.x;
+    // Use v in the return val so the loop doesn't get optimised out.
+    return fifytfifty ? v > 0.0f : v < 1.0f;
+}
+
+/**
+ * Agent function which causes a device exception. Slow just to ensure it runs at the same time. No way of timing accurately.)
+ */
+FLAMEGPU_AGENT_FUNCTION(SlowAgentFunctionWithDeviceException, MsgNone, MsgNone) {
+    // Repeatedly do some pointless maths on the value in register
+    const int INTERNAL_REPETITIONS = 65536;
+    for (int i = 0; i < INTERNAL_REPETITIONS; i++) {
+        // Read and write all the way to global mem each time to make this intentionally slow
+        // Read from the wrong data type (with a bad size) which should trigger the exception.
+        double v = FLAMEGPU->getVariable<double>("v");
+        FLAMEGPU->setVariable("v", v + v);
+    }
+    return ALIVE;
+}
+
+
+/**
+ * Fast but uninteresting agent function. not useful to time, but allows timing of post processing (to a certain degree)
+ */
+FLAMEGPU_AGENT_FUNCTION(FastAgentFunction, MsgNone, MsgNone) {
+    // Repeatedly do some pointless maths on the value in register
+    const int INTERNAL_REPETITIONS = 1;
+    for (int i = 0; i < INTERNAL_REPETITIONS; i++) {
+        // Read and write all the way to global mem each time to make this intentionally slow
+        float v = FLAMEGPU->getVariable<float>("v");
+        FLAMEGPU->setVariable("v", v + v);
+    }
+    return ALIVE;
+}
+
+/**
+ * Agent function condition which disabled all agents
+ */
+FLAMEGPU_AGENT_FUNCTION_CONDITION(FastConditionAllFalse) {
+    return false;
+}
+
+/**
+ * Agent function condition which enables all agents
+ */
+FLAMEGPU_AGENT_FUNCTION_CONDITION(FastConditionAllTrue) {
+    return true;
+}
+/**
+ * Agent function condition which enables 50% of agents
+ */
+FLAMEGPU_AGENT_FUNCTION_CONDITION(FastCondition5050) {
+    return (threadIdx.x + blockIdx.x * blockDim.x) % 2;
+}
+
+/**
+ * Test dectecting concurrency for the simple unintersting case.
+ */
+RELEASE_ONLY_TEST(TestCUDASimulationConcurrency, LayerConcurrency) {
+    // Define a model with multiple agent types
+    ModelDescription m("concurrency_test");
+
+    // Create a layer, which contains one function for each agent type - with no dependencies this is allowed.
+    LayerDescription &layer  = m.newLayer();
+
+    std::vector<AgentPopulation *> populations = std::vector<AgentPopulation *>();
+
+    // Add a few agent types, each with a single agent function.
+    for (int i = 0; i < CONCURRENCY_DEGREE; i++) {
+        // Generate the agent type
+        std::string agent_name("agent_" + std::to_string(i));
+        std::string agent_function(agent_name + "_slowAgentFunction");
+        AgentDescription &a = m.newAgent(agent_name);
+        a.newVariable<float>("v");
+        auto &f = a.newFunction(agent_function, SlowAgentFunction);
+        layer.addAgentFunction(f);
+
+        // Generate an iniital population.
+        AgentPopulation * a_pop = new AgentPopulation(a, POPULATION_SIZES);
+        for (unsigned int j = 0; j < POPULATION_SIZES; ++j) {
+            auto agent = a_pop->getNextInstance();
+            agent.setVariable<float>("v", static_cast<float>(j));
+        }
+        populations.push_back(a_pop);
+    }
+
+    // Convert the model to a simulation
+    CUDASimulation s(m);
+
+    // Run the simulation many times, with and without concurrency to get an accurate speedup
+    float speedup = concurrentLayerSpeedup(TIMING_REPETITIONS, s, populations);
+    // Assert that a speedup was achieved.
+    EXPECT_GE(speedup, SPEEDUP_THRESHOLD);
+}
+
+/**
+ * Test dectecting concurrency for the simple unintersting case.
+ * This executes a fast agent function, so might never be useful?
+ * Disabled as it is not expected to pass till pinned memory + lots of refactoring is implementd (for sub 1ms improvements per function per layer per iteration per step)
+ */
+RELEASE_ONLY_TEST(TestCUDASimulationConcurrency, DISABLED_FastLayerConcurrency) {
+    // Define a model with multiple agent types
+    ModelDescription m("concurrency_test");
+
+    // Create a layer, which contains one function for each agent type - with no dependencies this is allowed.
+    LayerDescription &layer  = m.newLayer();
+
+    std::vector<AgentPopulation *> populations = std::vector<AgentPopulation *>();
+
+    // Add a few agent types, each with a single agent function.
+    for (int i = 0; i < CONCURRENCY_DEGREE; i++) {
+        // Generate the agent type
+        std::string agent_name("agent_" + std::to_string(i));
+        std::string agent_function(agent_name + "_fastAgentFunction");
+        AgentDescription &a = m.newAgent(agent_name);
+        a.newVariable<float>("v");
+        auto &f = a.newFunction(agent_function, FastAgentFunction);
+        layer.addAgentFunction(f);
+
+        // Generate an iniital population.
+        AgentPopulation * a_pop = new AgentPopulation(a, POPULATION_SIZES);
+        for (unsigned int j = 0; j < POPULATION_SIZES; ++j) {
+            auto agent = a_pop->getNextInstance();
+            agent.setVariable<float>("v", static_cast<float>(j));
+        }
+        populations.push_back(a_pop);
+    }
+
+    // Convert the model to a simulation
+    CUDASimulation s(m);
+
+    // Run the simulation many times, with and without concurrency to get an accurate speedup
+    float speedup = concurrentLayerSpeedup(TIMING_REPETITIONS, s, populations);
+    // Assert that a speedup was achieved.
+    EXPECT_GE(speedup, SPEEDUP_THRESHOLD);
+}
+
+/**
+ * Time agents outputting messages to separate lists in the same layer.
+ * The same list should not be possible.
+ */
+RELEASE_ONLY_TEST(TestCUDASimulationConcurrency, ConcurrentMessageOutput) {
+    // Define a model with multiple agent types
+    ModelDescription m("ConcurrentMessageOutput");
+
+    // Create a layer, which contains one function for each agent type - with no dependencies this is allowed.
+    LayerDescription &layer  = m.newLayer();
+
+    std::vector<AgentPopulation *> populations = std::vector<AgentPopulation *>();
+
+    // Add a few agent types, each with a single agent function.
+    for (int i = 0; i < CONCURRENCY_DEGREE; i++) {
+        // Generate the agent type
+        std::string agent_name("agent_" + std::to_string(i));
+        std::string agent_function(agent_name + "_SlowMessageOutputAgentFunction");
+        std::string message_name(agent_name + "_messages");
+        AgentDescription &a = m.newAgent(agent_name);
+        a.newVariable<float>("v");
+        MsgBruteForce::Description &msg = m.newMessage(message_name);
+        msg.newVariable<float>("v");
+
+        auto &f = a.newFunction(agent_function, SlowMessageOutputAgentFunction);
+        f.setMessageOutput(msg);
+
+        layer.addAgentFunction(f);
+
+        // Generate an iniital population.
+        AgentPopulation * a_pop = new AgentPopulation(a, POPULATION_SIZES);
+        for (unsigned int j = 0; j < POPULATION_SIZES; ++j) {
+            auto agent = a_pop->getNextInstance();
+            agent.setVariable<float>("v", static_cast<float>(j));
+        }
+        populations.push_back(a_pop);
+    }
+
+    // Convert the model to a simulation
+    CUDASimulation s(m);
+
+    // Run the simulation many times, with and without concurrency to get an accurate speedup
+    float speedup = concurrentLayerSpeedup(TIMING_REPETITIONS, s, populations);
+    // Assert that a speedup was achieved.
+    EXPECT_GE(speedup, SPEEDUP_THRESHOLD);
+}
+
+
+/**
+ * Time agents outputting and inputting from independeant message lists
+ */
+RELEASE_ONLY_TEST(TestCUDASimulationConcurrency, ConcurrentMessageOutputInput) {
+    // Define a model with multiple agent types
+    ModelDescription m("ConcurrentMessageOutputInput");
+
+    // Create two layers.
+    LayerDescription &layer0  = m.newLayer();
+    LayerDescription &layer1  = m.newLayer();
+
+    std::vector<AgentPopulation *> populations = std::vector<AgentPopulation *>();
+
+    // Add a few agent types, each with a single agent function.
+    for (int i = 0; i < CONCURRENCY_DEGREE; i++) {
+        // Generate the agent type
+        std::string agent_name("agent_" + std::to_string(i));
+        std::string agent_function_out(agent_name + "_SlowMessageOutputAgentFunction");
+        std::string agent_function_in(agent_name + "_SlowMessageInputAgentFunction");
+        std::string message_name(agent_name + "_messages");
+        AgentDescription &a = m.newAgent(agent_name);
+        a.newVariable<float>("v");
+        MsgBruteForce::Description &msg = m.newMessage(message_name);
+        msg.newVariable<float>("v");
+
+        auto &f_out = a.newFunction(agent_function_out, SlowMessageOutputAgentFunction);
+        f_out.setMessageOutput(msg);
+
+        layer0.addAgentFunction(f_out);
+
+        auto &f_in = a.newFunction(agent_function_in, SlowMessageInputAgentFunction);
+        f_in.setMessageInput(msg);
+
+        layer1.addAgentFunction(f_in);
+
+        // Generate an iniital population.
+        AgentPopulation * a_pop = new AgentPopulation(a, POPULATION_SIZES);
+        for (unsigned int j = 0; j < POPULATION_SIZES; ++j) {
+            auto agent = a_pop->getNextInstance();
+            agent.setVariable<float>("v", static_cast<float>(j));
+        }
+        populations.push_back(a_pop);
+    }
+
+    // Convert the model to a simulation
+    CUDASimulation s(m);
+
+    // Run the simulation many times, with and without concurrency to get an accurate speedup
+    float speedup = concurrentLayerSpeedup(TIMING_REPETITIONS, s, populations);
+    // Assert that a speedup was achieved.
+    EXPECT_GE(speedup, SPEEDUP_THRESHOLD);
+}
+
+/**
+ * Time agents outputting to independant lists, then inputting from a common list (agent_0_messages)
+ * With access to per-layer timing, it would be possible to only output to one message list, as the timing of that layer would not effect the potential measured speedup
+ */
+RELEASE_ONLY_TEST(TestCUDASimulationConcurrency, ConcurrentMessageOutputInputSameList) {
+    // Define a model with multiple agent types
+    ModelDescription m("ConcurrentMessageOutputInputSameList");
+
+    // Create two layers.
+    LayerDescription &layer0  = m.newLayer();
+    LayerDescription &layer1  = m.newLayer();
+
+    std::vector<AgentPopulation *> populations = std::vector<AgentPopulation *>();
+
+    std::string msg_in_name("agent_0_messages");
+
+    // Add a few agent types, each with a single agent function.
+    for (int i = 0; i < CONCURRENCY_DEGREE; i++) {
+        // Generate the agent type
+        std::string agent_name("agent_" + std::to_string(i));
+        std::string agent_function_out(agent_name + "_SlowMessageOutputAgentFunction");
+        std::string agent_function_in(agent_name + "_SlowMessageInputAgentFunction");
+        std::string message_name(agent_name + "_messages");
+        AgentDescription &a = m.newAgent(agent_name);
+        a.newVariable<float>("v");
+        MsgBruteForce::Description &msg = m.newMessage(message_name);
+        msg.newVariable<float>("v");
+
+        MsgBruteForce::Description &msg_in = m.Message(msg_in_name);
+
+        auto &f_out = a.newFunction(agent_function_out, SlowMessageOutputAgentFunction);
+        f_out.setMessageOutput(msg);
+
+        layer0.addAgentFunction(f_out);
+
+        auto &f_in = a.newFunction(agent_function_in, SlowMessageInputAgentFunction);
+        f_in.setMessageInput(msg_in);
+
+        layer1.addAgentFunction(f_in);
+
+        // Generate an iniital population.
+        AgentPopulation * a_pop = new AgentPopulation(a, POPULATION_SIZES);
+        for (unsigned int j = 0; j < POPULATION_SIZES; ++j) {
+            auto agent = a_pop->getNextInstance();
+            agent.setVariable<float>("v", static_cast<float>(j));
+        }
+        populations.push_back(a_pop);
+    }
+
+    // Convert the model to a simulation
+    CUDASimulation s(m);
+
+    // Run the simulation many times, with and without concurrency to get an accurate speedup
+    float speedup = concurrentLayerSpeedup(TIMING_REPETITIONS, s, populations);
+    // Assert that a speedup was achieved.
+    EXPECT_GE(speedup, SPEEDUP_THRESHOLD);
+}
+
+/**
+ * Time agents outputting to independant lists, then inputting from a common list (agent_0_messages), using optional messaging.
+ */
+RELEASE_ONLY_TEST(TestCUDASimulationConcurrency, ConcurrentOptionalMessageOutputInputSameList) {
+    // Define a model with multiple agent types
+    ModelDescription m("ConcurrentMessageOutputInputSameList");
+
+    // Create two layers.
+    LayerDescription &layer0  = m.newLayer();
+    LayerDescription &layer1  = m.newLayer();
+
+    std::vector<AgentPopulation *> populations = std::vector<AgentPopulation *>();
+
+    std::string msg_in_name("agent_0_messages");
+
+    // Add a few agent types, each with a single agent function.
+    for (int i = 0; i < CONCURRENCY_DEGREE; i++) {
+        // Generate the agent type
+        std::string agent_name("agent_" + std::to_string(i));
+        std::string agent_function_out(agent_name + "_SlowOptionalMessageOutputAgentFunction");
+        std::string agent_function_in(agent_name + "_SlowOptionalMessageInputAgentFunction");
+        std::string message_name(agent_name + "_messages");
+        AgentDescription &a = m.newAgent(agent_name);
+        a.newVariable<unsigned int>("id");
+        a.newVariable<float>("v");
+        MsgBruteForce::Description &msg = m.newMessage(message_name);
+        msg.newVariable<float>("v");
+
+        MsgBruteForce::Description &msg_in = m.Message(msg_in_name);
+
+        auto &f_out = a.newFunction(agent_function_out, SlowOptionalMessageOutputAgentFunction);
+        f_out.setMessageOutputOptional(true);
+        f_out.setMessageOutput(msg);
+
+        layer0.addAgentFunction(f_out);
+
+        auto &f_in = a.newFunction(agent_function_in, SlowOptionalMessageInputAgentFunction);
+        f_in.setMessageInput(msg_in);
+
+        layer1.addAgentFunction(f_in);
+
+        // Generate an iniital population.
+        AgentPopulation * a_pop = new AgentPopulation(a, POPULATION_SIZES);
+        for (unsigned int j = 0; j < POPULATION_SIZES; ++j) {
+            auto agent = a_pop->getNextInstance();
+            agent.setVariable<unsigned int>("id", j);
+            agent.setVariable<float>("v", static_cast<float>(j));
+        }
+        populations.push_back(a_pop);
+    }
+
+    // Convert the model to a simulation
+    CUDASimulation s(m);
+
+    // Run the simulation many times, with and without concurrency to get an accurate speedup
+    float speedup = concurrentLayerSpeedup(TIMING_REPETITIONS, s, populations);
+    // Assert that a speedup was achieved.
+    EXPECT_GE(speedup, SPEEDUP_THRESHOLD);
+}
+
+
+/**
+ * Time agents outputting to independant lists, then inputting from a common list (agent_0_messages) using spatial messaging.
+ */
+RELEASE_ONLY_TEST(TestCUDASimulationConcurrency, ConcurrentMessageOutputInputSpatial2D) {
+    const float MESSAGE_BOUNDS_MIN = 0.f;
+    const float MESSAGE_BOUNDS_MAX = 9.f;
+    const float MESSAGE_BOUNDS_RADIUS = 1.f;
+
+    // Define a model with multiple agent types
+    ModelDescription m("ConcurrentMessageOutputInputSpatial2D");
+
+    // Create two layers.
+    LayerDescription &layer0  = m.newLayer();
+    LayerDescription &layer1  = m.newLayer();
+
+    std::vector<AgentPopulation *> populations = std::vector<AgentPopulation *>();
+
+    // Add a few agent types, each with a single agent function.
+    for (int i = 0; i < CONCURRENCY_DEGREE; i++) {
+        // Generate the agent type
+        std::string agent_name("agent_" + std::to_string(i));
+        std::string agent_function_out(agent_name + "_SlowMessageOutputAgentFunctionSpatial2D");
+        std::string agent_function_in(agent_name + "_SlowMessageInputAgentFunctionSpatial2D");
+        std::string message_name(agent_name + "_messages");
+        AgentDescription &a = m.newAgent(agent_name);
+        a.newVariable<float>("v");
+        a.newVariable<float>("x");
+        a.newVariable<float>("y");
+
+        MsgSpatial2D::Description &msg = m.newMessage<MsgSpatial2D>(message_name);
+        msg.newVariable<float>("v");
+        // msg.newVariable<float>("x");
+        // msg.newVariable<float>("y");
+        msg.setMin(MESSAGE_BOUNDS_MIN, MESSAGE_BOUNDS_MIN);
+        msg.setMax(MESSAGE_BOUNDS_MAX, MESSAGE_BOUNDS_MAX);
+        msg.setRadius(MESSAGE_BOUNDS_RADIUS);
+
+        auto &f_out = a.newFunction(agent_function_out, SlowMessageOutputAgentFunctionSpatial2D);
+        f_out.setMessageOutput(msg);
+
+        layer0.addAgentFunction(f_out);
+
+        auto &f_in = a.newFunction(agent_function_in, SlowMessageInputAgentFunctionSpatial2D);
+        f_in.setMessageInput(msg);
+
+        layer1.addAgentFunction(f_in);
+
+        // Generate an iniital population.
+        AgentPopulation * a_pop = new AgentPopulation(a, POPULATION_SIZES);
+        std::default_random_engine rng;
+        std::uniform_real_distribution<float> dist(0.0f, 11.0f);
+        for (unsigned int j = 0; j < POPULATION_SIZES; ++j) {
+            auto agent = a_pop->getNextInstance();
+            agent.setVariable<float>("v", static_cast<float>(j));
+            agent.setVariable<float>("x", dist(rng));
+            agent.setVariable<float>("y", dist(rng));
+        }
+        populations.push_back(a_pop);
+    }
+
+    // Convert the model to a simulation
+    CUDASimulation s(m);
+
+    // Run the simulation many times, with and without concurrency to get an accurate speedup
+    float speedup = concurrentLayerSpeedup(TIMING_REPETITIONS, s, populations);
+    // Assert that a speedup was achieved.
+    EXPECT_GE(speedup, SPEEDUP_THRESHOLD);
+}
+
+
+/**
+ * Time agents outputting to independant lists, then inputting from a common list (agent_0_messages) using spatial messaging.
+ */
+RELEASE_ONLY_TEST(TestCUDASimulationConcurrency, ConcurrentMessageOutputInputSpatial3D) {
+    const float MESSAGE_BOUNDS_MIN = 0.f;
+    const float MESSAGE_BOUNDS_MAX = 9.f;
+    const float MESSAGE_BOUNDS_RADIUS = 1.f;
+
+    // Define a model with multiple agent types
+    ModelDescription m("ConcurrentMessageOutputInputSpatial3D");
+
+    // Create two layers.
+    LayerDescription &layer0  = m.newLayer();
+    LayerDescription &layer1  = m.newLayer();
+
+    std::vector<AgentPopulation *> populations = std::vector<AgentPopulation *>();
+
+    // Add a few agent types, each with a single agent function.
+    for (int i = 0; i < CONCURRENCY_DEGREE; i++) {
+        // Generate the agent type
+        std::string agent_name("agent_" + std::to_string(i));
+        std::string agent_function_out(agent_name + "_SlowMessageOutputAgentFunctionSpatial3D");
+        std::string agent_function_in(agent_name + "_SlowMessageInputAgentFunctionSpatial3D");
+        std::string message_name(agent_name + "_messages");
+        AgentDescription &a = m.newAgent(agent_name);
+        a.newVariable<float>("v");
+        a.newVariable<float>("x");
+        a.newVariable<float>("y");
+        a.newVariable<float>("z");
+
+        MsgSpatial3D::Description &msg = m.newMessage<MsgSpatial3D>(message_name);
+        msg.newVariable<float>("v");
+        // msg.newVariable<float>("x");
+        // msg.newVariable<float>("y");
+        // msg.newVariable<float>("z");
+        msg.setMin(MESSAGE_BOUNDS_MIN, MESSAGE_BOUNDS_MIN, MESSAGE_BOUNDS_MIN);
+        msg.setMax(MESSAGE_BOUNDS_MAX, MESSAGE_BOUNDS_MAX, MESSAGE_BOUNDS_MAX);
+        msg.setRadius(MESSAGE_BOUNDS_RADIUS);
+
+        auto &f_out = a.newFunction(agent_function_out, SlowMessageOutputAgentFunctionSpatial3D);
+        f_out.setMessageOutput(msg);
+
+        layer0.addAgentFunction(f_out);
+
+        auto &f_in = a.newFunction(agent_function_in, SlowMessageInputAgentFunctionSpatial3D);
+        f_in.setMessageInput(msg);
+
+        layer1.addAgentFunction(f_in);
+
+        // Generate an iniital population.
+        AgentPopulation * a_pop = new AgentPopulation(a, POPULATION_SIZES);
+        std::default_random_engine rng;
+        std::uniform_real_distribution<float> dist(0.0f, 11.0f);
+        for (unsigned int j = 0; j < POPULATION_SIZES; ++j) {
+            auto agent = a_pop->getNextInstance();
+            agent.setVariable<float>("v", static_cast<float>(j));
+            agent.setVariable<float>("x", dist(rng));
+            agent.setVariable<float>("y", dist(rng));
+            agent.setVariable<float>("z", dist(rng));
+        }
+        populations.push_back(a_pop);
+    }
+
+    // Convert the model to a simulation
+    CUDASimulation s(m);
+
+    // Run the simulation many times, with and without concurrency to get an accurate speedup
+    float speedup = concurrentLayerSpeedup(TIMING_REPETITIONS, s, populations);
+    // Assert that a speedup was achieved.
+    EXPECT_GE(speedup, SPEEDUP_THRESHOLD);
+}
+
+/**
+ * Test for agent birth (to unique lists). Each agent type executes a function, and birth an agent to it's own population.
+ */
+RELEASE_ONLY_TEST(TestCUDASimulationConcurrency, LayerConcurrencyBirth) {
+    // Define a model with multiple agent types
+    ModelDescription m("LayerConcurrencyBirth");
+
+    // Create a layer, which contains one function for each agent type - with no dependencies this is allowed.
+    LayerDescription &layer  = m.newLayer();
+
+    std::vector<AgentPopulation *> populations = std::vector<AgentPopulation *>();
+
+    // Add a few agent types, each with a single agent function.
+    for (int i = 0; i < CONCURRENCY_DEGREE; i++) {
+        // Generate the agent type
+        std::string agent_name("agent_" + std::to_string(i));
+        std::string agent_function(agent_name + "_SlowAgentFunctionBirth");
+        AgentDescription &a = m.newAgent(agent_name);
+        a.newVariable<float>("v");
+        auto &f = a.newFunction(agent_function, SlowAgentFunctionBirth);
+        f.setAgentOutput(a);
+        layer.addAgentFunction(f);
+
+        // Generate an iniital population.
+        AgentPopulation * a_pop = new AgentPopulation(a, POPULATION_SIZES);
+        for (unsigned int j = 0; j < POPULATION_SIZES; ++j) {
+            auto agent = a_pop->getNextInstance();
+            agent.setVariable<float>("v", static_cast<float>(j));
+        }
+        populations.push_back(a_pop);
+    }
+
+    // Convert the model to a simulation
+    CUDASimulation s(m);
+
+    // Run the simulation many times, with and without concurrency to get an accurate speedup
+    float speedup = concurrentLayerSpeedup(TIMING_REPETITIONS, s, populations);
+    // Assert that a speedup was achieved.
+    EXPECT_GE(speedup, SPEEDUP_THRESHOLD);
+}
+
+/**
+ * Test for agent death. Each agent type executes a function and dies.
+ */
+RELEASE_ONLY_TEST(TestCUDASimulationConcurrency, LayerConcurrencyDeath) {
+    // Define a model with multiple agent types
+    ModelDescription m("LayerConcurrencyDeath");
+
+    // Create a layer, which contains one function for each agent type - with no dependencies this is allowed.
+    LayerDescription &layer  = m.newLayer();
+
+    std::vector<AgentPopulation *> populations = std::vector<AgentPopulation *>();
+
+    // Add a few agent types, each with a single agent function.
+    for (int i = 0; i < CONCURRENCY_DEGREE; i++) {
+        // Generate the agent type
+        std::string agent_name("agent_" + std::to_string(i));
+        std::string agent_function(agent_name + "_SlowAgentFunctionDeath");
+        AgentDescription &a = m.newAgent(agent_name);
+        a.newVariable<float>("v");
+        auto &f = a.newFunction(agent_function, SlowAgentFunctionDeath);
+        f.setAllowAgentDeath(true);
+        layer.addAgentFunction(f);
+
+        // Generate an iniital population.
+        AgentPopulation * a_pop = new AgentPopulation(a, POPULATION_SIZES);
+        for (unsigned int j = 0; j < POPULATION_SIZES; ++j) {
+            auto agent = a_pop->getNextInstance();
+            agent.setVariable<float>("v", static_cast<float>(j));
+        }
+        populations.push_back(a_pop);
+    }
+
+    // Convert the model to a simulation
+    CUDASimulation s(m);
+
+    // Run the simulation many times, with and without concurrency to get an accurate speedup
+    float speedup = concurrentLayerSpeedup(TIMING_REPETITIONS, s, populations);
+    // Assert that a speedup was achieved.
+    EXPECT_GE(speedup, SPEEDUP_THRESHOLD);
+}
+
+/**
+ * Test if Agent Function conditions are executed in parallel, with all agents disabled so the agent function condition is the only bit being timed.
+ */
+RELEASE_ONLY_TEST(TestCUDASimulationConcurrency, ConditionConcurrencyAllDisabled) {
+    // Define a model with multiple agent types
+    ModelDescription m("ConditionConcurrencyAllDisabled");
+
+    // Create a layer, which contains one function for each agent type - with no dependencies this is allowed.
+    LayerDescription &layer  = m.newLayer();
+
+    std::vector<AgentPopulation *> populations = std::vector<AgentPopulation *>();
+
+    // Add a few agent types, each with a single agent function.
+    for (int i = 0; i < CONCURRENCY_DEGREE; i++) {
+        // Generate the agent type
+        std::string agent_name("agent_" + std::to_string(i));
+        std::string agent_function(agent_name + "_SlowAgentFunction");
+        AgentDescription &a = m.newAgent(agent_name);
+        a.newVariable<float>("v");
+        auto &f = a.newFunction(agent_function, SlowAgentFunction);
+        f.setFunctionCondition(SlowConditionAllFalse);
+        layer.addAgentFunction(f);
+
+        // Generate an iniital population.
+        AgentPopulation * a_pop = new AgentPopulation(a, POPULATION_SIZES);
+        for (unsigned int j = 0; j < POPULATION_SIZES; ++j) {
+            auto agent = a_pop->getNextInstance();
+            agent.setVariable<float>("v", static_cast<float>(j));
+        }
+        populations.push_back(a_pop);
+    }
+
+    // Convert the model to a simulation
+    CUDASimulation s(m);
+
+    // Run the simulation many times, with and without concurrency to get an accurate speedup
+    float speedup = concurrentLayerSpeedup(TIMING_REPETITIONS, s, populations);
+    // Assert that a speedup was achieved.
+    EXPECT_GE(speedup, SPEEDUP_THRESHOLD);
+}
+
+/**
+ * Test if Agent Function conditions are executed in parallel, with all agents enabled so the condition and agent function are being verified as being in parallel.
+ */
+RELEASE_ONLY_TEST(TestCUDASimulationConcurrency, ConditionConcurrencyAllEnabled) {
+    // Define a model with multiple agent types
+    ModelDescription m("ConditionConcurrencyAllEnabled");
+
+    // Create a layer, which contains one function for each agent type - with no dependencies this is allowed.
+    LayerDescription &layer  = m.newLayer();
+
+    std::vector<AgentPopulation *> populations = std::vector<AgentPopulation *>();
+
+    // Add a few agent types, each with a single agent function.
+    for (int i = 0; i < CONCURRENCY_DEGREE; i++) {
+        // Generate the agent type
+        std::string agent_name("agent_" + std::to_string(i));
+        std::string agent_function(agent_name + "_SlowAgentFunction");
+        AgentDescription &a = m.newAgent(agent_name);
+        a.newVariable<float>("v");
+        auto &f = a.newFunction(agent_function, SlowAgentFunction);
+        f.setFunctionCondition(SlowConditionAllTrue);
+        layer.addAgentFunction(f);
+
+        // Generate an iniital population.
+        AgentPopulation * a_pop = new AgentPopulation(a, POPULATION_SIZES);
+        for (unsigned int j = 0; j < POPULATION_SIZES; ++j) {
+            auto agent = a_pop->getNextInstance();
+            agent.setVariable<float>("v", static_cast<float>(j));
+        }
+        populations.push_back(a_pop);
+    }
+
+    // Convert the model to a simulation
+    CUDASimulation s(m);
+
+    // Run the simulation many times, with and without concurrency to get an accurate speedup
+    float speedup = concurrentLayerSpeedup(TIMING_REPETITIONS, s, populations);
+    // Assert that a speedup was achieved.
+    EXPECT_GE(speedup, SPEEDUP_THRESHOLD);
+}
+
+/**
+ * Test if Agent Function conditions are executed in parallel, with all agents enabled so the condition and agent function are being verified as being in parallel.
+ * Disabled as it is not expected to pass till pinned memory + lots of refactoring is implementd (for sub 1ms improvements per function per layer per iteration per step)
+ */
+RELEASE_ONLY_TEST(TestCUDASimulationConcurrency, ConditionConcurrency5050) {
+    // Define a model with multiple agent types
+    ModelDescription m("ConditionConcurrency5050");
+
+    // Create a layer, which contains one function for each agent type - with no dependencies this is allowed.
+    LayerDescription &layer  = m.newLayer();
+
+    std::vector<AgentPopulation *> populations = std::vector<AgentPopulation *>();
+
+    // Add a few agent types, each with a single agent function.
+    for (int i = 0; i < CONCURRENCY_DEGREE; i++) {
+        // Generate the agent type
+        std::string agent_name("agent_" + std::to_string(i));
+        std::string agent_function(agent_name + "_SlowAgentFunction");
+        AgentDescription &a = m.newAgent(agent_name);
+        a.newVariable<float>("v");
+        auto &f = a.newFunction(agent_function, SlowAgentFunction);
+        f.setFunctionCondition(SlowCondition5050);
+        layer.addAgentFunction(f);
+
+        // Generate an iniital population.
+        AgentPopulation * a_pop = new AgentPopulation(a, POPULATION_SIZES);
+        for (unsigned int j = 0; j < POPULATION_SIZES; ++j) {
+            auto agent = a_pop->getNextInstance();
+            agent.setVariable<float>("v", static_cast<float>(j));
+        }
+        populations.push_back(a_pop);
+    }
+
+    // Convert the model to a simulation
+    CUDASimulation s(m);
+
+    // Run the simulation many times, with and without concurrency to get an accurate speedup
+    float speedup = concurrentLayerSpeedup(TIMING_REPETITIONS, s, populations);
+    // Assert that a speedup was achieved.
+    EXPECT_GE(speedup, SPEEDUP_THRESHOLD);
+}
+
+/**
+ * Test condition concurrency with fast kernels - i.e. only measure overheads.
+ * Disabled as it is not expected to pass till pinned memory + lots of refactoring is implementd (for sub 1ms improvements per function per layer per iteration per step)
+ */
+RELEASE_ONLY_TEST(TestCUDASimulationConcurrency, DISABLED_FastConditiRELEASE_ONLYonConcurrencyAllDisabled) {
+    // Define a model with multiple agent types
+    ModelDescription m("FastConditionConcurrencyAllDisabled");
+
+    // Create a layer, which contains one function for each agent type - with no dependencies this is allowed.
+    LayerDescription &layer  = m.newLayer();
+
+    std::vector<AgentPopulation *> populations = std::vector<AgentPopulation *>();
+
+    // Add a few agent types, each with a single agent function.
+    for (int i = 0; i < CONCURRENCY_DEGREE; i++) {
+        // Generate the agent type
+        std::string agent_name("agent_" + std::to_string(i));
+        std::string agent_function(agent_name + "_FastAgentFunction");
+        AgentDescription &a = m.newAgent(agent_name);
+        a.newVariable<float>("v");
+        auto &f = a.newFunction(agent_function, FastAgentFunction);
+        f.setFunctionCondition(FastConditionAllFalse);
+        layer.addAgentFunction(f);
+
+        // Generate an iniital population.
+        AgentPopulation * a_pop = new AgentPopulation(a, POPULATION_SIZES);
+        for (unsigned int j = 0; j < POPULATION_SIZES; ++j) {
+            auto agent = a_pop->getNextInstance();
+            agent.setVariable<float>("v", static_cast<float>(j));
+        }
+        populations.push_back(a_pop);
+    }
+
+    // Convert the model to a simulation
+    CUDASimulation s(m);
+
+    // Run the simulation many times, with and without concurrency to get an accurate speedup
+    float speedup = concurrentLayerSpeedup(TIMING_REPETITIONS, s, populations);
+    // Assert that a speedup was achieved.
+    EXPECT_GE(speedup, SPEEDUP_THRESHOLD);
+}
+
+/**
+ * Test condition concurrency with fast kernels - i.e. only measure overheads.
+ * Disabled as it is not expected to pass till pinned memory + lots of refactoring is implementd (for sub 1ms improvements per function per layer per iteration per step)
+ */
+RELEASE_ONLY_TEST(TestCUDASimulationConcurrency, DISABLED_FastConditionConcurrencyAllEnabled) {
+    // Define a model with multiple agent types
+    ModelDescription m("FastConditionConcurrencyAllEnabled");
+
+    // Create a layer, which contains one function for each agent type - with no dependencies this is allowed.
+    LayerDescription &layer  = m.newLayer();
+
+    std::vector<AgentPopulation *> populations = std::vector<AgentPopulation *>();
+
+    // Add a few agent types, each with a single agent function.
+    for (int i = 0; i < CONCURRENCY_DEGREE; i++) {
+        // Generate the agent type
+        std::string agent_name("agent_" + std::to_string(i));
+        std::string agent_function(agent_name + "_FastAgentFunction");
+        AgentDescription &a = m.newAgent(agent_name);
+        a.newVariable<float>("v");
+        auto &f = a.newFunction(agent_function, FastAgentFunction);
+        f.setFunctionCondition(FastConditionAllTrue);
+        layer.addAgentFunction(f);
+
+        // Generate an iniital population.
+        AgentPopulation * a_pop = new AgentPopulation(a, POPULATION_SIZES);
+        for (unsigned int j = 0; j < POPULATION_SIZES; ++j) {
+            auto agent = a_pop->getNextInstance();
+            agent.setVariable<float>("v", static_cast<float>(j));
+        }
+        populations.push_back(a_pop);
+    }
+
+    // Convert the model to a simulation
+    CUDASimulation s(m);
+
+    // Run the simulation many times, with and without concurrency to get an accurate speedup
+    float speedup = concurrentLayerSpeedup(TIMING_REPETITIONS, s, populations);
+    // Assert that a speedup was achieved.
+    EXPECT_GE(speedup, SPEEDUP_THRESHOLD);
+}
+
+/**
+ * Test condition concurrency with fast kernels - i.e. only measure overheads.
+ * Disabled as it is not expected to pass till pinned memory + lots of refactoring is implementd (for sub 1ms improvements per function per layer per iteration per step)
+ */
+RELEASE_ONLY_TEST(TestCUDASimulationConcurrency, DISABLED_FastConditionConcurrency5050) {
+    // Define a model with multiple agent types
+    ModelDescription m("FastConditionConcurrency5050");
+
+    // Create a layer, which contains one function for each agent type - with no dependencies this is allowed.
+    LayerDescription &layer  = m.newLayer();
+
+    std::vector<AgentPopulation *> populations = std::vector<AgentPopulation *>();
+
+    // Add a few agent types, each with a single agent function.
+    for (int i = 0; i < CONCURRENCY_DEGREE; i++) {
+        // Generate the agent type
+        std::string agent_name("agent_" + std::to_string(i));
+        std::string agent_function(agent_name + "_FastAgentFunction");
+        AgentDescription &a = m.newAgent(agent_name);
+        a.newVariable<float>("v");
+        auto &f = a.newFunction(agent_function, FastAgentFunction);
+        f.setFunctionCondition(FastCondition5050);
+        layer.addAgentFunction(f);
+
+        // Generate an iniital population.
+        AgentPopulation * a_pop = new AgentPopulation(a, POPULATION_SIZES);
+        for (unsigned int j = 0; j < POPULATION_SIZES; ++j) {
+            auto agent = a_pop->getNextInstance();
+            agent.setVariable<float>("v", static_cast<float>(j));
+        }
+        populations.push_back(a_pop);
+    }
+
+    // Convert the model to a simulation
+    CUDASimulation s(m);
+
+    // Run the simulation many times, with and without concurrency to get an accurate speedup
+    float speedup = concurrentLayerSpeedup(TIMING_REPETITIONS, s, populations);
+    // Assert that a speedup was achieved.
+    EXPECT_GE(speedup, SPEEDUP_THRESHOLD);
+}
+
+/**
+ * If SEATBELTS are on, try to get a device exception from parallel agent functions.
+ */
+RELEASE_ONLY_SEATBELTS_TEST(TestCUDASimulationConcurrency, LayerConcurrencyDeviceException) {
+    // Define a model with multiple agent types
+    ModelDescription m("LayerConcurrencyDeviceException");
+
+    // Create a layer, which contains one function for each agent type - with no dependencies this is allowed.
+    LayerDescription &layer  = m.newLayer();
+
+    std::vector<AgentPopulation *> populations = std::vector<AgentPopulation *>();
+
+    // Add a few agent types, each with a single agent function.
+    for (int i = 0; i < CONCURRENCY_DEGREE; i++) {
+        // Generate the agent type
+        std::string agent_name("agent_" + std::to_string(i));
+        std::string agent_function(agent_name + "_SlowAgentFunctionWithDeviceException");
+        AgentDescription &a = m.newAgent(agent_name);
+        a.newVariable<float>("v");
+        auto &f = a.newFunction(agent_function, SlowAgentFunctionWithDeviceException);
+        layer.addAgentFunction(f);
+
+        // Generate an iniital population.
+        AgentPopulation * a_pop = new AgentPopulation(a, POPULATION_SIZES);
+        for (unsigned int j = 0; j < POPULATION_SIZES; ++j) {
+            auto agent = a_pop->getNextInstance();
+            agent.setVariable<float>("v", static_cast<float>(j));
+        }
+        populations.push_back(a_pop);
+    }
+
+    // Convert the model to a simulation
+    CUDASimulation s(m);
+    s.SimulationConfig().steps = 1;
+
+    // set the flag saying to use streams for agnet function concurrency.
+    s.CUDAConfig().inLayerConcurrency = true;
+    s.applyConfig();
+    EXPECT_EQ(s.CUDAConfig().inLayerConcurrency, true);
+
+    // re-set each population
+    for (AgentPopulation * pop : populations) {
+        s.setPopulationData(*pop);
+    }
+    // Run and time the simulation, expecting a throw.
+    EXPECT_THROW(s.simulate(), DeviceError);
+}
+
+
+/************* 
+ * RTC Tests *
+ *************/
+
+/**
+ * Slow and uninteresting RTC agent function which will take a while to run for accurate timing
+ */
+const char* rtc_slowAgentFunction = R"###(
+    FLAMEGPU_AGENT_FUNCTION(rtc_slowAgentFunction, MsgNone, MsgNone) {
+        // Repeatedly do some pointless maths on the value in register
+        const int INTERNAL_REPETITIONS = 65536;
+        for (int i = 0; i < INTERNAL_REPETITIONS; i++) {
+            // Reead and write all the way to global mem each time to make this intentionally slow
+            float v = FLAMEGPU->getVariable<float>("v");
+            FLAMEGPU->setVariable("v", v + v);
+        }
+        return ALIVE;
+    }
+    )###";
+
+/**
+ * Test dectecting RTC concurrency for the simple unintersting case.
+ */
+RELEASE_ONLY_TEST(TestCUDASimulationConcurrency, RTCLayerConcurrency) {
+    // Define a model with multiple agent types
+    ModelDescription m("rtc_concurrency_test");
+
+    // Create a layer, which contains one function for each agent type - with no dependencies this is allowed.
+    LayerDescription &layer  = m.newLayer();
+
+    std::vector<AgentPopulation *> populations = std::vector<AgentPopulation *>();
+
+    // Add a few agent types, each with a single agent function.
+    for (int i = 0; i < CONCURRENCY_DEGREE; i++) {
+        // Generate the agent type
+        std::string agent_name("agent_" + std::to_string(i));
+        std::string agent_function(agent_name + "_slowAgentFunction");
+        AgentDescription &a = m.newAgent(agent_name);
+        a.newVariable<float>("v");
+
+        // @bug - first argument as the same string for many agent types leads to not all functions executing. Issue #378
+        auto &f = a.newRTCFunction(agent_function.c_str(), rtc_slowAgentFunction);
+        layer.addAgentFunction(f);
+
+        // Generate an iniital population.
+        AgentPopulation * a_pop = new AgentPopulation(a, POPULATION_SIZES);
+        for (unsigned int j = 0; j < POPULATION_SIZES; ++j) {
+            auto agent = a_pop->getNextInstance();
+            agent.setVariable<float>("v", static_cast<float>(j));
+        }
+        populations.push_back(a_pop);
+    }
+
+    // Convert the model to a simulation
+    CUDASimulation s(m);
+
+    // Run the simulation many times, with and without concurrency to get an accurate speedup
+    float speedup = concurrentLayerSpeedup(TIMING_REPETITIONS, s, populations);
+    // Assert that a speedup was achieved.
+    EXPECT_GE(speedup, SPEEDUP_THRESHOLD);
+}
+
+}  // namespace test_cuda_simulation_concurrency

--- a/tests/test_cases/util/test_CUDAEventTimer.cu
+++ b/tests/test_cases/util/test_CUDAEventTimer.cu
@@ -1,0 +1,54 @@
+#include <thread>
+#include <chrono>
+#include "flamegpu/util/CUDAEventTimer.cuh"
+#include "flamegpu/util/nvtx.h"
+#include "flamegpu/gpu/CUDAErrorChecking.h"
+
+#include "gtest/gtest.h"
+
+namespace test_CUDAEventTimer {
+
+/**
+ * This tests if the cudaEventTimer correctly times an event. 
+ * GPUs using WDDM driver can be inaccurate.
+ *   - eventRecord appear to be buffered to the device. 
+ *   - So need to device sync before the threadSleep.
+ *   - they appear to be accurate for timing the actual device work, just not wrt. the host (even in the default stream)
+ *   - Needs further investigation at some point (@todo). May be worth falling back to chrono::steady_clock and notify the reduced precision if wddm? 
+ */
+TEST(TestUtilCUDAEventTimer, CUDAEventTimer) {
+    NVTX_RANGE("TestUtilCUDAEventTimer:CUDAEventTimer");
+    // Create an event timer, time should be 0 initially.
+    util::CUDAEventTimer * timer = nullptr;
+    EXPECT_NO_THROW(timer = new util::CUDAEventTimer());
+    EXPECT_THROW(timer->getElapsedMilliseconds(), UnsycnedCUDAEventTimer);
+    // Time an arbitrary event, and check the value is approximately correct.
+    timer->start();
+    const int sleep_duration_seconds = 1;
+    const int min_expected_millis = static_cast<int>(sleep_duration_seconds * 1000. * 0.9);
+    // WDDM check (windows only)
+#ifdef _MSC_VER
+    int deviceIndex = 0;
+    int tccDriver = 0;  // Assume WDDM initially.
+    gpuErrchk(cudaGetDevice(&deviceIndex));
+    gpuErrchk(cudaDeviceGetAttribute(&tccDriver, cudaDevAttrTccDriver, deviceIndex));
+    if (tccDriver != 1) {
+        // Sync before the sleep to ensure the event has been recorded by wddm.
+        // checking the status of the default stream did not appear to fix this?
+        gpuErrchk(cudaDeviceSynchronize());
+    }
+#endif
+    // Sleep for some amount of time.
+    std::this_thread::sleep_for(std::chrono::seconds(sleep_duration_seconds));
+    // Stop the timer.
+    timer->stop();
+    // Sync the timer and compare the recorded against the expected time.
+    EXPECT_GE(timer->sync(), min_expected_millis);
+    EXPECT_GE(timer->getElapsedMilliseconds(), min_expected_millis);
+    // Trigger the destructor.
+    EXPECT_NO_THROW(delete timer);
+    // Reset the device for profiling?
+    gpuErrchk(cudaDeviceReset());
+}
+
+}  // namespace test_CUDAEventTimer

--- a/tests/test_cases/util/test_SteadyClockTimer.cpp
+++ b/tests/test_cases/util/test_SteadyClockTimer.cpp
@@ -1,0 +1,22 @@
+#include <thread>
+#include <chrono>
+#include "flamegpu/util/SteadyClockTimer.h"
+
+#include "gtest/gtest.h"
+
+TEST(TestSteadyClockTimer, SteadyClockTimer) {
+    // Create an event timer, time should be 0 initially.
+    util::SteadyClockTimer * timer = nullptr;
+    EXPECT_NO_THROW(timer = new util::SteadyClockTimer());
+
+    // Time an arbitrary event, and check the value is approximately correct.
+    timer->start();
+    const int sleep_duration_seconds = 1;
+    const int min_expected_millis = sleep_duration_seconds * 1000. * 0.9;
+    std::this_thread::sleep_for(std::chrono::seconds(sleep_duration_seconds));
+    timer->stop();
+    EXPECT_GE(timer->getElapsedMilliseconds(), min_expected_millis);
+
+    // Trigger the destructor.
+    EXPECT_NO_THROW(delete timer);
+}


### PR DESCRIPTION
Implement and detect in-layer concurrency via streams. 

This is now ready for review. It is not compelte, but is most of the way there and provides the majority of the intended benefit, although things can be improved.

Need to check that it has worked as intended on Windows (i.e. do the tests pass) in Release mode.

## Issues

Closes #189

Outstanding improvements detailed in #449


## Completed bits 

+ [x] add `CUDAConfig::inLayerConcurrency` property to prevent stream-based concurrency
    + required for testing, and potentially useful for debugging.
+ [x] Programatic Step Timing, init, exit and RTC timing.
    + [x] Plus output via `-t/--timing`?
    + [x] tests
+ [x] Simulate() NVTX Range
+ [x] NVTX Improvements `CUDASimulation`
+ [x] Refactor Step() into smaller chunks.
    + [x] Make Init functions user-callable
    + [x] Make Exit functions user-callable
+ [x] Better CUDASteam management/re-use
+ [x] Concurrent post-processing via streams (PBM construction, Scattering, CUB/Thrust calls...)
+ Add tests which detect concurrency, through the average runtime of steps:
    + [x] Naive agent function, different agent types
    + [x] Message Output to independant lists
    + [x] Message Input from independant lists
    + [x] Message Input from the same message list
    + [x] Optional Message Output
    + [x] Agent Birth (independant agent types)
    + [x] Agent Death
    + [x] Device Exception check (only runs with `SEATBELTS` on)
+ Add RTC tests which detect concurrency, through the average runtime of steps:
    + [x] Naive agent function, different agent types
    + Others (see issue)
+ [x] Check synchronisation is still performed as appropriate
+ [x] Disable performance related tests in debug mode.

This has primarily been tested / implemented under Linux. 
+ [x] Validate on Linux 
+ [x] Validate on Windows (WDDM), may be discrepancy.

Ideally the problem sizes should be small enough that individual agent functions will not fill the device, but this requires blocksize information to accurately target. Rather than exposing this, just use very small populations.




### Simple test case
4 agent types, 1 function each in the same layer, with small populations (4k?) each doing lots of pointless global memory accesses and floating point ops to ensure larger run time so that concurrency is (almost) guaranteed to occur. 
Time each function N times, and compare average with and without streams enabled.  

nvprof output for the simple test case, with `NO_SEATBELTS=OFF` showing that concurrency is already being achieved. My test correctly detects this! ~ 70ms with streams, ~ 200ms without
![image](https://user-images.githubusercontent.com/628937/92952663-43cc8e00-f458-11ea-9d92-26af4d4fb784.png)
