### PR TITLE
Wpressimising-move fix for GCC >= 9 (CUDA 11.0+) 

### DIFF
--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -14,13 +14,13 @@ jobs:
       matrix:
         include:
           # 20.04 supports CUDA 11.0+, once a github hosted runner is available.
-          # 18.04 supports CUDA 10.1+ (gxx <= 8)
+          # 18.04 supports CUDA 10.1+ (gcc <=8), 11.0+ (gcc<=9), 11.1+ (gcc<=10)
           - os: ubuntu-18.04
             cuda: "11.1"
-            gcc: 8
+            gcc: 10
           # - os: ubuntu-18.04
           #   cuda: "11.0"
-          #   gcc: 8
+          #   gcc: 9
           - os: ubuntu-18.04
             cuda: "10.2"
             gcc: 8

--- a/include/flamegpu/pop/AgentInstance.h
+++ b/include/flamegpu/pop/AgentInstance.h
@@ -141,7 +141,7 @@ std::array<T, N> AgentInstance::getVariable(const std::string &variable_name) co
     }
     std::array<T, N> rtn;
     memcpy(rtn.data(), reinterpret_cast<T*>(v.getDataPtr()) + (index * N), sizeof(T) * N);
-    return std::move(rtn);  // I think std::move will transfer the std::array rather than duplicating it
+    return rtn;
 }
 template <typename T>
 T AgentInstance::getVariable(const std::string &variable_name, const unsigned int &array_index) const {


### PR DESCRIPTION
Remove std::move on return statement, which leads to -Wpessimizing-move for gcc >= 9

Also adjusts CI GCC versions.

https://developers.redhat.com/blog/2019/04/12/understanding-when-not-to-stdmove-in-c/

> When returning a local variable of the same class type as the function return type, the compiler is free to omit any copying or moving (i.e., perform copy/move elision), if the variable we are returning is a non-volatile automatic object and is not a function parameter
> ...
> However, here the call to std::move precludes the NRVO, because it breaks the conditions specified in the C++ standard, namely [class.copy.elision]: the returned expression must be a name. The reason for this is that std::move returns a reference, and in general, the compiler can’t know to what object the function returns a reference to. So GCC 9 will issue a warning (when -Wall is in effect)