### PR TITLE
Fix ambiguity when specifying agent functions by name.

### DIFF
--- a/include/flamegpu/model/LayerDescription.h
+++ b/include/flamegpu/model/LayerDescription.h
@@ -81,22 +81,24 @@ class LayerDescription {
     /**
      * Adds an agent function to this layer
      * The agent function will be called during this stage of model execution
-     * @param name Name of the agent function description to execute during this layer
+     * @param agentName Name of the agent which owns the function to execute during this layer
+     * @param functionName Name of the agent function description to execute during this layer
      * @throw InvalidAgentFunc If the agent function does not exist within the model hierarchy
      * @throw InvalidAgentFunc If the agent function has already been added to the layer
      * @throw InvalidLayerMember If the layer already contains a SubModel
      */
-    void addAgentFunction(const std::string &name);
+    void addAgentFunction(const std::string &agentName, const std::string &functionName);
     /**
      * Adds an agent function to this layer
      * The agent function will be called during this stage of model execution
-     * @param name Name of the agent function description to execute during this layer
+     * @param agentName Name of the agent which owns the function to execute during this layer
+     * @param functionName Name of the agent function description to execute during this layer
      * @throw InvalidAgentFunc If the agent function does not exist within the model hierarchy
      * @throw InvalidAgentFunc If the agent function has already been added to the layer
      * @throw InvalidLayerMember If the layer already contains a SubModel
      * @note This version exists because the template overload was preventing implicit cast to std::string
      */
-    void addAgentFunction(const char *name);
+    void addAgentFunction(const char *agentName, const char *functionName);
     /**
      * Adds a host function to this layer
      * The host function will be called during this stage of model execution

--- a/src/flamegpu/model/AgentFunctionData.cpp
+++ b/src/flamegpu/model/AgentFunctionData.cpp
@@ -97,6 +97,19 @@ bool AgentFunctionData::operator==(const AgentFunctionData &rhs) const {
         && (rtc_condition_source == rhs.rtc_condition_source)
         && (rtc_func_condition_name == rhs.rtc_func_condition_name)) {
         // Test weak pointers
+        {   // parent
+            auto a = parent.lock();
+            auto b = rhs.parent.lock();
+            if (a && b) {
+                // We can't call equality here, as that would be infinite recursion
+                if (a->name != b->name ||
+                    a->functions.size() != b->functions.size()) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
         {  // message_input
             auto a = message_input.lock();
             auto b = rhs.message_input.lock();

--- a/src/flamegpu/model/LayerData.cpp
+++ b/src/flamegpu/model/LayerData.cpp
@@ -18,11 +18,9 @@ LayerData::LayerData(const std::shared_ptr<const ModelData> &model, const LayerD
     for (auto &_f : other.agent_functions) {
         for (auto &a : model->agents) {
             for (auto &f : a.second->functions) {
-                if (f.second->func == _f->func) {
-                    if (f.second->name == _f->name) {
-                        agent_functions.emplace(f.second);
-                        goto next_agent_fn;
-                    }
+                if (*f.second == *_f) {
+                    agent_functions.emplace(f.second);
+                    goto next_agent_fn;
                 }
             }
         }

--- a/src/flamegpu/model/LayerDescription.cpp
+++ b/src/flamegpu/model/LayerDescription.cpp
@@ -14,7 +14,7 @@ bool LayerDescription::operator!=(const LayerDescription& rhs) const {
     return !(*this == rhs);
 }
 
-void LayerDescription::addAgentFunction(const AgentFunctionDescription &afd) {    
+void LayerDescription::addAgentFunction(const AgentFunctionDescription &afd) {
     if (afd.model.lock() == model.lock()) {
         auto m = model.lock();
         // Find the same afd in the model hierarchy
@@ -44,7 +44,7 @@ void LayerDescription::addAgentFunction(const std::string &agentName, const std:
     if (a != mdl->agents.end()) {
         auto f = a->second->functions.find(functionName);
         if (f != a->second->functions.end()) {
-            // Check it's not a duplicate agent fn 
+            // Check it's not a duplicate agent fn
             if (layer->agent_functions.find(f->second) != layer->agent_functions.end()) {
                 THROW InvalidAgentFunc("Attempted to add agent function '%s' owned by agent '%s' to same layer twice, "
                     "in LayerDescription::addAgentFunction().",

--- a/tests/swig/python/model/test_layer.py
+++ b/tests/swig/python/model/test_layer.py
@@ -98,10 +98,10 @@ class LayerDescriptionTest(TestCase):
         l.addAgentFunction(f2)
         assert l.getAgentFunctionsCount() == 2
         # Add by string
-        l.addAgentFunction(FUNCTION_NAME3)
+        l.addAgentFunction(AGENT_NAME, FUNCTION_NAME3)
         assert l.getAgentFunctionsCount() == 3
         # Add by string literal (char*)
-        l.addAgentFunction(FUNCTION_NAME4)
+        l.addAgentFunction(AGENT_NAME, FUNCTION_NAME4)
         assert l.getAgentFunctionsCount() == 4
 
         # Cannot add function not attached to an agent
@@ -112,7 +112,7 @@ class LayerDescriptionTest(TestCase):
             l.addAgentFunction(f4)
         assert e.value.type() == "InvalidAgentFunc"
         with pytest.raises(pyflamegpu.FGPURuntimeException) as e:
-            l.addAgentFunction(FUNCTION_NAME5)
+            l.addAgentFunction(AGENT_NAME, FUNCTION_NAME5)
         assert e.value.type() == "InvalidAgentFunc"
         assert l.getAgentFunctionsCount() == 4
 
@@ -124,10 +124,10 @@ class LayerDescriptionTest(TestCase):
             l.addAgentFunction(f3)
         assert e.value.type() == "InvalidAgentFunc"
         with pytest.raises(pyflamegpu.FGPURuntimeException) as e:
-            l.addAgentFunction(FUNCTION_NAME4)
+            l.addAgentFunction(AGENT_NAME, FUNCTION_NAME4)
         assert e.value.type() == "InvalidAgentFunc"
         with pytest.raises(pyflamegpu.FGPURuntimeException) as e:
-            l.addAgentFunction(FUNCTION_NAME1)
+            l.addAgentFunction(AGENT_NAME, FUNCTION_NAME1)
         assert e.value.type() == "InvalidAgentFunc"
         assert l.getAgentFunctionsCount() == 4
 
@@ -170,7 +170,7 @@ class LayerDescriptionTest(TestCase):
             l.addAgentFunction(f2)
         assert e.value.type() == "InvalidAgentFunc"
         with pytest.raises(pyflamegpu.FGPURuntimeException) as e:
-            l.addAgentFunction(FUNCTION_NAME2)
+            l.addAgentFunction(AGENT_NAME, FUNCTION_NAME2)
         assert e.value.type() == "InvalidAgentFunc"
 
 
@@ -193,7 +193,7 @@ class LayerDescriptionTest(TestCase):
             l.addAgentFunction(f2)
         assert e.value.type() == "InvalidAgentFunc"
         with pytest.raises(pyflamegpu.FGPURuntimeException) as e:
-            l.addAgentFunction(FUNCTION_NAME2)
+            l.addAgentFunction(AGENT_NAME, FUNCTION_NAME2)
         assert e.value.type() == "InvalidAgentFunc"
 
     def test_same_agent_and_state3(self):
@@ -215,7 +215,7 @@ class LayerDescriptionTest(TestCase):
             l.addAgentFunction(f2)
         assert e.value.type() == "InvalidAgentFunc"
         with pytest.raises(pyflamegpu.FGPURuntimeException) as e:
-            l.addAgentFunction(FUNCTION_NAME2)
+            l.addAgentFunction(AGENT_NAME, FUNCTION_NAME2)
         assert e.value.type() == "InvalidAgentFunc"
 
     def test_same_agent_and_state4(self):
@@ -237,7 +237,7 @@ class LayerDescriptionTest(TestCase):
             l.addAgentFunction(f2)
         assert e.value.type() == "InvalidAgentFunc"
         with pytest.raises(pyflamegpu.FGPURuntimeException) as e:
-            l.addAgentFunction(FUNCTION_NAME2)
+            l.addAgentFunction(AGENT_NAME, FUNCTION_NAME2)
         assert e.value.type() == "InvalidAgentFunc"
 
     def test_same_agent_and_state5(self):
@@ -259,7 +259,7 @@ class LayerDescriptionTest(TestCase):
             l.addAgentFunction(f2)
         assert e.value.type() == "InvalidAgentFunc"
         with pytest.raises(pyflamegpu.FGPURuntimeException) as e:
-            l.addAgentFunction(FUNCTION_NAME2)
+            l.addAgentFunction(AGENT_NAME, FUNCTION_NAME2)
         assert e.value.type() == "InvalidAgentFunc"
 
     def test_same_agent_and_state6(self):
@@ -281,6 +281,6 @@ class LayerDescriptionTest(TestCase):
             l.addAgentFunction(f2)
         assert e.value.type() == "InvalidAgentFunc"
         with pytest.raises(pyflamegpu.FGPURuntimeException) as e:
-            l.addAgentFunction(FUNCTION_NAME2)
+            l.addAgentFunction(AGENT_NAME, FUNCTION_NAME2)
         assert e.value.type() == "InvalidAgentFunc"
     

--- a/tests/test_cases/gpu/test_cuda_agent_model.cu
+++ b/tests/test_cases/gpu/test_cuda_agent_model.cu
@@ -305,7 +305,7 @@ TEST(TestCUDAAgentModel, SharedAgentFunction) {
     cuda_model.setPopulationData(pop2);
 
     const unsigned int steps = 5;
-    for (int i = 0; i < steps; ++i) {
+    for (unsigned int i = 0; i < steps; ++i) {
         cuda_model.step();
     }
 

--- a/tests/test_cases/gpu/test_cuda_agent_model.cu
+++ b/tests/test_cases/gpu/test_cuda_agent_model.cu
@@ -311,13 +311,11 @@ TEST(TestCUDAAgentModel, SharedAgentFunction) {
 
     cuda_model.getPopulationData(pop1);
     cuda_model.getPopulationData(pop2);
-    printf("Pop1\n");
     for (unsigned int i = 0; i < populationSize; i++) {
         auto instance = pop1.getInstanceAt(i);
         EXPECT_EQ(instance.getVariable<int>("i"), 6);
         EXPECT_EQ(instance.getVariable<int>("j"), 4);
     }
-    printf("Pop2\n");
     for (unsigned int i = 0; i < populationSize; i++) {
         auto instance = pop2.getInstanceAt(i);
         EXPECT_EQ(instance.getVariable<int>("i"), 4);

--- a/tests/test_cases/gpu/test_cuda_agent_model.cu
+++ b/tests/test_cases/gpu/test_cuda_agent_model.cu
@@ -267,6 +267,63 @@ TEST(TestCUDAAgentModel, Step) {
     EXPECT_EQ(externalCounter, 5);
     EXPECT_EQ(c.getStepCounter(), 5u);
 }
+FLAMEGPU_AGENT_FUNCTION(add_fn, MsgNone, MsgNone) {
+    FLAMEGPU->setVariable<int>("i", FLAMEGPU->getVariable<int>("i") + 1);
+    FLAMEGPU->setVariable<int>("j", FLAMEGPU->getVariable<int>("j") + 1);
+    return ALIVE;
+}
+TEST(TestCUDAAgentModel, SharedAgentFunction) {
+    // Test that two different agents can share an agent function name/implementation
+    ModelDescription model("test");
+
+    auto &agent1 = model.newAgent("a1");
+    auto &agent2 = model.newAgent("a2");
+
+    agent1.newVariable<int>("i", 1);
+    agent1.newVariable<int>("j", -1);
+    agent2.newVariable<int>("i", -1);
+    agent2.newVariable<int>("j", 1);
+
+    auto &a1f = agent1.newFunction("add", add_fn);
+    auto &a2f = agent2.newFunction("add", add_fn);
+
+    auto &layer = model.newLayer();
+    layer.addAgentFunction(a1f);
+    layer.addAgentFunction(a2f);
+
+    CUDAAgentModel cuda_model(model);
+    cuda_model.applyConfig();
+
+    const unsigned int populationSize = 5;
+    AgentPopulation pop1(agent1, populationSize);
+    AgentPopulation pop2(agent2, populationSize);
+    for (unsigned int i = 0; i < populationSize; i++) {
+        pop1.getNextInstance();
+        pop2.getNextInstance();
+    }
+    cuda_model.setPopulationData(pop1);
+    cuda_model.setPopulationData(pop2);
+
+    const unsigned int steps = 5;
+    for (int i = 0; i < steps; ++i) {
+        cuda_model.step();
+    }
+
+    cuda_model.getPopulationData(pop1);
+    cuda_model.getPopulationData(pop2);
+    printf("Pop1\n");
+    for (unsigned int i = 0; i < populationSize; i++) {
+        auto instance = pop1.getInstanceAt(i);
+        EXPECT_EQ(instance.getVariable<int>("i"), 6);
+        EXPECT_EQ(instance.getVariable<int>("j"), 4);
+    }
+    printf("Pop2\n");
+    for (unsigned int i = 0; i < populationSize; i++) {
+        auto instance = pop2.getInstanceAt(i);
+        EXPECT_EQ(instance.getVariable<int>("i"), 4);
+        EXPECT_EQ(instance.getVariable<int>("j"), 6);
+    }
+}
 TEST(TestSimulation, Simulate) {
     // Simulation is abstract, so test via CUDAAgentModel
     // Depends on CUDAAgentModel::step()

--- a/tests/test_cases/gpu/test_cuda_subagent.cu
+++ b/tests/test_cases/gpu/test_cuda_subagent.cu
@@ -1541,8 +1541,8 @@ TEST(TestCUDASubAgent, AgentStateTransition_UnmapToUnmap_InSubModel) {
         auto &af2 = a.newFunction("a2", AddOne2);
         af2.setInitialState(UNMAPPED_STATE1);
         af2.setEndState(UNMAPPED_STATE1);
-        sm.newLayer().addAgentFunction("a1");
-        sm.newLayer().addAgentFunction("a2");
+        sm.newLayer().addAgentFunction(AGENT_NAME, "a1");
+        sm.newLayer().addAgentFunction(AGENT_NAME, "a2");
         sm.addInitFunction(InitCreateAgents_AgentStateTransition_UnmapToUnmap_InSubModel);
         sm.addExitCondition(ExitAlways);
     }
@@ -1600,7 +1600,7 @@ TEST(TestCUDASubAgent, AgentStateTransition_MapToMap_InSubModel) {
         auto &af = a.newFunction("a1", AddOne2);
         af.setInitialState(MAPPED_STATE1);
         af.setEndState(MAPPED_STATE2);
-        sm.newLayer().addAgentFunction("a1");
+        sm.newLayer().addAgentFunction(AGENT_NAME, "a1");
         sm.addExitCondition(ExitAlways);
     }
     ModelDescription m(MODEL_NAME);
@@ -1651,7 +1651,7 @@ TEST(TestCUDASubAgent, AgentStateTransition_MapToUnmap_InSubModel) {
         auto &af = a.newFunction("a1", AddOne2);
         af.setInitialState(MAPPED_STATE1);
         af.setEndState(UNMAPPED_STATE2);
-        sm.newLayer().addAgentFunction("a1");
+        sm.newLayer().addAgentFunction(AGENT_NAME, "a1");
         sm.addExitCondition(ExitAlways);
     }
     ModelDescription m(MODEL_NAME);
@@ -1695,7 +1695,7 @@ TEST(TestCUDASubAgent, AgentStateTransition_UnmapToMap_InSubModel) {
         auto &af = a.newFunction("a1", AddOne2);
         af.setInitialState(UNMAPPED_STATE1);
         af.setEndState(MAPPED_STATE2);
-        sm.newLayer().addAgentFunction("a1");
+        sm.newLayer().addAgentFunction(AGENT_NAME, "a1");
         sm.addInitFunction(InitCreateAgents_AgentStateTransition_UnmapToUnmap_InSubModel);
         sm.addExitCondition(ExitAlways);
     }
@@ -1769,8 +1769,8 @@ TEST(TestCUDASubAgent, AgentStateTransition_MapToUnmapToMap_InSubModel) {
         auto &af2 = a.newFunction("a2", AddOne2);
         af2.setInitialState(MAPPED_STATE1);
         af2.setEndState(MAPPED_STATE2);
-        sm.newLayer().addAgentFunction("a1");
-        sm.newLayer().addAgentFunction("a2");
+        sm.newLayer().addAgentFunction(AGENT_NAME, "a1");
+        sm.newLayer().addAgentFunction(AGENT_NAME, "a2");
         sm.addExitCondition(ExitAlways);
     }
     ModelDescription m(MODEL_NAME);
@@ -1827,8 +1827,8 @@ TEST(TestCUDASubAgent, AgentStateTransition_UnmapToUnmap_InNestedSubModel) {
         auto &af2 = a.newFunction("a2", AddOne2);
         af2.setInitialState(UNMAPPED_STATE1);
         af2.setEndState(UNMAPPED_STATE1);
-        sm.newLayer().addAgentFunction("a1");
-        sm.newLayer().addAgentFunction("a2");
+        sm.newLayer().addAgentFunction(AGENT_NAME, "a1");
+        sm.newLayer().addAgentFunction(AGENT_NAME, "a2");
         sm.addInitFunction(InitCreateAgents_AgentStateTransition_UnmapToUnmap_InSubModel);
         sm.addExitCondition(ExitAlways);
     }
@@ -1897,7 +1897,7 @@ TEST(TestCUDASubAgent, AgentStateTransition_MapToMap_InNestedSubModel) {
         auto &af = a.newFunction("a1", AddOne2);
         af.setInitialState(MAPPED_STATE1);
         af.setEndState(MAPPED_STATE2);
-        sm.newLayer().addAgentFunction("a1");
+        sm.newLayer().addAgentFunction(AGENT_NAME, "a1");
         sm.addExitCondition(ExitAlways);
     }
     ModelDescription proxy(PROXY_SUB_MODEL_NAME);
@@ -1960,7 +1960,7 @@ TEST(TestCUDASubAgent, AgentStateTransition_MapToUnmap_InNestedSubModel) {
         auto &af = a.newFunction("a1", AddOne2);
         af.setInitialState(MAPPED_STATE1);
         af.setEndState(UNMAPPED_STATE2);
-        sm.newLayer().addAgentFunction("a1");
+        sm.newLayer().addAgentFunction(AGENT_NAME, "a1");
         sm.addExitCondition(ExitAlways);
     }
     ModelDescription proxy(PROXY_SUB_MODEL_NAME);
@@ -2016,7 +2016,7 @@ TEST(TestCUDASubAgent, AgentStateTransition_UnmapToMap_InNestedSubModel) {
         auto &af = a.newFunction("a1", AddOne2);
         af.setInitialState(UNMAPPED_STATE1);
         af.setEndState(MAPPED_STATE2);
-        sm.newLayer().addAgentFunction("a1");
+        sm.newLayer().addAgentFunction(AGENT_NAME, "a1");
         sm.addInitFunction(InitCreateAgents_AgentStateTransition_UnmapToUnmap_InSubModel);
         sm.addExitCondition(ExitAlways);
     }
@@ -2101,8 +2101,8 @@ TEST(TestCUDASubAgent, AgentStateTransition_MapToUnmapToMap_InNestedSubModel) {
         auto &af2 = a.newFunction("a2", AddOne2);
         af2.setInitialState(MAPPED_STATE1);
         af2.setEndState(MAPPED_STATE2);
-        sm.newLayer().addAgentFunction("a1");
-        sm.newLayer().addAgentFunction("a2");
+        sm.newLayer().addAgentFunction(AGENT_NAME, "a1");
+        sm.newLayer().addAgentFunction(AGENT_NAME, "a2");
         sm.addExitCondition(ExitAlways);
     }
     ModelDescription proxy(PROXY_SUB_MODEL_NAME);

--- a/tests/test_cases/model/test_layer.cu
+++ b/tests/test_cases/model/test_layer.cu
@@ -71,10 +71,10 @@ TEST(LayerDescriptionTest, AgentFunction) {
     EXPECT_NO_THROW(l.addAgentFunction(f2));
     EXPECT_EQ(l.getAgentFunctionsCount(), 2u);
     // Add by string
-    EXPECT_NO_THROW(l.addAgentFunction(std::string(FUNCTION_NAME3)));
+    EXPECT_NO_THROW(l.addAgentFunction(AGENT_NAME, std::string(FUNCTION_NAME3)));
     EXPECT_EQ(l.getAgentFunctionsCount(), 3u);
     // Add by string literal (char*)
-    EXPECT_NO_THROW(l.addAgentFunction(FUNCTION_NAME4));
+    EXPECT_NO_THROW(l.addAgentFunction(AGENT_NAME, FUNCTION_NAME4));
     EXPECT_EQ(l.getAgentFunctionsCount(), 4u);
 
     // Cannot add function not attached to an agent
@@ -86,8 +86,8 @@ TEST(LayerDescriptionTest, AgentFunction) {
     // Cannot add duplicate function variable with same name
     EXPECT_THROW(l.addAgentFunction(agent_fn2), InvalidAgentFunc);
     EXPECT_THROW(l.addAgentFunction(f3), InvalidAgentFunc);
-    EXPECT_THROW(l.addAgentFunction(std::string(FUNCTION_NAME4)), InvalidAgentFunc);
-    EXPECT_THROW(l.addAgentFunction(FUNCTION_NAME1), InvalidAgentFunc);
+    EXPECT_THROW(l.addAgentFunction(AGENT_NAME, std::string(FUNCTION_NAME4)), InvalidAgentFunc);
+    EXPECT_THROW(l.addAgentFunction(AGENT_NAME, FUNCTION_NAME1), InvalidAgentFunc);
     EXPECT_EQ(l.getAgentFunctionsCount(), 4u);
 
     // Function have the right name (not implemented
@@ -129,7 +129,7 @@ TEST(LayerDescriptionTest, SameAgentAndState1) {
     // Both have agent in default state
     EXPECT_NO_THROW(l.addAgentFunction(agent_fn2));
     EXPECT_THROW(l.addAgentFunction(agent_fn3), InvalidAgentFunc);
-    EXPECT_THROW(l.addAgentFunction(FUNCTION_NAME2), InvalidAgentFunc);
+    EXPECT_THROW(l.addAgentFunction(AGENT_NAME, FUNCTION_NAME2), InvalidAgentFunc);
     EXPECT_THROW(l.addAgentFunction(f2), InvalidAgentFunc);
 }
 TEST(LayerDescriptionTest, SameAgentAndState2) {
@@ -148,7 +148,7 @@ TEST(LayerDescriptionTest, SameAgentAndState2) {
     // Both have STATE_NAME:NEW_STATE_NAME state
     EXPECT_NO_THROW(l.addAgentFunction(agent_fn2));
     EXPECT_THROW(l.addAgentFunction(agent_fn3), InvalidAgentFunc);
-    EXPECT_THROW(l.addAgentFunction(FUNCTION_NAME2), InvalidAgentFunc);
+    EXPECT_THROW(l.addAgentFunction(AGENT_NAME, FUNCTION_NAME2), InvalidAgentFunc);
     EXPECT_THROW(l.addAgentFunction(f2), InvalidAgentFunc);
 }
 TEST(LayerDescriptionTest, SameAgentAndState3) {
@@ -167,7 +167,7 @@ TEST(LayerDescriptionTest, SameAgentAndState3) {
     // Both share initial state
     EXPECT_NO_THROW(l.addAgentFunction(agent_fn2));
     EXPECT_THROW(l.addAgentFunction(agent_fn3), InvalidAgentFunc);
-    EXPECT_THROW(l.addAgentFunction(FUNCTION_NAME2), InvalidAgentFunc);
+    EXPECT_THROW(l.addAgentFunction(AGENT_NAME, FUNCTION_NAME2), InvalidAgentFunc);
     EXPECT_THROW(l.addAgentFunction(f2), InvalidAgentFunc);
 }
 TEST(LayerDescriptionTest, SameAgentAndState4) {
@@ -186,7 +186,7 @@ TEST(LayerDescriptionTest, SameAgentAndState4) {
     // start matches end and vice versa
     EXPECT_NO_THROW(l.addAgentFunction(agent_fn2));
     EXPECT_THROW(l.addAgentFunction(agent_fn3), InvalidAgentFunc);
-    EXPECT_THROW(l.addAgentFunction(FUNCTION_NAME2), InvalidAgentFunc);
+    EXPECT_THROW(l.addAgentFunction(AGENT_NAME, FUNCTION_NAME2), InvalidAgentFunc);
     EXPECT_THROW(l.addAgentFunction(f2), InvalidAgentFunc);
 }
 TEST(LayerDescriptionTest, SameAgentAndState5) {
@@ -205,7 +205,7 @@ TEST(LayerDescriptionTest, SameAgentAndState5) {
     // end matches start state
     EXPECT_NO_THROW(l.addAgentFunction(agent_fn2));
     EXPECT_THROW(l.addAgentFunction(agent_fn3), InvalidAgentFunc);
-    EXPECT_THROW(l.addAgentFunction(FUNCTION_NAME2), InvalidAgentFunc);
+    EXPECT_THROW(l.addAgentFunction(AGENT_NAME, FUNCTION_NAME2), InvalidAgentFunc);
     EXPECT_THROW(l.addAgentFunction(f2), InvalidAgentFunc);
 }
 TEST(LayerDescriptionTest, SameAgentAndState6) {
@@ -224,7 +224,7 @@ TEST(LayerDescriptionTest, SameAgentAndState6) {
     // start matches end state
     EXPECT_NO_THROW(l.addAgentFunction(agent_fn2));
     EXPECT_THROW(l.addAgentFunction(agent_fn3), InvalidAgentFunc);
-    EXPECT_THROW(l.addAgentFunction(FUNCTION_NAME2), InvalidAgentFunc);
+    EXPECT_THROW(l.addAgentFunction(AGENT_NAME, FUNCTION_NAME2), InvalidAgentFunc);
     EXPECT_THROW(l.addAgentFunction(f2), InvalidAgentFunc);
 }
 

--- a/tests/test_cases/runtime/messaging/test_brute_force.cu
+++ b/tests/test_cases/runtime/messaging/test_brute_force.cu
@@ -304,7 +304,7 @@ TEST(TestMessage_BruteForce, OptionalNone) {
     // Validate each agent has seen no messages.
     for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
         AgentInstance ai = pop.getInstanceAt(i);
-        unsigned int index = ai.getVariable<unsigned int>("index");
+        // unsigned int index = ai.getVariable<unsigned int>("index");
         const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
         // no messages should have been read.
         EXPECT_EQ(UINT_MAX, message_read);


### PR DESCRIPTION
Also extend `AgentFunctDescription::operator==` to also consider parents (in a minimal fashion, to prevent recursion loop).
Closes #378