### PR TITLE
Add NO_SEATBELTS checks to device agent birth/death.

### DIFF
--- a/include/flamegpu/runtime/AgentFunction.h
+++ b/include/flamegpu/runtime/AgentFunction.h
@@ -87,10 +87,14 @@ __global__ void agent_function_wrapper(
         MsgOut::Out(agent_func_name_hash, messagename_outp_hash, out_messagelist_metadata, scanFlag_messageOutput));
 
     // call the user specified device function
-    {
-        FLAME_GPU_AGENT_STATUS flag = AgentFunction()(&api);
+    FLAME_GPU_AGENT_STATUS flag = AgentFunction()(&api);
+    if (scanFlag_agentDeath) {
         // (scan flags will not be processed unless agent death has been requested in model definition)
         scanFlag_agentDeath[FLAMEGPU_DEVICE_API<MsgIn, MsgOut>::TID()] = flag;
+#ifndef NO_SEATBELTS
+    } else if (flag == DEAD) {
+        DTHROW("Agent death must be enabled per agent function when defining the model.\n");
+#endif
     }
 }
 

--- a/include/flamegpu/runtime/flamegpu_device_api.h
+++ b/include/flamegpu/runtime/flamegpu_device_api.h
@@ -303,27 +303,33 @@ __device__ void FLAMEGPU_DEVICE_API<MsgIn, MsgOut>::setVariable(const char(&vari
 template<typename MsgIn, typename MsgOut>
 template<typename T, unsigned int N>
 __device__ void FLAMEGPU_DEVICE_API<MsgIn, MsgOut>::AgentOut::setVariable(const char(&variable_name)[N], T value) const {
-    if (variable_name[0] == '_') {
-        return;  // Fail silently
-    }
     if (agent_output_hash) {
-        // simple indexing assumes index is the thread number (this may change later)
-        unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
+        if (variable_name[0] == '_') {
+            return;  // Fail silently
+        }
+        if (agent_output_hash) {
+            // simple indexing assumes index is the thread number (this may change later)
+            unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
 
-        // set the variable using curve
-        Curve::setNewAgentVariable<T>(variable_name, agent_output_hash, value, index);
+            // set the variable using curve
+            Curve::setNewAgentVariable<T>(variable_name, agent_output_hash, value, index);
 
-        // Mark scan flag
-        this->scan_flag[index] = 1;
+            // Mark scan flag
+            this->scan_flag[index] = 1;
+        }
+#ifndef NO_SEATBELTS
+    } else {
+        DTHROW("Agent output must be enabled per agent function when defining the model.\n");
+#endif
     }
 }
 template<typename MsgIn, typename MsgOut>
 template<typename T, unsigned int N, unsigned int M>
 __device__ void FLAMEGPU_DEVICE_API<MsgIn, MsgOut>::AgentOut::setVariable(const char(&variable_name)[M], const unsigned int &array_index, T value) const {
-    if (variable_name[0] == '_') {
-        return;  // Fail silently
-    }
     if (agent_output_hash) {
+        if (variable_name[0] == '_') {
+            return;  // Fail silently
+        }
         // simple indexing assumes index is the thread number (this may change later)
         unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
 
@@ -332,6 +338,10 @@ __device__ void FLAMEGPU_DEVICE_API<MsgIn, MsgOut>::AgentOut::setVariable(const 
 
         // Mark scan flag
         this->scan_flag[index] = 1;
+#ifndef NO_SEATBELTS
+    } else {
+        DTHROW("Agent output must be enabled per agent function when defining the model.\n");
+#endif
     }
 }
 

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -493,7 +493,7 @@ bool CUDASimulation::step() {
             Curve::NamespaceHash agent_func_name_hash = agentname_hash + funcname_hash;
             Curve::NamespaceHash agentoutput_hash = func_des->agent_output.lock() ? singletons->curve.variableRuntimeHash("_agent_birth") + funcname_hash : 0;
             curandState * t_rng = d_rng + totalThreads;
-            unsigned int *scanFlag_agentDeath = this->singletons->scatter.Scan().Config(CUDAScanCompaction::Type::AGENT_DEATH, j).d_ptrs.scan_flag;
+            unsigned int *scanFlag_agentDeath = func_des->has_agent_death ? this->singletons->scatter.Scan().Config(CUDAScanCompaction::Type::AGENT_DEATH, j).d_ptrs.scan_flag : nullptr;
             unsigned int *scanFlag_messageOutput = this->singletons->scatter.Scan().Config(CUDAScanCompaction::Type::MESSAGE_OUTPUT, j).d_ptrs.scan_flag;
             unsigned int *scanFlag_agentOutput = this->singletons->scatter.Scan().Config(CUDAScanCompaction::Type::AGENT_OUTPUT, j).d_ptrs.scan_flag;
             unsigned int sm_size = 0;

--- a/tests/test_cases/exception/test_device_exception.cu
+++ b/tests/test_cases/exception/test_device_exception.cu
@@ -1093,3 +1093,34 @@ TEST_F(DeviceExceptionTest, AgentFunctionConditionError2) {
     // Test Something
     ms->run(1);
 }
+
+// Test error if agent birth/death not enabled
+FLAMEGPU_AGENT_FUNCTION(AgentBirthMock1, MsgNone, MsgNone) {
+    FLAMEGPU->agent_out.setVariable<int>("int", 0);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(AgentBirthMock2, MsgNone, MsgNone) {
+    FLAMEGPU->agent_out.setVariable<int, 2>("int", 0, 0);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(AgentDeathMock, MsgNone, MsgNone) {
+    return DEAD;
+}
+TEST_F(DeviceExceptionTest, AgentBirthDisabled1) {
+    // Add required agent function
+    ms->addFunc(AgentBirthMock1);
+    // Test Something
+    ms->run(1);
+}
+TEST_F(DeviceExceptionTest, AgentBirthDisabled2) {
+    // Add required agent function
+    ms->addFunc(AgentBirthMock2);
+    // Test Something
+    ms->run(1);
+}
+TEST_F(DeviceExceptionTest, AgentDeathDisabled) {
+    // Add required agent function
+    ms->addFunc(AgentDeathMock);
+    // Test Something
+    ms->run(1);
+}


### PR DESCRIPTION
Tweaked death slightly, so it now checks before setting death flag, previously it would always set death flag regardless. This was a touch easier than passing an extra value to kernel (tad more expensive if doing death, tad cheaper if not doing death?). Happy to do the inverse if preferred.

Closes #382 