### PR TITLE
Moves further device side error checks behind NO_SEATBELTS.

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -542,21 +542,6 @@ else()
     set(SHORT_HASH "GitHash") # Placeholder, though its unlikely to be required
 endif()
 
-file(WRITE ${SHORT_HASH_FILE} ${SHORT_HASH})
 # Also create version.h
 configure_file(${FLAMEGPU_ROOT}/cmake/version.h ${FLAMEGPU_ROOT}/include/flamegpu/version.h)
-
-# The trick here is to make sure short_hash.txt is listed as a byproduct
-add_custom_target(
-    git_short_hash
-    BYPRODUCTS
-        ${SHORT_HASH_FILE}
-    COMMAND
-        ${CMAKE_COMMAND}
-        "-DSHORT_HASH_FILE=${SHORT_HASH_FILE}"
-        "-P" "${CMAKE_CURRENT_LIST_FILE}"
-    COMMENT
-        "Re-checking short hash..."
-    VERBATIM
-    USES_TERMINAL)
 endmacro()

--- a/include/flamegpu/runtime/messaging/Array/ArrayDevice.h
+++ b/include/flamegpu/runtime/messaging/Array/ArrayDevice.h
@@ -346,25 +346,27 @@ class MsgArray::Out {
 
 template<typename T, unsigned int N>
 __device__ T MsgArray::In::Message::getVariable(const char(&variable_name)[N]) const {
+#ifndef NO_SEATBELTS
     // Ensure that the message is within bounds.
-    if (index < this->_parent.length) {
-        // get the value from curve using the stored hashes and message index.
-        return Curve::getVariable<T>(variable_name, this->_parent.combined_hash, index);
-    } else {
-        // @todo - Improved error handling of out of bounds message access? Return a default value or assert?
+    if (index >= this->_parent.length) {
+        DTHROW("Invalid Array message, unable to get variable '%s'.\n", variable_name);
         return static_cast<T>(0);
     }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    return Curve::getVariable<T>(variable_name, this->_parent.combined_hash, index);
 }
 template<typename T, unsigned int N>
 __device__ T MsgArray::In::Filter::Message::getVariable(const char(&variable_name)[N]) const {
+#ifndef NO_SEATBELTS
     // Ensure that the message is within bounds.
-    if (index_1d < this->_parent.length) {
-        // get the value from curve using the stored hashes and message index.
-        return Curve::getVariable<T>(variable_name, this->_parent.combined_hash, index_1d);
-    } else {
-        // @todo - Improved error handling of out of bounds message access? Return a default value or assert?
+    if (index_1d >= this->_parent.length) {
+        DTHROW("Invalid Array message, unable to get variable '%s'.\n", variable_name);
         return static_cast<T>(0);
     }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    return Curve::getVariable<T>(variable_name, this->_parent.combined_hash, index_1d);
 }
 
 template<typename T, unsigned int N>

--- a/include/flamegpu/runtime/messaging/Array2D/Array2DDevice.h
+++ b/include/flamegpu/runtime/messaging/Array2D/Array2DDevice.h
@@ -373,25 +373,27 @@ class MsgArray2D::Out {
 
 template<typename T, unsigned int N>
 __device__ T MsgArray2D::In::Message::getVariable(const char(&variable_name)[N]) const {
+#ifndef NO_SEATBELTS
     // Ensure that the message is within bounds.
-    if (index < this->_parent.metadata->length) {
-        // get the value from curve using the stored hashes and message index.
-        return Curve::getVariable<T>(variable_name, this->_parent.combined_hash, index);
-    } else {
-        // @todo - Improved error handling of out of bounds message access? Return a default value or assert?
+    if (index >= this->_parent.metadata->length) {
+        DTHROW("Invalid Array2D message, unable to get variable '%s'.\n", variable_name);
         return static_cast<T>(0);
     }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    return Curve::getVariable<T>(variable_name, this->_parent.combined_hash, index);
 }
 template<typename T, unsigned int N>
 __device__ T MsgArray2D::In::Filter::Message::getVariable(const char(&variable_name)[N]) const {
+#ifndef NO_SEATBELTS
     // Ensure that the message is within bounds.
-    if (index_1d < this->_parent.metadata->length) {
-        // get the value from curve using the stored hashes and message index.
-        return Curve::getVariable<T>(variable_name, this->_parent.combined_hash, index_1d);
-    } else {
-        // @todo - Improved error handling of out of bounds message access? Return a default value or assert?
+    if (index_1d >= this->_parent.metadata->length) {
+        DTHROW("Invalid Array2D message, unable to get variable '%s'.\n", variable_name);
         return static_cast<T>(0);
     }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    return Curve::getVariable<T>(variable_name, this->_parent.combined_hash, index_1d);
 }
 
 template<typename T, unsigned int N>

--- a/include/flamegpu/runtime/messaging/Array3D/Array3DDevice.h
+++ b/include/flamegpu/runtime/messaging/Array3D/Array3DDevice.h
@@ -392,25 +392,27 @@ class MsgArray3D::Out {
 
 template<typename T, unsigned int N>
 __device__ T MsgArray3D::In::Message::getVariable(const char(&variable_name)[N]) const {
+#ifndef NO_SEATBELTS
     // Ensure that the message is within bounds.
-    if (index < this->_parent.metadata->length) {
-        // get the value from curve using the stored hashes and message index.
-        return Curve::getVariable<T>(variable_name, this->_parent.combined_hash, index);
-    } else {
-        // @todo - Improved error handling of out of bounds message access? Return a default value or assert?
+    if (index >= this->_parent.metadata->length) {
+        DTHROW("Invalid Array3D message, unable to get variable '%s'.\n", variable_name);
         return static_cast<T>(0);
     }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    return Curve::getVariable<T>(variable_name, this->_parent.combined_hash, index);
 }
 template<typename T, unsigned int N>
 __device__ T MsgArray3D::In::Filter::Message::getVariable(const char(&variable_name)[N]) const {
+#ifndef NO_SEATBELTS
     // Ensure that the message is within bounds.
-    if (index_1d < this->_parent.metadata->length) {
-        // get the value from curve using the stored hashes and message index.
-        return Curve::getVariable<T>(variable_name, this->_parent.combined_hash, index_1d);
-    } else {
-        // @todo - Improved error handling of out of bounds message access? Return a default value or assert?
+    if (index_1d >= this->_parent.metadata->length) {
+        DTHROW("Invalid Array3D message, unable to get variable '%s'.\n", variable_name);
         return static_cast<T>(0);
     }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    return Curve::getVariable<T>(variable_name, this->_parent.combined_hash, index_1d);
 }
 
 template<typename T, unsigned int N>

--- a/include/flamegpu/runtime/messaging/BruteForce/BruteForceDevice.h
+++ b/include/flamegpu/runtime/messaging/BruteForce/BruteForceDevice.h
@@ -201,15 +201,16 @@ class MsgBruteForce::Out {
 
 template<typename T, unsigned int N>
 __device__ T MsgBruteForce::In::Message::getVariable(const char(&variable_name)[N]) const {
+#ifndef NO_SEATBELTS
     // Ensure that the message is within bounds.
-    if (index < this->_parent.len) {
-        // get the value from curve using the stored hashes and message index.
-        T value = Curve::getVariable<T>(variable_name, this->_parent.combined_hash, index);
-        return value;
-    } else {
-        // @todo - Improved error handling of out of bounds message access? Return a default value or assert?
+    if (index >= this->_parent.len) {
+        DTHROW("Brute force message index exceeds messagelist length, unable to get variable '%s'.\n", variable_name);
         return static_cast<T>(0);
     }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    T value = Curve::getVariable<T>(variable_name, this->_parent.combined_hash, index);
+    return value;
 }
 
 /**

--- a/include/flamegpu/runtime/messaging/Bucket/BucketDevice.h
+++ b/include/flamegpu/runtime/messaging/Bucket/BucketDevice.h
@@ -301,15 +301,16 @@ __device__ void MsgBucket::Out::setKey(const IntT &key) const {
 
 template<typename T, unsigned int N>
 __device__ T MsgBucket::In::Filter::Message::getVariable(const char(&variable_name)[N]) const {
+#ifndef NO_SEATBELTS
     // Ensure that the message is within bounds.
-    if (cell_index < _parent.bucket_end) {
-        // get the value from curve using the stored hashes and message index.
-        T value = Curve::getVariable<T>(variable_name, this->_parent.combined_hash, cell_index);
-        return value;
-    } else {
-        // @todo - Improved error handling of out of bounds message access? Return a default value or assert?
+    if (cell_index >= _parent.bucket_end) {
+        DTHROW("Bucket message index exceeds bin length, unable to get variable '%s'.\n", variable_name);
         return static_cast<T>(0);
     }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    T value = Curve::getVariable<T>(variable_name, this->_parent.combined_hash, cell_index);
+    return value;
 }
 
 #endif  // INCLUDE_FLAMEGPU_RUNTIME_MESSAGING_BUCKET_BUCKETDEVICE_H_

--- a/include/flamegpu/runtime/messaging/Spatial2D/Spatial2DDevice.h
+++ b/include/flamegpu/runtime/messaging/Spatial2D/Spatial2DDevice.h
@@ -257,15 +257,16 @@ class MsgSpatial2D::Out : public MsgBruteForce::Out {
 
 template<typename T, unsigned int N>
 __device__ T MsgSpatial2D::In::Filter::Message::getVariable(const char(&variable_name)[N]) const {
-    //// Ensure that the message is within bounds.
-    if (relative_cell < 2) {
-        // get the value from curve using the stored hashes and message index.
-        T value = Curve::getVariable<T>(variable_name, this->_parent.combined_hash, cell_index);
-        return value;
-    } else {
-        // @todo - Improved error handling of out of bounds message access? Return a default value or assert?
+#ifndef NO_SEATBELTS
+    // Ensure that the message is within bounds.
+    if (relative_cell >= 2) {
+        DTHROW("MsgSpatial2D in invalid bin, unable to get variable '%s'.\n", variable_name);
         return static_cast<T>(0);
     }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    T value = Curve::getVariable<T>(variable_name, this->_parent.combined_hash, cell_index);
+    return value;
 }
 
 

--- a/include/flamegpu/runtime/messaging/Spatial3D/Spatial3DDevice.h
+++ b/include/flamegpu/runtime/messaging/Spatial3D/Spatial3DDevice.h
@@ -269,15 +269,16 @@ class MsgSpatial3D::Out : public MsgBruteForce::Out {
 
 template<typename T, unsigned int N>
 __device__ T MsgSpatial3D::In::Filter::Message::getVariable(const char(&variable_name)[N]) const {
-    //// Ensure that the message is within bounds.
-    if (relative_cell[0] < 2) {
-        // get the value from curve using the stored hashes and message index.
-        T value = Curve::getVariable<T>(variable_name, this->_parent.combined_hash, cell_index);
-        return value;
-    } else {
-        // @todo - Improved error handling of out of bounds message access? Return a default value or assert?
+#ifndef NO_SEATBELTS
+    // Ensure that the message is within bounds.
+    if (relative_cell[0] >= 2) {
+        DTHROW("MsgSpatial3D in invalid bin, unable to get variable '%s'.\n", variable_name);
         return static_cast<T>(0);
     }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    T value = Curve::getVariable<T>(variable_name, this->_parent.combined_hash, cell_index);
+    return value;
 }
 
 


### PR DESCRIPTION
These (getVariable() for each message type) were all missing for some reason.