### PR TITLE
Update Thrust and Jitify Dependencies

### DIFF
--- a/cmake/Jitify.cmake
+++ b/cmake/Jitify.cmake
@@ -10,7 +10,7 @@ cmake_policy(SET CMP0079 NEW)
 FetchContent_Declare(
     jitify
     GIT_REPOSITORY https://github.com/NVIDIA/jitify.git
-    GIT_TAG        2a015bb6f290f6ffa70d5d268399ce65942b96e0
+    GIT_TAG        3e96bcceb9e42105f6a32315abb2af04585a55b0
     SOURCE_DIR     ${FETCHCONTENT_BASE_DIR}/jitify-src/jitify
     GIT_PROGRESS   ON
     # UPDATE_DISCONNECTED   ON

--- a/cmake/Thrust.cmake
+++ b/cmake/Thrust.cmake
@@ -13,12 +13,17 @@ cmake_policy(SET CMP0079 NEW)
 # This may need some adjusting for future Thrust versions (potentially)
 
 # Declare information about where and what we want from thrust.
-# Thrust version must be >= 1.9.10 for good cmake integration, making our lives easy
-# We require 1.9.8 for a bug fix anyway, so no harm using 1.9.10 instead.
+# Thrust version must be >= 1.9.10 for good cmake integration. 
+# Thrust 1.9.8 is a miniumum as it includes a bugfix that was causing issues.
+# Once https://github.com/NVIDIA/thrust/issues/1294 is resolved (CUDA 11.2?) Then we can attempt to find the CUDA distributed version of thrust, and use that if it is atleast the supported version 
+# (This will prevent us having to track the CUDA release version explicitly in the future. )
+
+set(THRUST_DOWNLOAD_VERSION 1.10.0)
+
 FetchContent_Declare(
     thrust
-    GIT_REPOSITORY https://github.com/thrust/thrust.git
-    GIT_TAG        1.9.10
+    GIT_REPOSITORY https://github.com/NVIDIA/thrust.git
+    GIT_TAG        ${THRUST_DOWNLOAD_VERSION}
     GIT_SHALLOW    1
     GIT_PROGRESS   ON
     # UPDATE_DISCONNECTED   ON


### PR DESCRIPTION
Also adds a note about the potential to use FindThrust from a future CUDA version, to prevent compilation errors with future thrust version mismatches.

Tests all pass under linux.