### PR TITLE
Add CUDA 11.1.0 to CI

### DIFF
--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -13,10 +13,14 @@ jobs:
       # explicit include-based build matrix, of known valid options
       matrix:
         include:
+          # 20.04 supports CUDA 11.0+, once a github hosted runner is available.
           # 18.04 supports CUDA 10.1+ (gxx <= 8)
           - os: ubuntu-18.04
-            cuda: "11.0"
+            cuda: "11.1"
             gcc: 8
+          # - os: ubuntu-18.04
+          #   cuda: "11.0"
+          #   gcc: 8
           - os: ubuntu-18.04
             cuda: "10.2"
             gcc: 8

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -15,8 +15,11 @@ jobs:
         include:
           # Windows2019 & VS 2019 supports 10.1+
           - os: windows-2019
-            cuda: "11.0.221"
+            cuda: "11.1.0"
             visual_studio: "Visual Studio 16 2019"
+          # - os: windows-2019
+          #   cuda: "11.0.3"
+          #   visual_studio: "Visual Studio 16 2019"
           - os: windows-2019
             cuda: "10.2.89"
             visual_studio: "Visual Studio 16 2019"
@@ -26,7 +29,10 @@ jobs:
 
           # Windows2016 & VS 2017 supports 10.0+
           # - os: windows-2016
-          #   cuda: "11.0.167"
+          #   cuda: "11.1.0"
+          #   visual_studio: "Visual Studio 15 2017"
+          # - os: windows-2016
+          #   cuda: "11.0.3"
           #   visual_studio: "Visual Studio 15 2017"
           # - os: windows-2016
           #   cuda: "10.2.89"

--- a/scripts/actions/install_cuda_windows.ps1
+++ b/scripts/actions/install_cuda_windows.ps1
@@ -3,6 +3,8 @@
 ## -------------------
 
 # Dictionary of known cuda versions and thier download URLS, which do not follow a consistent pattern :(
+# From 11.0, the download URLs have changed as verisoning within CUDA has changed. 
+# The toolkit verison is separate from the individual versions of tools, i.e. toolkit 11.1.0 contains cudart 11.1.74, but CUPTI 11.1.69  
 $CUDA_KNOWN_URLS = @{
     "8.0.44" = "http://developer.nvidia.com/compute/cuda/8.0/Prod/network_installers/cuda_8.0.44_win10_network-exe";
     "8.0.61" = "http://developer.nvidia.com/compute/cuda/8.0/Prod2/network_installers/cuda_8.0.61_win10_network-exe";
@@ -14,9 +16,10 @@ $CUDA_KNOWN_URLS = @{
     "10.1.168" = "http://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.168_win10_network.exe";
     "10.1.243" = "http://developer.download.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.243_win10_network.exe";
     "10.2.89" = "http://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe";
-    "11.0.167" = "http://developer.download.nvidia.com/compute/cuda/11.0.1/network_installers/cuda_11.0.1_win10_network.exe"
-    "11.0.194" = "http://developer.download.nvidia.com/compute/cuda/11.0.2/network_installers/cuda_11.0.2_win10_network.exe"
-    "11.0.221" = "http://developer.download.nvidia.com/compute/cuda/11.0.3/network_installers/cuda_11.0.3_win10_network.exe"
+    "11.0.1" = "http://developer.download.nvidia.com/compute/cuda/11.0.1/network_installers/cuda_11.0.1_win10_network.exe"
+    "11.0.2" = "http://developer.download.nvidia.com/compute/cuda/11.0.2/network_installers/cuda_11.0.2_win10_network.exe"
+    "11.0.3" = "http://developer.download.nvidia.com/compute/cuda/11.0.3/network_installers/cuda_11.0.3_win10_network.exe"
+    "11.1.0" = "https://developer.download.nvidia.com/compute/cuda/11.1.0/network_installers/cuda_11.1.0_win10_network.exe"
 }
 
 # @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead?


### PR DESCRIPTION
Adds CUDA 11.1.0 (the first release of 11.1) to CI. 

Also adjusts the version numbers used in the windows script to match the download versions for 11.0+, rather than the nvcc version contained within.