### PR TITLE
Use __ldg for Spatial3D Messages (non RTC)

### DIFF
--- a/include/flamegpu/runtime/cuRVE/curve.h
+++ b/include/flamegpu/runtime/cuRVE/curve.h
@@ -542,6 +542,7 @@ template <typename T>
 __device__ __forceinline__ T Curve::getVariableByHash_ldg(const VariableHash variable_hash, unsigned int index) {
     size_t offset = index *sizeof(T);
 
+#ifndef NO_SEATBELTS
     // do a check on the size as otherwise the value_ptr may eb out of bounds.
     size_t size = getVariableSize(variable_hash);
 
@@ -549,15 +550,14 @@ __device__ __forceinline__ T Curve::getVariableByHash_ldg(const VariableHash var
     if (size != sizeof(T)) {
         curve_internal::d_curve_error = DEVICE_ERROR_UNKNOWN_TYPE;
         return NULL;
-    } else {
-        // get a pointer to the specific variable by offsetting by the provided index
-        T *value_ptr = reinterpret_cast<T*>(getVariablePtrByHash(variable_hash, offset));
-
-        if (value_ptr)
-            return __ldg(value_ptr);
-        else
-            return 0;
     }
+#endif
+    // get a pointer to the specific variable by offsetting by the provided index
+    T *value_ptr = reinterpret_cast<T*>(getVariablePtrByHash(variable_hash, offset));
+
+    if (value_ptr)
+        return __ldg(value_ptr);
+    return 0;
 }
 template <typename T, unsigned int N>
 __device__ __forceinline__ T Curve::getArrayVariableByHash(const VariableHash variable_hash, unsigned int agent_index, unsigned int array_index) {

--- a/include/flamegpu/runtime/messaging/Spatial3D/Spatial3DDevice.h
+++ b/include/flamegpu/runtime/messaging/Spatial3D/Spatial3DDevice.h
@@ -295,7 +295,7 @@ __device__ T MsgSpatial3D::In::Filter::Message::getVariable(const char(&variable
     }
 #endif
     // get the value from curve using the stored hashes and message index.
-    T value = Curve::getMessageVariable<T>(variable_name, this->_parent.combined_hash, cell_index);
+    T value = Curve::getMessageVariable_ldg<T>(variable_name, this->_parent.combined_hash, cell_index);
     return value;
 }
 


### PR DESCRIPTION
This appears to improve performance of boids 32k on a Titan V GPU by a small amount (~1.5%)

Should check on Turing and possibly at larger size before merging / closing.

![spatial-ldg](https://user-images.githubusercontent.com/628937/96755671-ed455e80-13ca-11eb-998c-db24b133bce3.png)
