### PR TITLE
Improve doc comments for host functions/conditions.

### DIFF
--- a/include/flamegpu/runtime/flamegpu_host_api_macros.h
+++ b/include/flamegpu/runtime/flamegpu_host_api_macros.h
@@ -27,7 +27,9 @@ void funcName ## _impl(FLAMEGPU_HOST_API* FLAMEGPU); \
 FLAMEGPU_HOST_FUNCTION_POINTER funcName = funcName ## _impl;\
 void funcName ## _impl(FLAMEGPU_HOST_API* FLAMEGPU)
 
-// FLAMEGPU function return type
+/**
+ * Return type for FLAMEGPU conditions
+ */
 enum FLAME_GPU_CONDITION_RESULT { CONTINUE, EXIT };
 /**
  * @brief FLAMEGPU host function pointer definition

--- a/src/flamegpu/model/LayerDescription.cpp
+++ b/src/flamegpu/model/LayerDescription.cpp
@@ -135,13 +135,6 @@ void LayerDescription::addSubModel(const SubModelDescription &submodel) {
         submodel.data->submodel->name.c_str(), mdl->name.c_str());
 }
 
-void LayerDescription::addHostFunctionCallback(HostFunctionCallback* func_callback) {
-    if (!layer->host_functions_callbacks.insert(func_callback).second) {
-            THROW InvalidHostFunc("Attempted to add same host function callback twice,"
-                "in LayerDescription::addHostFunctionCallback()");
-        }
-}
-
 std::string LayerDescription::getName() const {
     return layer->name;
 }
@@ -158,11 +151,6 @@ ModelData::size_type LayerDescription::getAgentFunctionsCount() const {
 ModelData::size_type LayerDescription::getHostFunctionsCount() const {
     // Safe down-cast
     return static_cast<ModelData::size_type>(layer->host_functions.size());
-}
-
-ModelData::size_type LayerDescription::getHostFunctionCallbackCount() const {
-    // Safe down-cast
-    return static_cast<ModelData::size_type>(layer->host_functions_callbacks.size());
 }
 
 const AgentFunctionDescription &LayerDescription::getAgentFunction(unsigned int index) const {
@@ -186,16 +174,4 @@ FLAMEGPU_HOST_FUNCTION_POINTER LayerDescription::getHostFunction(unsigned int in
     THROW OutOfBoundsException("Index %d is out of bounds (only %d items exist) "
         "in LayerDescription.getHostFunction().",
         index, layer->host_functions.size());
-}
-
-HostFunctionCallback* LayerDescription::getHostFunctionCallback(unsigned int index) const {
-    if (index < layer->host_functions_callbacks.size()) {
-        auto it = layer->host_functions_callbacks.begin();
-        for (unsigned int i = 0; i < index; ++i)
-            ++it;
-        return *it;
-    }
-    THROW OutOfBoundsException("Index %d is out of bounds (only %d items exist) "
-        "in LayerDescription.getHostFunctionCallback()\n",
-        index, layer->host_functions_callbacks.size());
 }

--- a/src/flamegpu/model/ModelDescription.cpp
+++ b/src/flamegpu/model/ModelDescription.cpp
@@ -156,38 +156,11 @@ void ModelDescription::addExitFunction(FLAMEGPU_EXIT_FUNCTION_POINTER func_p) {
     }
 }
 
-void ModelDescription::addInitFunctionCallback(HostFunctionCallback* func_callback) {
-    if (!model->initFunctionCallbacks.insert(func_callback).second) {
-            THROW InvalidHostFunc("Attempted to add same init function callback twice,"
-                "in ModelDescription::addInitFunctionCallback()");
-        }
-}
-void ModelDescription::addStepFunctionCallback(HostFunctionCallback* func_callback) {
-    if (!model->stepFunctionCallbacks.insert(func_callback).second) {
-            THROW InvalidHostFunc("Attempted to add same step function callback twice,"
-                "in ModelDescription::addStepFunctionCallback()");
-        }
-}
-void ModelDescription::addExitFunctionCallback(HostFunctionCallback* func_callback) {
-    if (!model->exitFunctionCallbacks.insert(func_callback).second) {
-            THROW InvalidHostFunc("Attempted to add same exit function callback twice,"
-                "in ModelDescription::addExitFunctionCallback()");
-        }
-}
-
-
 void ModelDescription::addExitCondition(FLAMEGPU_EXIT_CONDITION_POINTER func_p) {
     if (!model->exitConditions.insert(func_p).second) {
         THROW InvalidHostFunc("Attempted to add same exit condition twice,"
             "in ModelDescription::addExitCondition()");
     }
-}
-
-void ModelDescription::addExitConditionCallback(HostFunctionConditionCallback *func_callback) {
-    if (!model->exitConditionCallbacks.insert(func_callback).second) {
-            THROW InvalidHostFunc("Attempted to add same exit condition callback twice,"
-                "in ModelDescription::addExitConditionCallback()");
-        }
 }
 
 /**


### PR DESCRIPTION
Also put SWIG hostfn callbacks behind macros (to reduce confusion for those who read headers, hence why this depends on alternate_array_interface branch).

Closes #268 
Closes #270

Any further detail will need to go in the userguide.