### PR TITLE
Invert the NO_SEATBELTS cmake option for usability.

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -368,7 +368,7 @@ function(add_flamegpu_executable NAME SRC FLAMEGPU_ROOT PROJECT_ROOT IS_EXAMPLE)
     endif()
     
     # This macro disables expensive runtime checks (when not in debug mode)
-    if (NO_SEATBELTS)
+    if (NOT SEATBELTS)
         add_compile_definitions($<IF:$<CONFIG:Debug>,,NO_SEATBELTS>)
     endif()
 
@@ -426,7 +426,7 @@ function(add_flamegpu_library NAME SRC FLAMEGPU_ROOT)
     endif()
     
     # This macro disables expensive runtime checks (when not in debug mode)
-    if (NO_SEATBELTS)
+    if (NOT SEATBELTS)
         add_compile_definitions($<IF:$<CONFIG:Debug>,,NO_SEATBELTS>)
     endif()
     

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,7 @@ project(flamegpu2 CUDA CXX)
 
 # Option to enable/disable runtime checks which may impact performance
 # This will primarily prevent device code from reporting errors
-option(NO_SEATBELTS "Disable runtime checks which harm performance for release/profile builds.\nThis should only be enabled after a model is known to be correct." OFF)
+option(SEATBELTS "Enable runtime checks which harm performance for release/profile builds.\nThis should only be disabled after a model is known to be correct." ON)
 
 # Include common rules.
 include(${FLAMEGPU_ROOT}/cmake/common.cmake)


### PR DESCRIPTION
`-DSEATBELTS=OFF` makes more sense than `-DNO_SEATBELTS=ON`.

Does not change compile time macro.
