### PR TITLE
Ensemble 1 notes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ option(BUILD_EXAMPLE_CIRCLES_BRUTEFORCE "Enable building examples/circles_brutef
 option(BUILD_EXAMPLE_CIRCLES_SPATIAL3D "Enable building examples/circles_spatial3D" OFF)
 option(BUILD_EXAMPLE_GAME_OF_LIFE "Enable building examples/game_of_life" OFF)
 option(BUILD_EXAMPLE_HOST_FUNCTIONS "Enable building examples/host_functions" OFF)
+option(BUILD_EXAMPLE_ENSEMBLE "Enable building examples/ensemble" OFF)
 option(BUILD_SWIG_PYTHON "Enable python bindings via SWIG" OFF)
 cmake_dependent_option(BUILD_SWIG_PYTHON_VIRTUALENV "Enable building of SWIG Python Virtual Env for Python Testing" OFF
                        "BUILD_SWIG_PYTHON" OFF)
@@ -106,10 +107,6 @@ endif()
 
 # Add each example
 
-if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_HOST_FUNCTIONS)
-    add_subdirectory(examples/host_functions)
-endif()
-
 if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_BOIDS_BRUTEFORCE)
     add_subdirectory(examples/boids_bruteforce)
 endif()
@@ -137,6 +134,15 @@ endif()
 if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_GAME_OF_LIFE)
     add_subdirectory(examples/game_of_life)
 endif()
+
+if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_HOST_FUNCTIONS)
+    add_subdirectory(examples/host_functions)
+endif()
+
+if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_ENSEMBLE)
+    add_subdirectory(examples/ensemble)
+endif()
+
 # Add the tests directory (if required)
 if(BUILD_TESTS)
     add_subdirectory(tests)

--- a/examples/ensemble/CMakeLists.txt
+++ b/examples/ensemble/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Set the minimum cmake version to that which supports cuda natively.
+# 3.10 required for cuda -std=c++14, however 3.12 fixes some device linker errors
+cmake_minimum_required(VERSION VERSION 3.12 FATAL_ERROR)
+
+# Name the project and set languages
+project(ensemble CUDA CXX)
+
+# Set the location of the ROOT flame gpu project relative to this CMakeList.txt
+get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../.. REALPATH)
+
+# Include common rules.
+include(${FLAMEGPU_ROOT}/cmake/common.cmake)
+
+# Define output location of binary files
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    # If top level project
+    SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin/${CMAKE_SYSTEM_NAME_LOWER}-x64/${CMAKE_BUILD_TYPE}/)
+else()
+    # If called via add_subdirectory()
+    SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../../bin/${CMAKE_SYSTEM_NAME_LOWER}-x64/${CMAKE_BUILD_TYPE}/)
+endif()
+
+# Prepare list of source files
+# Can't do this automatically, as CMake wouldn't know when to regen (as CMakeLists.txt would be unchanged)
+SET(ALL_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cu
+)
+
+# Option to enable/disable building the static library
+# option(VISUALISATION "Enable visualisation support" OFF) # This example is unlikely to have a visualisation
+
+# Add the executable and set required flags for the target
+add_flamegpu_executable("${PROJECT_NAME}" "${ALL_SRC}" "${FLAMEGPU_ROOT}" "${PROJECT_BINARY_DIR}" TRUE)
+
+# Also set as startup project (if top level project)
+set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"  PROPERTY VS_STARTUP_PROJECT "${PROJECT_NAME}")

--- a/examples/ensemble/src/main.cu
+++ b/examples/ensemble/src/main.cu
@@ -1,0 +1,452 @@
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <fstream>
+
+#include "flamegpu/flame_api.h"
+
+/**
+ * FLAME GPU 2 implementation of the Boids model, using spatial3D messaging.
+ * This is based on the FLAME GPU 1 implementation, but with dynamic generation of agents. 
+ * Agents are also clamped to be within the environment bounds, rather than wrapped as in FLAME GPU 1.
+ * 
+ * @todo - Should the agent's velocity change when it is clamped to the environment?
+ */
+
+
+/**
+ * Get the length of a vector
+ * @param x x component of the vector
+ * @param y y component of the vector
+ * @param z z component of the vector
+ * @return the length of the vector
+ */ 
+FLAMEGPU_HOST_DEVICE_FUNCTION float vec3Length(const float x, const float y, const float z) {
+    return sqrtf(x * x + y * y + z * z);
+}
+
+/**
+ * Add a scalar to a vector in-place
+ * @param x x component of the vector
+ * @param y y component of the vector
+ * @param z z component of the vector
+ * @param value scalar value to add
+ */ 
+FLAMEGPU_HOST_DEVICE_FUNCTION void vec3Add(float &x, float &y, float &z, const float value) {
+    x += value;
+    y += value;
+    z += value;
+}
+
+/**
+ * Subtract a scalar from a vector in-place
+ * @param x x component of the vector
+ * @param y y component of the vector
+ * @param z z component of the vector
+ * @param value scalar value to subtract
+ */ 
+FLAMEGPU_HOST_DEVICE_FUNCTION void vec3Sub(float &x, float &y, float &z, const float value) {
+    x -= value;
+    y -= value;
+    z -= value;
+}
+
+/**
+ * Multiply a vector by a scalar value in-place
+ * @param x x component of the vector
+ * @param y y component of the vector
+ * @param z z component of the vector
+ * @param multiplier scalar value to multiply by
+ */ 
+FLAMEGPU_HOST_DEVICE_FUNCTION void vec3Mult(float &x, float &y, float &z, const float multiplier) {
+    x *= multiplier;
+    y *= multiplier;
+    z *= multiplier;
+}
+
+/**
+ * Divide a vector by a scalar value in-place
+ * @param x x component of the vector
+ * @param y y component of the vector
+ * @param z z component of the vector
+ * @param divisor scalar value to divide by
+ */ 
+FLAMEGPU_HOST_DEVICE_FUNCTION void vec3Div(float &x, float &y, float &z, const float divisor) {
+    x /= divisor;
+    y /= divisor;
+    z /= divisor;
+}
+
+/**
+ * Normalize a 3 component vector in-place
+ * @param x x component of the vector
+ * @param y y component of the vector
+ * @param z z component of the vector
+ */ 
+FLAMEGPU_HOST_DEVICE_FUNCTION void vec3Normalize(float &x, float &y, float &z) {
+    // Get the length
+    float length = vec3Length(x, y, z);
+    vec3Div(x, y, z, length);
+}
+
+/**
+ * Clamp each component of a 3-part position to lie within a minimum and maximum value.
+ * Performs the operation in place
+ * Unlike the FLAME GPU 1 example, this is a clamping operation, rather than wrapping.
+ * @param x x component of the vector
+ * @param y y component of the vector
+ * @param z z component of the vector
+ * @param MIN_POSITION the minimum value for each component
+ * @param MAX_POSITION the maximum value for each component
+ */
+FLAMEGPU_HOST_DEVICE_FUNCTION void clampPosition(float &x, float &y, float &z, const float MIN_POSITION, const float MAX_POSITION) {
+    x = (x < MIN_POSITION)? MIN_POSITION: x;
+    x = (x > MAX_POSITION)? MAX_POSITION: x;
+
+    y = (y < MIN_POSITION)? MIN_POSITION: y;
+    y = (y > MAX_POSITION)? MAX_POSITION: y;
+
+    z = (z < MIN_POSITION)? MIN_POSITION: z;
+    z = (z > MAX_POSITION)? MAX_POSITION: z;
+}
+
+
+
+/**
+ * outputdata agent function for Boid agents, which outputs publicly visible properties to a message list
+ */
+FLAMEGPU_AGENT_FUNCTION(outputdata, MsgNone, MsgSpatial3D) {
+    // Output each agents publicly visible properties.
+    FLAMEGPU->message_out.setVariable<int>("id", FLAMEGPU->getVariable<int>("id"));
+    FLAMEGPU->message_out.setVariable<float>("x", FLAMEGPU->getVariable<float>("x"));
+    FLAMEGPU->message_out.setVariable<float>("y", FLAMEGPU->getVariable<float>("y"));
+    FLAMEGPU->message_out.setVariable<float>("z", FLAMEGPU->getVariable<float>("z"));
+    FLAMEGPU->message_out.setVariable<float>("fx", FLAMEGPU->getVariable<float>("fx"));
+    FLAMEGPU->message_out.setVariable<float>("fy", FLAMEGPU->getVariable<float>("fy"));
+    FLAMEGPU->message_out.setVariable<float>("fz", FLAMEGPU->getVariable<float>("fz"));
+    return ALIVE;
+}
+/**
+ * inputdata agent function for Boid agents, which reads data from neighbouring Boid agents, to perform the boid flocking model.
+ */
+FLAMEGPU_AGENT_FUNCTION(inputdata, MsgSpatial3D, MsgNone) {
+    // Agent properties in local register
+    int id = FLAMEGPU->getVariable<int>("id");
+    // Agent position
+    float agent_x = FLAMEGPU->getVariable<float>("x");
+    float agent_y = FLAMEGPU->getVariable<float>("y");
+    float agent_z = FLAMEGPU->getVariable<float>("z");
+    // Agent velocity
+    float agent_fx = FLAMEGPU->getVariable<float>("fx");
+    float agent_fy = FLAMEGPU->getVariable<float>("fy");
+    float agent_fz = FLAMEGPU->getVariable<float>("fz");
+
+    // Boids percieved center
+    float perceived_centre_x = 0.0f;
+    float perceived_centre_y = 0.0f;
+    float perceived_centre_z = 0.0f;
+    int perceived_count = 0;
+
+    // Boids global velocity matching
+    float global_velocity_x = 0.0f;
+    float global_velocity_y = 0.0f;
+    float global_velocity_z = 0.0f;
+
+    // Boids short range avoidance centre
+    float collision_centre_x = 0.0f;
+    float collision_centre_y = 0.0f;
+    float collision_centre_z = 0.0f;
+    int collision_count = 0;
+
+    const float INTERACTION_RADIUS = FLAMEGPU->environment.getProperty<float>("INTERACTION_RADIUS");
+    const float SEPARATION_RADIUS = FLAMEGPU->environment.getProperty<float>("SEPARATION_RADIUS");
+    // Iterate location messages, accumulating relevant data and counts.
+    for (const auto &message : FLAMEGPU->message_in(agent_x, agent_y, agent_z)) {
+        // Ignore self messages.
+        if (message.getVariable<int>("id") != id) {
+            // Get the message location and velocity.
+            const float message_x = message.getVariable<float>("x");
+            const float message_y = message.getVariable<float>("y");
+            const float message_z = message.getVariable<float>("z");
+            const float message_fx = message.getVariable<float>("fx");
+            const float message_fy = message.getVariable<float>("fy");
+            const float message_fz = message.getVariable<float>("fz");
+
+            // Check interaction radius
+            float separation = vec3Length(agent_x - message_x, agent_y - message_y, agent_z - message_z);
+
+            if (separation < (INTERACTION_RADIUS)) {
+                // Update the percieved centre
+                perceived_centre_x += message_x;
+                perceived_centre_y += message_y;
+                perceived_centre_z += message_z;
+                perceived_count++;
+
+                // Update percieved velocity matching
+                global_velocity_x += message_fx;
+                global_velocity_y += message_fy;
+                global_velocity_z += message_fz;
+
+                // Update collision centre
+                if (separation < (SEPARATION_RADIUS)) {  // dependant on model size
+                    collision_centre_x += message_x;
+                    collision_centre_y += message_y;
+                    collision_centre_z += message_z;
+                    collision_count += 1;
+                }
+            }
+        }
+    }
+
+    // Divide positions/velocities by relevant counts.
+    vec3Div(perceived_centre_x, perceived_centre_y, perceived_centre_z, perceived_count);
+    vec3Div(global_velocity_x, global_velocity_y, global_velocity_z, perceived_count);
+    vec3Div(global_velocity_x, global_velocity_y, global_velocity_z, collision_count);
+
+    // Total change in velocity
+    float velocity_change_x = 0.f;
+    float velocity_change_y = 0.f;
+    float velocity_change_z = 0.f;
+
+    // Rule 1) Steer towards perceived centre of flock (Cohesion)
+    float steer_velocity_x = 0.f;
+    float steer_velocity_y = 0.f;
+    float steer_velocity_z = 0.f;
+    if (perceived_count > 0) {
+        const float STEER_SCALE = FLAMEGPU->environment.getProperty<float>("STEER_SCALE");
+        steer_velocity_x = (perceived_centre_x - agent_x) * STEER_SCALE;
+        steer_velocity_y = (perceived_centre_y - agent_y) * STEER_SCALE;
+        steer_velocity_z = (perceived_centre_z - agent_z) * STEER_SCALE;
+    }
+    velocity_change_x += steer_velocity_x;
+    velocity_change_y += steer_velocity_y;
+    velocity_change_z += steer_velocity_z;
+
+    // Rule 2) Match neighbours speeds (Alignment)
+    float match_velocity_x = 0.f;
+    float match_velocity_y = 0.f;
+    float match_velocity_z = 0.f;
+    if (collision_count > 0) {
+        const float MATCH_SCALE = FLAMEGPU->environment.getProperty<float>("MATCH_SCALE");
+        match_velocity_x = global_velocity_x * MATCH_SCALE;
+        match_velocity_y = global_velocity_y * MATCH_SCALE;
+        match_velocity_z = global_velocity_z * MATCH_SCALE;
+    }
+    velocity_change_x += match_velocity_x;
+    velocity_change_y += match_velocity_y;
+    velocity_change_z += match_velocity_z;
+
+    // Rule 3) Avoid close range neighbours (Separation)
+    float avoid_velocity_x = 0.0f;
+    float avoid_velocity_y = 0.0f;
+    float avoid_velocity_z = 0.0f;
+    if (collision_count > 0) {
+        const float COLLISION_SCALE = FLAMEGPU->environment.getProperty<float>("COLLISION_SCALE");
+        avoid_velocity_x = (agent_x - collision_centre_x) * COLLISION_SCALE;
+        avoid_velocity_y = (agent_y - collision_centre_y) * COLLISION_SCALE;
+        avoid_velocity_z = (agent_z - collision_centre_z) * COLLISION_SCALE;
+    }
+    velocity_change_x += avoid_velocity_x;
+    velocity_change_y += avoid_velocity_y;
+    velocity_change_z += avoid_velocity_z;
+
+    // Global scale of velocity change
+    vec3Mult(velocity_change_x, velocity_change_y, velocity_change_z, FLAMEGPU->environment.getProperty<float>("GLOBAL_SCALE"));
+
+    // Update agent velocity
+    agent_fx += velocity_change_x;
+    agent_fy += velocity_change_y;
+    agent_fz += velocity_change_z;
+
+    // Bound velocity
+    float agent_fscale = vec3Length(agent_fx, agent_fy, agent_fz);
+    if (agent_fscale > 1) {
+        vec3Div(agent_fx, agent_fy, agent_fz, agent_fscale);
+    }
+
+    // Apply the velocity
+    const float TIME_SCALE = FLAMEGPU->environment.getProperty<float>("TIME_SCALE");
+    agent_x += agent_fx * TIME_SCALE;
+    agent_y += agent_fy * TIME_SCALE;
+    agent_z += agent_fz * TIME_SCALE;
+
+    // Bound position
+    clampPosition(agent_x, agent_y, agent_z, FLAMEGPU->environment.getProperty<float>("MIN_POSITION"), FLAMEGPU->environment.getProperty<float>("MAX_POSITION"));
+
+    // Update global agent memory.
+    FLAMEGPU->setVariable<float>("x", agent_x);
+    FLAMEGPU->setVariable<float>("y", agent_y);
+    FLAMEGPU->setVariable<float>("z", agent_z);
+
+    FLAMEGPU->setVariable<float>("fx", agent_fx);
+    FLAMEGPU->setVariable<float>("fy", agent_fy);
+    FLAMEGPU->setVariable<float>("fz", agent_fz);
+
+    return ALIVE;
+}
+
+int main(int argc, const char ** argv) {
+    ModelDescription model("boids_spatial3D");
+
+    /**
+     * GLOBALS
+     */
+     {
+        EnvironmentDescription &env = model.Environment();
+
+        // Population size to generate, if no agents are loaded from disk
+        env.newProperty("POPULATION_TO_GENERATE", 32768u);
+
+        // Environment Bounds
+        env.newProperty("MIN_POSITION", -0.5f);
+        env.newProperty("MAX_POSITION", +0.5f);
+
+        // Initialisation parameter(s)
+        env.newProperty("MAX_INITIAL_SPEED", 1.0f);
+        env.newProperty("MIN_INITIAL_SPEED", 0.01f);
+
+        // Interaction radius
+        env.newProperty("INTERACTION_RADIUS", 0.1f);
+        env.newProperty("SEPARATION_RADIUS", 0.005f);
+
+        // Global Scalers
+        env.newProperty("TIME_SCALE", 0.0005f);
+        env.newProperty("GLOBAL_SCALE", 0.15f);
+
+        // Rule scalers
+        env.newProperty("STEER_SCALE", 0.65f);
+        env.newProperty("COLLISION_SCALE", 0.75f);
+        env.newProperty("MATCH_SCALE", 1.25f);
+    }
+
+
+    {   // Location message
+        EnvironmentDescription &env = model.Environment();
+        MsgSpatial3D::Description &message = model.newMessage<MsgSpatial3D>("location");
+        // Set the range and bounds.
+        message.setRadius(env.getProperty<float>("INTERACTION_RADIUS"));
+        message.setMin(env.getProperty<float>("MIN_POSITION"), env.getProperty<float>("MIN_POSITION"), env.getProperty<float>("MIN_POSITION"));
+        message.setMax(env.getProperty<float>("MAX_POSITION"), env.getProperty<float>("MAX_POSITION"), env.getProperty<float>("MAX_POSITION"));
+
+        // A message to hold the location of an agent.
+        message.newVariable<int>("id");
+        // X Y Z are implicit.
+        // message.newVariable<float>("x");
+        // message.newVariable<float>("y");
+        // message.newVariable<float>("z");
+        message.newVariable<float>("fx");
+        message.newVariable<float>("fy");
+        message.newVariable<float>("fz");
+    }
+    {   // Boid agent
+        AgentDescription &agent = model.newAgent("Boid");
+        agent.newVariable<int>("id");
+        agent.newVariable<float>("x");
+        agent.newVariable<float>("y");
+        agent.newVariable<float>("z");
+        agent.newVariable<float>("fx");
+        agent.newVariable<float>("fy");
+        agent.newVariable<float>("fz");
+        agent.newFunction("outputdata", outputdata).setMessageOutput("location");
+        agent.newFunction("inputdata", inputdata).setMessageInput("location");
+    }
+
+    /**
+     * Control flow
+     */     
+    {   // Layer #1
+        LayerDescription &layer = model.newLayer();
+        layer.addAgentFunction(outputdata);
+    }
+    {   // Layer #2
+        LayerDescription &layer = model.newLayer();
+        layer.addAgentFunction(inputdata);
+    }
+
+
+    /**
+     * Create Model Runner
+     */
+    CUDASimulation cuda_model(model);
+
+    /**
+     * Create visualisation
+     */
+#ifdef VISUALISATION
+    ModelVis &visualisation = cuda_model.getVisualisation();
+    {
+        EnvironmentDescription &env = model.Environment();
+        float envWidth = env.get<float>("MAX_POSITION") - env.get<float>("MIN_POSITION");
+        const float INIT_CAM = env.get<float>("MAX_POSITION") * 1.25f;
+        visualisation.setInitialCameraLocation(INIT_CAM, INIT_CAM, INIT_CAM);
+        visualisation.setCameraSpeed(0.002f * envWidth);
+        auto &circ_agt = visualisation.addAgent("Boid");
+        // Position vars are named x, y, z; so they are used by default
+        circ_agt.setModel(Stock::Models::ICOSPHERE);
+        circ_agt.setModelScale(env.get<float>("SEPARATION_RADIUS"));
+    }
+    visualisation.activate();
+#endif
+
+    // Initialisation
+    cuda_model.initialise(argc, argv);
+
+    // If no xml model file was is provided, generate a population.
+    if (cuda_model.getSimulationConfig().input_file.empty()) {
+        EnvironmentDescription &env = model.Environment();
+        // Uniformly distribute agents within space, with uniformly distributed initial velocity.
+        // c++ random number generator engine
+        std::mt19937 rngEngine(cuda_model.getSimulationConfig().random_seed);
+        // Uniform distribution for agent position components
+        std::uniform_real_distribution<float> position_distribution(env.getProperty<float>("MIN_POSITION"), env.getProperty<float>("MAX_POSITION"));
+        // Uniform distribution of velocity direction components
+        std::uniform_real_distribution<float> velocity_distribution(-1, 1);
+        // Uniform distribution of velocity magnitudes
+        std::uniform_real_distribution<float> velocity_magnitude_distribution(env.getProperty<float>("MIN_INITIAL_SPEED"), env.getProperty<float>("MAX_INITIAL_SPEED"));
+
+        // Generate a population of agents, based on the relevant environment property
+        const unsigned int populationSize = env.getProperty<unsigned int>("POPULATION_TO_GENERATE");
+        AgentPopulation population(model.Agent("Boid"), populationSize);
+        for (unsigned int i = 0; i < populationSize; i++) {
+            AgentInstance instance = population.getNextInstance();
+            instance.setVariable<int>("id", i);
+
+            // Agent position in space
+            instance.setVariable<float>("x", position_distribution(rngEngine));
+            instance.setVariable<float>("y", position_distribution(rngEngine));
+            instance.setVariable<float>("z", position_distribution(rngEngine));
+
+            // Generate a random velocity direction
+            float fx = velocity_distribution(rngEngine);
+            float fy = velocity_distribution(rngEngine);
+            float fz = velocity_distribution(rngEngine);
+            // Generate a random speed between 0 and the maximum initial speed
+            float fmagnitude = velocity_magnitude_distribution(rngEngine);
+            // Use the random speed for the velocity.
+            vec3Normalize(fx, fy, fz);
+            vec3Mult(fx, fy, fz, fmagnitude);
+
+            // Set these for the agent.
+            instance.setVariable<float>("fx", fx);
+            instance.setVariable<float>("fy", fy);
+            instance.setVariable<float>("fz", fz);
+        }
+        cuda_model.setPopulationData(population);
+    }
+
+    /**
+     * Execution
+     */
+    cuda_model.simulate();
+
+
+    /**
+     * Export Pop
+     */
+    // cuda_model.exportData("end.xml");
+
+#ifdef VISUALISATION
+    visualisation.join();
+#endif
+    return 0;
+}

--- a/examples/ensemble/src/main.cu
+++ b/examples/ensemble/src/main.cu
@@ -367,7 +367,7 @@ int main(int argc, const char ** argv) {
     /**
      * Create Model Runner
      */
-    CUDASimulation cuda_model(model);
+    CUDAEnsemble cuda_model(model);
 
     /**
      * Create visualisation

--- a/include/flamegpu/exception/FGPUException.h
+++ b/include/flamegpu/exception/FGPUException.h
@@ -415,5 +415,9 @@ DERIVED_FGPUException(DeviceError, "Error reported from device code");
  * Defines an error reported when versions do not match
  */
 DERIVED_FGPUException(VersionMismatch, "Versions do not match");
+/**
+ * Exceptions related specifically to the execution of ensembles
+ */
+DERIVED_FGPUException(EnsembleException, "Ensemble requirements not met");
 
 #endif  // INCLUDE_FLAMEGPU_EXCEPTION_FGPUEXCEPTION_H_

--- a/include/flamegpu/flame_api.h
+++ b/include/flamegpu/flame_api.h
@@ -20,6 +20,7 @@
 #include "flamegpu/model/SubEnvironmentDescription.h"
 #include "flamegpu/pop/AgentPopulation.h"
 #include "flamegpu/gpu/CUDASimulation.h"
+#include "flamegpu/gpu/CUDAEnsemble.h"
 #include "flamegpu/runtime/messaging.h"
 #include "flamegpu/runtime/AgentFunction_shim.h"
 #include "flamegpu/runtime/AgentFunctionCondition_shim.h"

--- a/include/flamegpu/gpu/CUDAAgent.h
+++ b/include/flamegpu/gpu/CUDAAgent.h
@@ -45,19 +45,19 @@ class CUDAAgent : public AgentInterface {
     /**
      * Normal constructor
      * @param description Agent description of the agent
-     * @param _cuda_model Parent CUDASimulation of the agent
+     * @param instance_id Instance id of parent CUDASimulation of the agent
      */
-    CUDAAgent(const AgentData& description, const CUDASimulation &_cuda_model);
+    CUDAAgent(const AgentData& description, const unsigned int &instance_id);
     /**
      * Subagent form constructor, used when creating a CUDAAgent for a mapped agent within a submodel
      * @param description Agent description of the agent
-     * @param _cuda_model Parent CUDASimulation of the agent
+     * @param instance_id Instance id of parent CUDASimulation of the agent
      * @param master_agent The (parent) agent which this is agent is mapped to
      * @param mapping Mapping definition for how this agent is connected with its master agent.
      */
     CUDAAgent(
         const AgentData &description,
-        const CUDASimulation &_cuda_model,
+        const unsigned int &instance_id,
         const std::unique_ptr<CUDAAgent> &master_agent,
         const std::shared_ptr<SubAgentData> &mapping);
     /** 
@@ -261,9 +261,10 @@ class CUDAAgent : public AgentInterface {
      */
     const unsigned int fat_index;
     /**
-     * The parent model
+     * The parent model's instance id
+     * This is used for building the rtc header
      */
-    const CUDASimulation &cuda_model;
+    const unsigned int &instance_id;
     /**
      * map between function_name (or function_name_condition) and the jitify instance
      */

--- a/include/flamegpu/gpu/CUDAEnsemble.h
+++ b/include/flamegpu/gpu/CUDAEnsemble.h
@@ -1,0 +1,429 @@
+#ifndef INCLUDE_FLAMEGPU_GPU_CUDAENSEMBLE_H_
+#define INCLUDE_FLAMEGPU_GPU_CUDAENSEMBLE_H_
+#include <atomic>
+#include <memory>
+#include <vector>
+#include <string>
+#include <unordered_map>
+#include <map>
+
+
+#include "flamegpu/exception/FGPUDeviceException.h"
+#include "flamegpu/sim/Simulation.h"
+
+#include "flamegpu/gpu/CUDAAgent.h"
+#include "flamegpu/gpu/CUDAMessage.h"
+#include "flamegpu/gpu/CUDAScatter.h"
+#include "flamegpu/runtime/utility/RandomManager.cuh"
+#include "flamegpu/runtime/flamegpu_host_new_agent_api.h"
+#include "flamegpu/visualiser/ModelVis.h"
+
+
+/**
+ * Experimental class for managing multiple simultaneously executing copies of a simulation
+ * Based on CUDASimulation, however as it holds multiple populations it has various major differences to the user interface and model execution
+ */
+class CUDAEnsemble {
+    /**
+     * Requires internal access to scan/scatter singletons
+     */
+    friend class HostAgentInstance;
+    /**
+     * Map of a number of CUDA agents by name.
+     * The CUDA agents are responsible for allocating and managing all the device memory
+     * Each vector holds a CUDAAgent/CUDAMessage per active instance executed by the ensemble.
+     * When an active instance completes, it's CUDAAgent/CUDAMessage structures are reused
+     * This saves additional memory allocations etc
+     */
+    typedef std::unordered_map<std::string, std::vector<std::shared_ptr<CUDAAgent>>> CUDAEnsembleAgentMap;
+    typedef std::unordered_map<std::string, std::vector<std::reference_wrapper<AgentPopulation>>> CUDAEnsembleAgentPop;
+    /**
+     * Map of a number of CUDA messages by name.
+     * The CUDA messages are responsible for allocating and managing all the device memory
+     */
+    typedef std::unordered_map<std::string, std::vector<std::shared_ptr<CUDAMessage>>> CUDAEnsembleMessageMap;
+    /**
+     * Map of a number of CUDA sub models by name.
+     * The CUDA submodels are responsible for allocating and managing all the device memory of non mapped agent vars
+     * Ordered is used, so that random seed mutation always occurs same order.
+     */
+    typedef std::map<std::string, std::unique_ptr<CUDAEnsemble>> CUDASubModelMap;
+
+ public:
+    typedef std::vector<NewAgentStorage> AgentDataBuffer;
+    typedef std::unordered_map<std::string, AgentDataBuffer> AgentDataBufferStateMap;
+    typedef std::unordered_map<std::string, VarOffsetStruct> AgentOffsetMap;
+    typedef std::unordered_map<std::string, AgentDataBufferStateMap> AgentDataMap;
+     /**
+      * CUDA specific config
+      */
+    struct CConfig {
+        /**
+         * GPU to execute model on
+         * Defaults to device 0, this is most performant device as detected by CUDA
+         */
+        int device_id = 0;
+    };
+    /**
+     * Ensemble specific config
+     */
+    struct EConfig {
+        /**
+         * Write more status information to stdout during model execution
+         */
+        bool verbose = false;
+        /**
+         * Print timing info after ensemble execution has completed
+         */
+        bool timing = false;
+        /**
+         * Steps to run each run for
+         * If 0 is provided, the model must have atleast 1 exit condition
+         */
+        unsigned int steps = 100;
+        /**
+         * Max concurrent simulations
+         */
+        unsigned int max_concurrent_runs = 2;
+        /**
+         * Total runs
+         */
+        unsigned int total_runs = 100;
+        /**
+         * Directory to store output data (each run will get it's own output directory within this)
+         * @note Do we also want to allow format selection?
+         */
+        std::string out_directory;
+    };
+    /**
+     * Initialise cuda runner
+     * Allocates memory for agents/messages, copies environment properties to device etc
+     * If provided, you can pass runtime arguments to this constructor, to automatically call inititialise()
+     * This is not required, you can call inititialise() manually later, or not at all.
+     * @param model The model description to initialise the runner to execute
+     * @param argc Runtime argument count
+     * @param argv Runtime argument list ptr
+     */
+    explicit CUDAEnsemble(const ModelDescription& model, int argc = 0, const char** argv = nullptr);
+
+ private:
+    /**
+     * Private constructor, used to initialise submodels
+     * Allocates CUDASubAgents, and handles mappings
+     * @param submodel_desc The submodel description of the submodel (this should be from the already cloned model hierarchy)
+     * @param master_model The CUDAEnsemble of the master model
+     * @todo Move common components (init list and initOffsetsAndMap()) into a common/shared constructor
+     */
+    CUDAEnsemble(const std::shared_ptr<SubModelData>& submodel_desc, CUDAEnsemble *master_model);
+
+ public:
+    /**
+     * Inverse operation of contructor
+     */
+    virtual ~CUDAEnsemble();
+    /**
+     * Execute the simulation until config.steps have been executed, or an exit condition trips
+     */
+    void simulate();
+    /**
+     * Replaces internal population data for the specified agent
+     * @param population The agent type and data to replace agents with
+     * @return The index of population
+     * @throw InvalidCudaAgent If the agent type is not recognised
+     */
+    unsigned int addPopulationData(AgentPopulation& population);
+    void setPopulationData(const unsigned int &index,AgentPopulation& population);
+    /**
+     * Returns the internal population data for the specified agent
+     * @param index Index of the population to return
+     * @param population The agent type and data to fetch
+     * @throw InvalidCudaAgent If the agent type is not recognised
+     */
+    void getPopulationData(const unsigned int &index, AgentPopulation& population);
+    /**
+     * Returns the number of populations within the ensemble
+     */
+    unsigned int getPopulationCount() const;
+    /**
+     * @return A mutable reference to the cuda model specific configuration struct
+     * @see Simulation::applyConfig() Should be called afterwards to apply changes
+     */
+    CConfig &CUDAConfig();
+    EConfig &EnsembleConfig();
+    /**
+     * @return An immutable reference to the cuda model specific configuration struct
+     */
+    const CConfig &getCUDAConfig() const;
+    const EConfig &getEnsembleConfig() const;
+//#ifdef VISUALISATION
+//    /**
+//     * Creates (on first call) and returns the visualisation configuration options for this model instance
+//     */
+//    ModelVis &getVisualisation();
+//#endif
+
+    /**
+     * Get the duration of the last call to simulate() in milliseconds. 
+     * With a resolution of around 0.5 microseconds (cudaEventElapsedtime)
+     * @note Individual sim times makes no sense here, so this time should refer to execution of ensemble. E.g. you request 100, how long does running of 100 take.
+     */
+    float getElapsedTime() const;
+
+ private:
+    /**
+     * Steps the simulation once
+     * @return False if an exit condition was triggered
+     */
+    bool step();
+    /**
+     * Performs a cudaMemCopyToSymbol in the runtime library and also updates the symbols of any RTC functions (which exist separately within their own cuda module)
+     * Will thrown an error if any of the calls fail.
+     * @param symbol A device symbol
+     * @param rtc_symbol_name The name of the symbol
+     * @param src Source memory address
+     * @param count Size in bytes to copy
+     * @param offset Offset from start of symbol in bytes
+     */
+    void RTCSafeCudaMemcpyToSymbol(const void* symbol, const char* rtc_symbol_name, const void* src, size_t count, size_t offset = 0) const;
+
+    /**
+     * Performs a cudaMemCopy to a pointer in the runtime library and also updates the symbols of any RTC functions (which exist separately within their own cuda module)
+     * Will thrown an error if any of the calls fail.
+     * @param ptr a pointer to a symbol in device memory
+     * @param rtc_symbol_name The name of the symbol
+     * @param src Source memory address
+     * @param count Size in bytes to copy
+     * @param offset Offset from start of symbol in bytes
+     */
+    void RTCSafeCudaMemcpyToSymbolAddress(void* ptr, const char* rtc_symbol_name, const void* src, size_t count, size_t offset = 0) const;
+
+    /**
+     * Updates the environment property cache for all RTC agent functions
+     * @param src Source memory address
+     * @param count Length of buffer (Probably EnvironmentManager::MAX_BUFFER_SIZE)
+     */
+    void RTCUpdateEnvironmentVariables(const void* src, size_t count) const;
+    /**
+     * Returns the unique instance id of this CUDAEnsemble instance
+     * @note This value is used internally for environment property storage
+     */
+    //using Simulation::getInstanceID;
+    struct CUDAEnsembleInstance : public SimInterface {
+        CUDAEnsembleInstance(std::shared_ptr<const ModelData> modelddata,
+        std::map<std::string, std::unique_ptr<CUDAEnsemble>> &submodels,
+        RandomManager &rng,
+        const AgentOffsetMap &agentOffsets, const unsigned int &instance_id);
+        ~CUDAEnsembleInstance() override {};
+        const ModelData& getModelDescription() const override {
+            return *model;
+        }
+        AgentInterface& getAgent(const std::string& name) override {
+            const auto it = agent_map.find(name);
+
+            if (it == agent_map.end()) {
+                THROW InvalidCudaAgent("CUDA agent ('%s') not found, in CUDAEnsembleInstance::getAgent().",
+                    name.c_str());
+            }
+            return *(it->second.get());
+        }
+        CUDAAgent& getCUDAAgent(const std::string& agent_name) const {
+            const auto it = agent_map.find(agent_name);
+
+            if (it == agent_map.end()) {
+                THROW InvalidCudaAgent("CUDA agent ('%s') not found, in CUDASimulation::getCUDAAgent().",
+                    agent_name.c_str());
+            }
+
+            return *(it->second);
+        }
+        CUDAMessage& getCUDAMessage(const std::string& message_name) const {
+            const auto it = message_map.find(message_name);
+
+            if (it == message_map.end()) {
+                THROW InvalidCudaMessage("CUDA message ('%s') not found, in CUDASimulation::getCUDAMessage().",
+                    message_name.c_str());
+            }
+
+            return *(it->second);
+        }
+        unsigned int getInstanceID() const override {
+            return instance_id;
+        }
+        unsigned int getStepCounter() override {
+            return 0;// TODO: how will this work?
+        }
+        const std::shared_ptr<const ModelData> model;
+        std::unordered_map<std::string, std::unique_ptr<CUDAAgent>> agent_map;
+        std::unordered_map<std::string, std::unique_ptr<CUDAMessage>> message_map;
+        std::map<std::string, std::unique_ptr<CUDAEnsemble>> &submodel_map;
+        typedef std::vector<NewAgentStorage> AgentDataBuffer;//Hate duplicating these typedefs
+        typedef std::unordered_map<std::string, AgentDataBuffer> AgentDataBufferStateMap;
+        typedef std::unordered_map<std::string, AgentDataBufferStateMap> AgentDataMap;
+        AgentDataMap agentData;
+        const unsigned int instance_id;
+        std::unique_ptr<FLAMEGPU_HOST_API> host_api = nullptr;
+    };
+
+ protected:
+    /**
+     * Returns the model to a clean state
+     * This clears all agents and message lists, resets environment properties and reseeds random generation.
+     * Also calls resetStepCounter();
+     * @param submodelReset This should only be set to true when called automatically when a submodel reaches it's exit condition during execution. This performs a subset of the regular reset procedure.
+     * @note If triggered on a submodel, agent states and environment properties mapped to a parent agent, and random generation are not affected.
+     * @note If random was manually seeded, it will return to it's original state. If random was seeded from time, it will return to a new random state.
+     */
+    void reset(bool submodelReset) override;
+
+ private:
+    /**
+     * Reinitalises random generation for this model and all submodels
+     * @param seed New random seed (this updates stored seed in config)
+     */
+    void reseed(const unsigned int &seed);
+    /**
+     * Number of times step() has been called since sim was last reset/init
+     */
+    unsigned int step_count;
+    /**
+     * Duration of the last call to simulate() in milliseconds, with a resolution of around 0.5 microseconds (cudaEventElapsedtime)
+     */
+    float ensemble_elapsed_time;
+    /**
+     * Update the step counter for host and device.
+     */
+    void incrementStepCounter();
+    /**
+     * Internal model config
+     */
+    CConfig cuda_config;
+    EConfig ensemble_config;
+    const std::shared_ptr<const ModelData> model;    
+    /**
+     * This is only used when model is a submodel, otherwise it is empty
+     * If it is set, it causes simulate() to additionally reset/cull unmapped populations
+     */
+    const std::shared_ptr<const SubModelData> submodel;
+    /**
+     * Only used by submodels, only required to fetch the name of master model when initialising environment (as this occurs after constructor)
+     */
+    CUDAEnsemble const * mastermodel;
+    /**
+     * Map of submodel storage
+     */
+    CUDASubModelMap submodel_map;
+    /**
+     * We hold agent population data here before/after use
+     */
+    CUDAEnsembleAgentPop agent_data;
+    /**
+     * Streams created within this cuda context for executing functions within layers in parallel
+     */
+    std::vector<cudaStream_t> streams;
+    std::vector<CUDAEnsembleInstance> instance_vector;
+    /**
+     * Struct containing references to the various singletons which may include CUDA code, and therefore can only be initialsed after the deferred arg parsing is completed.
+     */
+    struct Singletons {
+      /**
+       * Curve instance used for variable mapping
+       * @todo Is this necessary? CUDAAgent/CUDAMessage have their own copy
+       */
+      Curve &curve;
+      /**
+       * Resizes device random array during step()
+       */
+      RandomManager rng;
+      /**
+       * Held here for tracking when to release cuda memory
+       */
+      CUDAScatter scatter;
+      /**
+       * Held here for tracking when to release cuda memory
+       */
+      EnvironmentManager &environment;
+#ifndef NO_SEATBELTS
+      /**
+       * Provides buffers for device error checking
+       */
+      DeviceExceptionManager exception;
+#endif
+      Singletons(Curve &curve, EnvironmentManager &environment) : curve(curve), environment(environment) { }
+    } * singletons;
+    /**
+     * Common method for adding this Model's data to env manager
+     */
+    void initEnvironmentMgr();
+    /**
+     * Flag indicating that the model has been initialsed
+     */
+    bool singletonsInitialised;
+
+    /**
+     * Flag indicating that RTC functions have been compiled
+     */
+    bool rtcInitialised;
+
+    /**
+     * Initialise the instances singletons.
+     */
+    void initialiseSingletons();
+    /**
+     * Initialise the rtc by building any RTC functions.
+     * This must be done at the start of step to ensure that any device selection has taken place and to preserve the context between runtime and RTC.
+     */
+    void initialiseRTC();
+    /**
+     * This must be allocated after initialise singletons
+     * This must be reset after cudaDeviceReset()
+     */
+    jitify::JitCache *rtc_kernel_cache;
+    /**
+     * Adds any agents stored in agentData to the device
+     * Clears agent storage in agentData
+     * @param streamId Stream index to perform scatter on
+     * @note called at the end of step() and after all init/hostLayer functions and exit conditions have finished
+     */
+    void processHostAgentCreation(const unsigned int &streamId);
+
+ public:
+
+    void initialise(int argc, const char** argv);
+    void applyConfig();
+ private:
+    // 1 Of these structs exists per stream
+    struct InstanceOffsetData {
+        InstanceOffsetData(const unsigned int &activeInstances);
+        ~InstanceOffsetData();
+        unsigned int * const d_instance_offsets;
+        Curve::NamespaceHash * const d_instance_id_hashes;
+    private:
+        static void * const cmalloc(const size_t &len);
+    };
+    std::vector<InstanceOffsetData> instance_offset_vector;
+    // Setup all of the CUDAAgent, CUDAMessage objects for the active instances
+    void initCUDAInstances(const unsigned int &active_instances);
+    // Purge all of the CUDAAgent, CUDAMessage instances
+    void releaseCUDAInstances();
+    /**
+     * Provides the offset data for variable storage
+     * Used by host agent creation
+     */
+    AgentOffsetMap agentOffsets;
+    void initOffsetsAndMap();
+    /**
+     * This tracks the current number of alive CUDAEnsemble instances
+     * When the last is destructed, cudaDeviceReset is triggered();
+     */
+    static std::atomic<int> active_instances;
+    void printHelp(const char *executable);
+    int checkArgs(int argc, const char** argv);
+
+ public:
+    /**
+     * If changed to false, will not auto cudaDeviceReset when final CUDAEnsemble instance is destructed
+     */
+    static bool AUTO_CUDA_DEVICE_RESET;
+};
+
+#endif  // INCLUDE_FLAMEGPU_GPU_CUDAENSEMBLE_H_

--- a/include/flamegpu/gpu/CUDAMessage.h
+++ b/include/flamegpu/gpu/CUDAMessage.h
@@ -38,7 +38,7 @@ class CUDAMessage {
       * Allocates enough memory for each variable within the provided MessageData
       * @param description The message to represent
       */
-    explicit CUDAMessage(const MsgBruteForce::Data& description, const CUDASimulation& cuda_model);
+    explicit CUDAMessage(const MsgBruteForce::Data& description);
     /**
      * Destructor, releases CUDA memory
      */
@@ -170,11 +170,6 @@ class CUDAMessage {
      */
     bool pbm_construction_required;
     std::unique_ptr<MsgSpecialisationHandler> specialisation_handler;
-
-    /**
-     * A reference to the cuda model which this object belongs to
-     */
-    const CUDASimulation& cuda_model;
 };
 
 #endif  // INCLUDE_FLAMEGPU_GPU_CUDAMESSAGE_H_

--- a/include/flamegpu/gpu/CUDASimulation.h
+++ b/include/flamegpu/gpu/CUDASimulation.h
@@ -122,7 +122,7 @@ class CUDASimulation : public Simulation {
     /**
      * Returns the number of times step() has been called since the simulation was last reset/init
      */
-    unsigned int getStepCounter() override;
+    unsigned int getStepCounter() const override;
     /**
      * Manually resets the step counter
      */

--- a/include/flamegpu/model/AgentFunctionData.h
+++ b/include/flamegpu/model/AgentFunctionData.h
@@ -28,6 +28,10 @@ struct AgentFunctionData {
      */
     AgentFunctionWrapper *func;
     /**
+     * The cuda kernel entry point for executing the agent function as part of an Ensemble
+     */
+    AgentFunctionEnsembleWrapper *ensemble_func;
+    /**
      * The string representing the RTC defined agent function
      */
     std::string rtc_source;
@@ -73,6 +77,10 @@ struct AgentFunctionData {
      * @see void agent_function_condition_wrapper(Curve::NamespaceHash, Curve::NamespaceHash, const int, const unsigned int, const unsigned int)
      */
     AgentFunctionConditionWrapper *condition;
+    /**
+     * The cuda kernel entry point for executing the agent function condition as part of an Ensemble
+     */
+    AgentFunctionConditionEnsembleWrapper *ensemble_condition;
     /**
      * The string representing the RTC defined agent function condition
      */
@@ -127,7 +135,7 @@ struct AgentFunctionData {
     /**
      * Normal constructor, only to be called by AgentDescription
      */
-    AgentFunctionData(std::shared_ptr<AgentData> _parent, const std::string &function_name, AgentFunctionWrapper *agent_function, const std::string &in_type, const std::string &out_type);
+    AgentFunctionData(std::shared_ptr<AgentData> _parent, const std::string &function_name, AgentFunctionWrapper *agent_function, AgentFunctionEnsembleWrapper *agent_ensemble_function, const std::string &in_type, const std::string &out_type);
     /**
      * Normal constructor for RTC function, only to be called by AgentDescription
      */

--- a/include/flamegpu/model/AgentFunctionDescription.h
+++ b/include/flamegpu/model/AgentFunctionDescription.h
@@ -301,9 +301,10 @@ template<typename AgentFunction>
 AgentFunctionDescription &AgentDescription::newFunction(const std::string &function_name, AgentFunction) {
     if (agent->functions.find(function_name) == agent->functions.end()) {
         AgentFunctionWrapper *f = AgentFunction::fnPtr();
+        AgentFunctionEnsembleWrapper *ef = AgentFunction::e_fnPtr();
         std::string in_t = CurveRTCHost::demangle(AgentFunction::inType().name());
         std::string out_t = CurveRTCHost::demangle(AgentFunction::outType().name());
-        auto rtn = std::shared_ptr<AgentFunctionData>(new AgentFunctionData(this->agent->shared_from_this(), function_name, f, in_t, out_t));
+        auto rtn = std::shared_ptr<AgentFunctionData>(new AgentFunctionData(this->agent->shared_from_this(), function_name, f, ef, in_t, out_t));
         agent->functions.emplace(function_name, rtn);
         return *rtn->description;
     }

--- a/include/flamegpu/model/ModelDescription.h
+++ b/include/flamegpu/model/ModelDescription.h
@@ -13,6 +13,7 @@
 class AgentDescription;
 class LayerDescription;
 class SubModelDescription;
+class CUDAEnsemble;
 struct ModelData;
 
 /**
@@ -25,6 +26,7 @@ class ModelDescription {
      * Simulation accesses the classes internals to convert it to a constant ModelData
      */
     friend Simulation::Simulation(const ModelDescription& model);
+    friend CUDAEnsemble;
 
  public:
     /**

--- a/include/flamegpu/runtime/AgentFunction.h
+++ b/include/flamegpu/runtime/AgentFunction.h
@@ -43,8 +43,8 @@ typedef void(AgentFunctionEnsembleWrapper)(
     Curve::NamespaceHash messagename_inp_hash,
     Curve::NamespaceHash messagename_outp_hash,
     Curve::NamespaceHash agent_output_hash,
-    const void *in_messagelist_metadata,
-    const void *out_messagelist_metadata,
+    const void ** in_messagelist_metadata,
+    const void ** out_messagelist_metadata,
     curandState *d_rng,
     unsigned int *scanFlag_agentDeath,
     unsigned int *scanFlag_messageOutput,
@@ -149,8 +149,8 @@ __global__ void agent_function_ensemble_wrapper(
     Curve::NamespaceHash messagename_inp_hash,
     Curve::NamespaceHash messagename_outp_hash,
     Curve::NamespaceHash agent_output_hash,
-    const void *in_messagelist_metadata,
-    const void *out_messagelist_metadata,
+    const void ** in_messagelist_metadata,
+    const void ** out_messagelist_metadata,
     curandState *d_rng,
     unsigned int *scanFlag_agentDeath,
     unsigned int *scanFlag_messageOutput,
@@ -164,10 +164,9 @@ __global__ void agent_function_ensemble_wrapper(
     if (FLAMEGPU_DEVICE_API<MsgIn, MsgOut>::TID() >= instance_offsets[total_instances])
         return;
     // Perform a search to extract correct instance_id_hash
-    // Note this cannot handle active instances with 0 length    
-    Curve::NamespaceHash instance_id_hash;
+    // Note this cannot handle active instances with 0 length
+    unsigned int min = 0;
     {
-        unsigned int min = 0;
         unsigned int max = total_instances;
 
         while (min + 1 != max) {
@@ -181,16 +180,20 @@ __global__ void agent_function_ensemble_wrapper(
             }
         }
         instance_id_hash = instance_id_hash_array[min];
+        instance_id_hash = instance_id_hash_array[min];
+        instance_id_hash = instance_id_hash_array[min];
+        instance_id_hash = instance_id_hash_array[min];
+        instance_id_hash = instance_id_hash_array[min];
     }
     // create a new device FLAME_GPU instance
     FLAMEGPU_DEVICE_API<MsgIn, MsgOut> api = FLAMEGPU_DEVICE_API<MsgIn, MsgOut>(
-        instance_id_hash,
+        instance_id_hash_array[min],
         agent_func_name_hash,
         agent_output_hash,
         d_rng,
         scanFlag_agentOutput,
-        MsgIn::In(agent_func_name_hash, messagename_inp_hash, in_messagelist_metadata),
-        MsgOut::Out(agent_func_name_hash, messagename_outp_hash, out_messagelist_metadata, scanFlag_messageOutput));
+        MsgIn::In(agent_func_name_hash, messagename_inp_hash, in_messagelist_metadata[min]),
+        MsgOut::Out(agent_func_name_hash, messagename_outp_hash, out_messagelist_metadata[min], scanFlag_messageOutput));
 
     // call the user specified device function
     FLAME_GPU_AGENT_STATUS flag = AgentFunction()(&api);

--- a/include/flamegpu/runtime/AgentFunction.h
+++ b/include/flamegpu/runtime/AgentFunction.h
@@ -32,9 +32,28 @@ typedef void(AgentFunctionWrapper)(
     unsigned int *scanFlag_messageOutput,
     unsigned int *scanFlag_agentOutput);  // Can't put __global__ in a typedef
 
+typedef void(AgentFunctionEnsembleWrapper)(
+#ifndef NO_SEATBELTS
+    DeviceExceptionBuffer *error_buffer,
+#endif
+    unsigned int total_instances,
+    unsigned int *instance_offsets,
+    Curve::NamespaceHash *instance_id_hash_array,
+    Curve::NamespaceHash agent_func_name_hash,
+    Curve::NamespaceHash messagename_inp_hash,
+    Curve::NamespaceHash messagename_outp_hash,
+    Curve::NamespaceHash agent_output_hash,
+    const void *in_messagelist_metadata,
+    const void *out_messagelist_metadata,
+    curandState *d_rng,
+    unsigned int *scanFlag_agentDeath,
+    unsigned int *scanFlag_messageOutput,
+    unsigned int *scanFlag_agentOutput);  // Can't put __global__ in a typedef
+
 /**
  * Wrapper function for launching agent functions
  * Initialises FLAMEGPU_API instance
+ * @param error_buffer If provided, this buffer is used for reporting device exceptions.
  * @param instance_id_hash CURVE hash of the CUDASimulation's instance id
  * @param agent_func_name_hash CURVE hash of the agent + function's names
  * @param messagename_inp_hash CURVE hash of the input message's name
@@ -97,6 +116,92 @@ __global__ void agent_function_wrapper(
 #endif
     }
 }
+/**
+ * Wrapper function for launching agent functions as part of an ensemble
+ * Initialises FLAMEGPU_API instance
+ * @param error_buffer If provided, this buffer is used for reporting device exceptions.
+ * @param total_instances Total number of instances in this ensemble launch
+ * @param instance_offsets Array of where each instance begins based on global thread index
+ * @param instance_id_hash_array Array of instance id hashes, these should be different for each instance
+ * @param agent_func_name_hash CURVE hash of the agent + function's names
+ * @param messagename_inp_hash CURVE hash of the input message's name
+ * @param messagename_outp_hash CURVE hash of the output message's name
+ * @param agent_output_hash CURVE hash of "_agent_birth" or 0 if agent birth not present
+ * @param in_messagelist_metadata Pointer to the MsgIn metadata struct, it is interpreted by MsgIn
+ * @param out_messagelist_metadata Pointer to the MsgOut metadata struct, it is interpreted by MsgOut
+ * @param d_rng Array of curand states for this kernel
+ * @param scanFlag_agentDeath Scanflag array for agent death
+ * @param scanFlag_messageOutput Scanflag array for optional message output
+ * @param scanFlag_agentOutput Scanflag array for optional agent output
+ * @tparam AgentFunction The modeller defined agent function (defined as FLAMEGPU_AGENT_FUNCTION in model code)
+ * @tparam MsgIn Message handler for input messages (e.g. MsgNone, MsgBruteForce, MsgSpatial3D)
+ * @tparam MsgOut Message handler for output messages (e.g. MsgNone, MsgBruteForce, MsgSpatial3D)
+ */
+template<typename AgentFunction, typename MsgIn, typename MsgOut>
+__global__ void agent_function_ensemble_wrapper(
+#ifndef NO_SEATBELTS
+    DeviceExceptionBuffer *error_buffer,
+#endif
+    unsigned int total_instances,
+    unsigned int *instance_offsets,
+    Curve::NamespaceHash *instance_id_hash_array,
+    Curve::NamespaceHash agent_func_name_hash,
+    Curve::NamespaceHash messagename_inp_hash,
+    Curve::NamespaceHash messagename_outp_hash,
+    Curve::NamespaceHash agent_output_hash,
+    const void *in_messagelist_metadata,
+    const void *out_messagelist_metadata,
+    curandState *d_rng,
+    unsigned int *scanFlag_agentDeath,
+    unsigned int *scanFlag_messageOutput,
+    unsigned int *scanFlag_agentOutput) {
+#ifndef NO_SEATBELTS
+    // We place this at the start of shared memory, so we can locate it anywhere in device code without a reference
+    extern __shared__ DeviceExceptionBuffer *buff[];
+    buff[0] = error_buffer;
+#endif
+    // Must be terminated here, else AgentRandom has bounds issues inside FLAMEGPU_DEVICE_API constructor
+    if (FLAMEGPU_DEVICE_API<MsgIn, MsgOut>::TID() >= instance_offsets[total_instances])
+        return;
+    // Perform a search to extract correct instance_id_hash
+    // Note this cannot handle active instances with 0 length    
+    Curve::NamespaceHash instance_id_hash;
+    {
+        unsigned int min = 0;
+        unsigned int max = total_instances;
 
+        while (min + 1 != max) {
+            unsigned int tid = FLAMEGPU_DEVICE_API<MsgIn, MsgOut>::TID();
+            const unsigned int val = min + ((max-min)/2);
+            const unsigned int test = instance_offsets[val];
+            if (tid < test) {
+                max = val;
+            } else if (tid >= test) {
+                min = val;
+            }
+        }
+        instance_id_hash = instance_id_hash_array[min];
+    }
+    // create a new device FLAME_GPU instance
+    FLAMEGPU_DEVICE_API<MsgIn, MsgOut> api = FLAMEGPU_DEVICE_API<MsgIn, MsgOut>(
+        instance_id_hash,
+        agent_func_name_hash,
+        agent_output_hash,
+        d_rng,
+        scanFlag_agentOutput,
+        MsgIn::In(agent_func_name_hash, messagename_inp_hash, in_messagelist_metadata),
+        MsgOut::Out(agent_func_name_hash, messagename_outp_hash, out_messagelist_metadata, scanFlag_messageOutput));
+
+    // call the user specified device function
+    FLAME_GPU_AGENT_STATUS flag = AgentFunction()(&api);
+    if (scanFlag_agentDeath) {
+        // (scan flags will not be processed unless agent death has been requested in model definition)
+        scanFlag_agentDeath[FLAMEGPU_DEVICE_API<MsgIn, MsgOut>::TID()] = flag;
+#ifndef NO_SEATBELTS
+    } else if (flag == DEAD) {
+        DTHROW("Agent death must be enabled per agent function when defining the model.\n");
+#endif
+    }
+}
 
 #endif  // INCLUDE_FLAMEGPU_RUNTIME_AGENTFUNCTION_H_

--- a/include/flamegpu/runtime/AgentFunctionCondition.h
+++ b/include/flamegpu/runtime/AgentFunctionCondition.h
@@ -19,9 +19,21 @@ typedef void(AgentFunctionConditionWrapper)(
     curandState *d_rng,
     unsigned int *scanFlag_conditionResult);  // Can't put __global__ in a typedef
 
+typedef void(AgentFunctionConditionEnsembleWrapper)(
+#ifndef NO_SEATBELTS
+    DeviceExceptionBuffer *error_buffer,
+#endif
+    unsigned int total_instances,
+    unsigned int *instance_offsets,
+    Curve::NamespaceHash *instance_id_hash,
+    Curve::NamespaceHash agent_func_name_hash,
+    curandState *d_rng,
+    unsigned int *scanFlag_conditionResult);  // Can't put __global__ in a typedef
+
 /**
- * Wrapper function for launching agent functions
+ * Wrapper function for launching agent function conditions
  * Initialises FLAMEGPU_API instance
+ * @param error_buffer If provided, this buffer is used for reporting device exceptions.
  * @param instance_id_hash CURVE hash of the CUDASimulation's instance id
  * @param agent_func_name_hash CURVE hash of the agent + function's names
  * @param popNo Total number of agents exeucting the function (number of threads launched)
@@ -62,6 +74,70 @@ __global__ void agent_function_condition_wrapper(
         scanFlag_conditionResult[FLAMEGPU_READ_ONLY_DEVICE_API::TID()] = conditionResult;
     }
 }
+/**
+ * Wrapper function for launching agent function conditions as part of an ensemble
+ * Initialises FLAMEGPU_API instance
+ * @param error_buffer If provided, this buffer is used for reporting device exceptions.
+ * @param total_instances Total number of instances in this ensemble launch
+ * @param instance_offsets Array of where each instance begins based on global thread index
+ * @param instance_id_hash_array Array of instance id hashes, these should be different for each instance
+ * @param agent_func_name_hash CURVE hash of the agent + function's names
+ * @param d_rng Array of curand states for this kernel
+ * @param scanFlag_conditionResult Scanflag array for condition result (this uses same buffer as agent death)
+ * @tparam AgentFunctionCondition The modeller defined agent function condition (defined as FLAMEGPU_AGENT_FUNCTION_CONDITION in model code)
+ * @note This is basically a cutdown version of agent_function_wrapper
+ */
+template<typename AgentFunctionCondition>
+__global__ void agent_function_condition_ensemble_wrapper(
+#ifndef NO_SEATBELTS
+    DeviceExceptionBuffer *error_buffer,
+#endif
+    unsigned int total_instances,
+    unsigned int *instance_offsets,
+    Curve::NamespaceHash *instance_id_hash_array,
+    Curve::NamespaceHash agent_func_name_hash,
+    curandState *d_rng,
+    unsigned int *scanFlag_conditionResult) {
+#ifndef NO_SEATBELTS
+    // We place this at the start of shared memory, so we can locate it anywhere in device code without a reference
+    extern __shared__ DeviceExceptionBuffer *shared_mem[];
+    shared_mem[0] = error_buffer;
+#endif
+    // Must be terminated here, else AgentRandom has bounds issues inside FLAMEGPU_DEVICE_API constructor
+    if (FLAMEGPU_READ_ONLY_DEVICE_API::TID() >= instance_offsets[total_instances])
+        return;
+    // Perform a search to extract correct instance_id_hash
+    // Note this cannot handle active instances with 0 length    
+    Curve::NamespaceHash instance_id_hash;
+    {
+        unsigned int min = 0;
+        unsigned int max = total_instances;
 
+        while (min + 1 != max) {
+            unsigned int tid = FLAMEGPU_READ_ONLY_DEVICE_API::TID();
+            const unsigned int val = min + ((max-min)/2);
+            const unsigned int test = instance_offsets[val];
+            if (tid < test) {
+                max = val;
+            } else if (tid >= test) {
+                min = val;
+            }
+        }
+        instance_id_hash = instance_id_hash_array[min];
+    }
+    // create a new device FLAME_GPU instance
+    FLAMEGPU_READ_ONLY_DEVICE_API api = FLAMEGPU_READ_ONLY_DEVICE_API(
+        instance_id_hash,
+        agent_func_name_hash,
+        d_rng);
+
+    // call the user specified device function
+    {
+        // Negate the return value, we want false at the start of the scattered array
+        bool conditionResult = !(AgentFunctionCondition()(&api));
+        // (scan flags will be processed to filter agents
+        scanFlag_conditionResult[FLAMEGPU_READ_ONLY_DEVICE_API::TID()] = conditionResult;
+    }
+}
 
 #endif  // INCLUDE_FLAMEGPU_RUNTIME_AGENTFUNCTIONCONDITION_H_

--- a/include/flamegpu/runtime/cuRVE/curve.h
+++ b/include/flamegpu/runtime/cuRVE/curve.h
@@ -361,6 +361,7 @@ class Curve {
      * Has access to call purge
      */
     friend class CUDASimulation;
+    friend class CUDAEnsemble;
     /**
      * Wipes out host mirrors of device memory
      * Only really to be used after calls to cudaDeviceReset()

--- a/include/flamegpu/runtime/flamegpu_device_api.h
+++ b/include/flamegpu/runtime/flamegpu_device_api.h
@@ -40,6 +40,17 @@ class FLAMEGPU_READ_ONLY_DEVICE_API {
         const unsigned int,
         curandState *,
         unsigned int *);
+    template<typename AgentFunctionCondition>
+    friend __global__ void agent_function_condition_ensemble_wrapper(
+#ifndef NO_SEATBELTS
+        DeviceExceptionBuffer *error_buffer,
+#endif
+        unsigned int total_instances,
+        unsigned int *instance_offsets,
+        Curve::NamespaceHash *instance_id_hash_array,
+        Curve::NamespaceHash agent_func_name_hash,
+        curandState *d_rng,
+        unsigned int *scanFlag_conditionResult);
 
  public:
     /**

--- a/include/flamegpu/runtime/flamegpu_host_api.h
+++ b/include/flamegpu/runtime/flamegpu_host_api.h
@@ -40,7 +40,7 @@ class FLAMEGPU_HOST_API {
      * Initailises pointers to 0
      * Stores reference of CUDASimulation
      */
-     explicit FLAMEGPU_HOST_API(CUDASimulation&_agentModel,
+     explicit FLAMEGPU_HOST_API(SimInterface &_agentModel,
         RandomManager &rng,
          const AgentOffsetMap &agentOffsets,
          AgentDataMap &agentData);
@@ -112,7 +112,7 @@ class FLAMEGPU_HOST_API {
     void resizeTempStorage(const CUB_Config &cc, const unsigned int &items, const size_t &newSize);
     template<typename T>
     void resizeOutputSpace(const unsigned int &items = 1);
-    CUDASimulation &agentModel;
+    SimInterface &agentModel;
     void *d_cub_temp;
     size_t d_cub_temp_size;
     void *d_output_space;

--- a/include/flamegpu/runtime/flamegpu_host_new_agent_api.h
+++ b/include/flamegpu/runtime/flamegpu_host_new_agent_api.h
@@ -274,6 +274,7 @@ struct NewAgentStorage {
      * Used by CUDASimulation::processHostAgentCreation() which needs raw access to the data buffer
      */
     friend class CUDASimulation;
+    friend class CUDAEnsemble;
  private:
     char *const data;
     const VarOffsetStruct &offsets;

--- a/include/flamegpu/runtime/utility/EnvironmentManager.cuh
+++ b/include/flamegpu/runtime/utility/EnvironmentManager.cuh
@@ -43,6 +43,7 @@ class EnvironmentManager {
      * Uses instance to initialise a models environment properties on the device
      */
     friend class CUDASimulation;
+    friend class CUDAEnsemble;
     /**
      * Uses instance to access env properties in host functions
      */

--- a/include/flamegpu/sim/Simulation.h
+++ b/include/flamegpu/sim/Simulation.h
@@ -11,8 +11,18 @@ class FLAMEGPU_HOST_API;
 class ModelDescription;
 class AgentPopulation;
 struct ModelData;
-
-class Simulation {
+/**
+ * This class holds a minimal interface for a simulation for use internally.
+ * This allows items such as FLAMEGPU_HOST_API to be passed either a CUDASimulation or a CUDAEnsembleInstance
+ */
+struct SimInterface {
+    virtual ~SimInterface() = default;
+    virtual const ModelData& getModelDescription() const = 0;
+    virtual AgentInterface &getAgent(const std::string &name) = 0;
+    virtual unsigned int getInstanceID() const = 0;
+    virtual unsigned int getStepCounter() = 0;
+};
+class Simulation : public SimInterface {
  public:
     struct Config {
         Config() : random_seed(static_cast<unsigned int>(time(nullptr))) {

--- a/include/flamegpu/sim/Simulation.h
+++ b/include/flamegpu/sim/Simulation.h
@@ -20,7 +20,10 @@ struct SimInterface {
     virtual const ModelData& getModelDescription() const = 0;
     virtual AgentInterface &getAgent(const std::string &name) = 0;
     virtual unsigned int getInstanceID() const = 0;
-    virtual unsigned int getStepCounter() = 0;
+    //These step counter methods could be implemented here and made final?
+    virtual unsigned int getStepCounter() const = 0;
+    virtual void incrementStepCounter() = 0;
+    virtual void resetStepCounter() = 0;
 };
 class Simulation : public SimInterface {
  public:
@@ -74,8 +77,6 @@ class Simulation : public SimInterface {
      * @note If random was manually seeded, it will return to it's original state. If random was seeded from time, it will return to a new random state.
      */
     void reset();
-    virtual unsigned int getStepCounter() = 0;
-    virtual void resetStepCounter() = 0;
 
     const ModelData& getModelDescription() const;
     /**

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,6 +99,7 @@ SET(SRC_INCLUDE
     ${FLAMEGPU_ROOT}/include/flamegpu/gpu/CUDAErrorChecking.h
     ${FLAMEGPU_ROOT}/include/flamegpu/gpu/CUDAMessageList.h
     ${FLAMEGPU_ROOT}/include/flamegpu/gpu/CUDASimulation.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/gpu/CUDAEnsemble.h
     ${FLAMEGPU_ROOT}/include/flamegpu/gpu/CUDAMessage.h
     ${FLAMEGPU_ROOT}/include/flamegpu/gpu/CUDAAgent.h
     ${FLAMEGPU_ROOT}/include/flamegpu/gpu/CUDAAgentStateList.h
@@ -185,8 +186,9 @@ SET(SRC_FLAMEGPU2
     ${FLAMEGPU_ROOT}/src/flamegpu/gpu/CUDAFatAgentStateList.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/gpu/CUDAMessage.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/gpu/CUDAScatter.cu
-    ${FLAMEGPU_ROOT}/src/flamegpu/sim/Simulation.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/gpu/CUDASimulation.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/gpu/CUDAEnsemble.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/sim/Simulation.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/cuRVE/curve.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/cuRVE/curve_rtc.cpp
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/flamegpu_host_api.cu

--- a/src/flamegpu/gpu/CUDAAgent.cu
+++ b/src/flamegpu/gpu/CUDAAgent.cu
@@ -304,11 +304,6 @@ void CUDAAgent::mapNewRuntimeVariables(const CUDAAgent& func_agent, const AgentF
                 "in CUDAAgent::mapNewRuntimeVariables()",
                 agent_description.name.c_str(), func.agent_output_state.c_str());
         }
-        // Notify scan flag that it might need resizing
-        // We need a 3rd array, because a function might combine agent birth, agent death and message output
-        scatter.Scan().resize(maxLen, CUDAScanCompaction::AGENT_OUTPUT, streamId);
-        // Ensure the scan flag is zeroed
-        scatter.Scan().zero(CUDAScanCompaction::AGENT_OUTPUT, streamId);
 
         // Request a buffer for new
         char *d_new_buffer = static_cast<char*>(fat_agent->allocNewBuffer(TOTAL_AGENT_VARIABLE_SIZE, maxLen, agent_description.variables.size()));

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -1,0 +1,1479 @@
+#include "flamegpu/gpu/CUDAEnsemble.h"
+
+#include <curand_kernel.h>
+
+#include <algorithm>
+#include <string>
+
+#include "flamegpu/model/AgentFunctionData.h"
+#include "flamegpu/model/LayerData.h"
+#include "flamegpu/model/AgentDescription.h"
+#include "flamegpu/model/SubModelData.h"
+#include "flamegpu/model/SubAgentData.h"
+#include "flamegpu/pop/AgentPopulation.h"
+#include "flamegpu/runtime/flamegpu_host_api.h"
+#include "flamegpu/gpu/CUDAScanCompaction.h"
+#include "flamegpu/util/nvtx.h"
+#include "flamegpu/util/compute_capability.cuh"
+#include "flamegpu/util/SignalHandlers.h"
+#include "flamegpu/runtime/cuRVE/curve_rtc.h"
+#include "flamegpu/runtime/HostFunctionCallback.h"
+#include "flamegpu/exception/FGPUException.h"
+
+
+std::atomic<int> CUDAEnsemble::active_instances;  // This value should default init to 0, specifying =0 was causing warnings on Windows.
+bool CUDAEnsemble::AUTO_CUDA_DEVICE_RESET = true;
+
+CUDAEnsemble::CUDAEnsemble(const ModelDescription& _model, int argc, const char** argv)
+    : step_count(0)
+    , ensemble_elapsed_time(0.f)
+    , model(_model.model->clone())
+    , streams(std::vector<cudaStream_t>())
+    , singletons(nullptr)
+    , singletonsInitialised(false)
+    , rtcInitialised(false)
+    , rtc_kernel_cache(nullptr) {
+    ++active_instances;
+    initOffsetsAndMap();
+
+    // Register the signal handler.
+    SignalHandlers::registerSignalHandlers();
+
+    // We don't actually allocate any CUDA at this point
+    // It's not yet clear how many instances will be required
+
+    // Populate the environment properties
+    // env doesnt work with ensemble yet
+    //initEnvironmentMgr();
+
+    // populate the CUDA submodel map
+    const auto &smm = model->submodels;
+    // create new cuda message and add to the map
+    for (auto it_sm = smm.cbegin(); it_sm != smm.cend(); ++it_sm) {
+        submodel_map.emplace(it_sm->first, std::unique_ptr<CUDAEnsemble>(new CUDAEnsemble(it_sm->second, this)));
+    }
+
+    if (argc && argv) {
+        initialise(argc, argv);
+    }
+}
+CUDAEnsemble::CUDAEnsemble(const std::shared_ptr<SubModelData> &submodel_desc, CUDAEnsemble *master_model)
+    : step_count(0)
+    , model(submodel_desc->submodel)
+    , submodel(submodel_desc)
+    , mastermodel(master_model)
+    , streams(std::vector<cudaStream_t>())
+    , singletons(nullptr)
+    , singletonsInitialised(false)
+    , rtcInitialised(false)
+    , rtc_kernel_cache(nullptr)  {
+    ++active_instances;
+    initOffsetsAndMap();
+    
+    // We don't actually allocate any CUDA at this point
+    // It's not yet clear how many instances will be required
+
+    // Populate the environment properties
+    // env doesnt work with ensemble yet
+    //initEnvironmentMgr();
+
+    // populate the CUDA submodel map
+    const auto &smm = model->submodels;
+    // create new cuda model and add to the map
+    for (auto it_sm = smm.cbegin(); it_sm != smm.cend(); ++it_sm) {
+        submodel_map.emplace(it_sm->first, std::unique_ptr<CUDAEnsemble>(new CUDAEnsemble(it_sm->second, this)));
+    }
+    // Submodels all run silent by default
+    ensemble_config.verbose = false;
+}
+
+CUDAEnsemble::~CUDAEnsemble() {
+    submodel_map.clear();  // Test
+    // De-initialise, freeing singletons?
+    // @todo - this is unsafe in a destructor as it may invoke cuda commands.
+    if (singletonsInitialised) {
+        // unique pointers cleanup by automatically
+        // Drop all constants from the constant cache linked to this model
+        //singletons->environment.free(instance_id);
+
+        delete singletons;
+        singletons = nullptr;
+    }
+
+    // We must explicitly delete all cuda members before we cuda device reset
+    submodel_map.clear();
+    instance_vector.clear();
+    delete rtc_kernel_cache;
+    rtc_kernel_cache = nullptr;
+
+    // If we are the last instance to destruct
+    if ((!--active_instances)&& AUTO_CUDA_DEVICE_RESET) {
+        gpuErrchk(cudaDeviceReset());
+        //EnvironmentManager::getInstance().purge();
+        Curve::getInstance().purge();
+    }
+}
+
+bool CUDAEnsemble::step() {
+    NVTX_RANGE(std::string("CUDAEnsemble::step " + std::to_string(step_count)).c_str());
+
+    // Ensure singletons have been initialised
+    initialiseSingletons();
+    // Update environment on device
+    //singletons->environment.updateDevice(getInstanceID());
+
+    // If verbose, print the step number.
+    if (ensemble_config.verbose) {
+        fprintf(stdout, "Processing Simulation Step %u\n", step_count);
+    }
+
+    unsigned int nStreams = 1;
+    std::string message_name;
+    Curve::NamespaceHash message_name_inp_hash = 0;
+    Curve::NamespaceHash message_name_outp_hash = 0;
+
+    // TODO: simulation.getMaxFunctionsPerLayer()
+    for (auto lyr = model->layers.begin(); lyr != model->layers.end(); ++lyr) {
+        unsigned int temp = static_cast<unsigned int>((*lyr)->agent_functions.size());
+        nStreams = std::max(nStreams, temp);
+    }
+
+    /*!  Stream creations */
+    // Ensure there are enough streams to execute the layer.
+    while (streams.size() < nStreams) {
+        cudaStream_t stream;
+        gpuErrchk(cudaStreamCreate(&stream));
+        streams.push_back(stream);
+    }
+    while (instance_offset_vector.size() < nStreams) {
+        instance_offset_vector.push_back(InstanceOffsetData(ensemble_config.max_concurrent_runs));
+    }
+
+    // Reset message list flags
+    for (auto &instance:instance_vector) {
+        for (auto m =  instance.message_map.begin(); m != instance.message_map.end(); ++m) {
+            m->second->setTruncateMessageListFlag();
+        }
+    }
+
+    /*! for each each sim layer, launch each agent function in its own stream */
+    unsigned int lyr_idx = 0;
+    for (auto lyr = model->layers.begin(); lyr != model->layers.end(); ++lyr) {
+        NVTX_RANGE(std::string("StepLayer " + std::to_string(lyr_idx)).c_str());
+
+        if ((*lyr)->sub_model) {
+            auto &sm = submodel_map.at((*lyr)->sub_model->name);
+            sm->resetStepCounter();
+            sm->simulate();
+            sm->reset(true);
+            // Next layer, this layer cannot also contain agent functions
+            continue;
+        }
+
+        const auto& functions = (*lyr)->agent_functions;
+
+        // Track stream id
+        int j = 0;
+        // Sum the total number of threads being launched in the layer
+        unsigned int totalThreads = 0;        
+        std::vector<unsigned int> instance_offsets;
+        std::vector<Curve::NamespaceHash> instance_id_hashes;
+        /*! for each function apply any agent function conditions*/
+        {
+            // Map agent memory
+            for (const std::shared_ptr<AgentFunctionData> &func_des : functions) {
+                if ((func_des->condition) || (!func_des->rtc_func_condition_name.empty())) {
+                    auto func_agent = func_des->parent.lock();
+                    NVTX_RANGE(std::string("condition map " + func_agent->name + "::" + func_des->name).c_str());
+                    
+                    unsigned int flag_array_len = 0;
+                    for (auto &instance:instance_vector) {
+                        const CUDAAgent& cuda_agent = instance.getCUDAAgent(func_agent->name);
+
+                        const unsigned int state_list_size = cuda_agent.getStateSize(func_des->initial_state);
+                        if (state_list_size == 0) {
+                            continue;
+                        }
+
+                        // Configure runtime access of the functions variables within the FLAME_API object
+                        cuda_agent.mapRuntimeVariables(*func_des);
+
+                        // Store data ready for kernel launch
+                        instance_offsets.push_back(state_list_size);
+                        instance_id_hashes.push_back(Curve::variableRuntimeHash(instance.getInstanceID()));
+
+                        flag_array_len += state_list_size;
+                        totalThreads += state_list_size;
+                    }
+
+                    // Resize & zero the scan flag that will be written to
+                    singletons->scatter.Scan().resize(flag_array_len, CUDAScanCompaction::AGENT_DEATH, j);
+                    singletons->scatter.Scan().zero(CUDAScanCompaction::AGENT_DEATH, j);
+                    ++j;
+                }
+            }
+
+            // Update curve
+            singletons->curve.updateDevice();
+            // Ensure RandomManager is the correct size to accommodate all threads to be launched
+            curandState *d_rng = singletons->rng.resize(totalThreads);
+            // Track stream id
+            j = 0;
+            // Sum the total number of threads being launched in the layer
+            totalThreads = 0;
+            // Launch function condition kernels
+            for (const std::shared_ptr<AgentFunctionData> &func_des : functions) {
+                if ((func_des->condition) || (!func_des->rtc_func_condition_name.empty())) {
+                    auto func_agent = func_des->parent.lock();
+                    NVTX_RANGE(std::string("condition " + func_agent->name + "::" + func_des->name).c_str());
+                    if (!func_agent) {
+                        THROW InvalidAgentFunc("Agent function condition refers to expired agent.");
+                    }
+                    std::string agent_name = func_agent->name;
+                    std::string func_name = func_des->name;
+
+
+                    unsigned int state_list_size = 0;
+                    
+                    for (auto &instance:instance_vector) {
+                        const CUDAAgent& cuda_agent = instance.getCUDAAgent(agent_name);
+                        state_list_size += cuda_agent.getStateSize(func_des->initial_state);
+                    }
+
+                    if (state_list_size == 0) {
+                        ++j;
+                        continue;
+                    }
+
+                    int blockSize = 0;  // The launch configurator returned block size
+                    int minGridSize = 0;  // The minimum grid size needed to achieve the // maximum occupancy for a full device // launch
+                    int gridSize = 0;  // The actual grid size needed, based on input size
+
+                    //  Agent function condition kernel wrapper args
+                    Curve::NamespaceHash agentname_hash = Curve::variableRuntimeHash(agent_name.c_str());
+                    Curve::NamespaceHash funcname_hash = Curve::variableRuntimeHash(func_name.c_str());
+                    Curve::NamespaceHash agent_func_name_hash = agentname_hash + funcname_hash;
+                    curandState *t_rng = d_rng + totalThreads;
+                    unsigned int *scanFlag_agentDeath = this->singletons->scatter.Scan().Config(CUDAScanCompaction::Type::AGENT_DEATH, j).d_ptrs.scan_flag;
+                    unsigned int sm_size = 0;
+                    unsigned int total_launching_instances = instance_id_hashes.size();
+#ifndef NO_SEATBELTS
+                    auto *error_buffer = this->singletons->exception.getDevicePtr(j);
+                    sm_size = sizeof(error_buffer);
+#endif
+                    // Fill the params to send to kernel
+                    {
+                        instance_offsets.push_back(state_list_size);
+                        gpuErrchk(cudaMemcpy(instance_offset_vector[j].d_instance_offsets, instance_offsets.data(), sizeof(unsigned int) * instance_offsets.size(), cudaMemcpyHostToDevice));
+                        gpuErrchk(cudaMemcpy(instance_offset_vector[j].d_instance_id_hashes, instance_id_hashes.data(), sizeof(Curve::NamespaceHash) * instance_id_hashes.size(), cudaMemcpyHostToDevice));
+                    }
+                    // switch between normal and RTC agent function condition
+                    if (func_des->ensemble_condition) {
+                        // calculate the grid block size for agent function condition
+                        cudaOccupancyMaxPotentialBlockSize(&minGridSize, &blockSize, func_des->ensemble_condition, 0, state_list_size);
+
+                        //! Round up according to CUDAAgent state list size
+                        gridSize = (state_list_size + blockSize - 1) / blockSize;
+                        (func_des->ensemble_condition) << <gridSize, blockSize, sm_size, streams.at(j) >> > (
+#ifndef NO_SEATBELTS
+                        error_buffer,
+#endif
+                        total_launching_instances,
+                        instance_offset_vector[j].d_instance_offsets,
+                        instance_offset_vector[j].d_instance_id_hashes,
+                        agent_func_name_hash,
+                        t_rng,
+                        scanFlag_agentDeath);
+                        gpuErrchkLaunch();
+                    } else {  // RTC function
+                        std::string func_condition_identifier = func_name + "_condition";
+                        // get instantiation
+                        const jitify::KernelInstantiation& instance = instance_vector[0].getCUDAAgent(agent_name).getRTCInstantiation(func_condition_identifier);
+                        // calculate the grid block size for main agent function
+                        CUfunction cu_func = (CUfunction)instance;
+                        cuOccupancyMaxPotentialBlockSize(&minGridSize, &blockSize, cu_func, 0, 0, state_list_size);
+                        //! Round up according to CUDAAgent state list size
+                        gridSize = (state_list_size + blockSize - 1) / blockSize;
+                        // launch the kernel
+                        CUresult a = instance.configure(gridSize, blockSize, sm_size, streams.at(j)).launch({
+#ifndef NO_SEATBELTS
+                                reinterpret_cast<void*>(&error_buffer),
+#endif
+                                reinterpret_cast<void*>(&total_launching_instances),
+                                const_cast<void*>(reinterpret_cast<const void*>(&instance_offset_vector[j].d_instance_offsets)),
+                                const_cast<void*>(reinterpret_cast<const void*>(&instance_offset_vector[j].d_instance_id_hashes)),
+                                reinterpret_cast<void*>(&agent_func_name_hash),
+                                reinterpret_cast<void*>(&t_rng),
+                                reinterpret_cast<void*>(&scanFlag_agentDeath) });
+                        if (a != CUresult::CUDA_SUCCESS) {
+                            const char* err_str = nullptr;
+                            cuGetErrorString(a, &err_str);
+                            THROW InvalidAgentFunc("There was a problem launching the runtime agent function condition '%s': %s", func_des->rtc_func_condition_name.c_str(), err_str);
+                        }
+                        cudaDeviceSynchronize();
+                        gpuErrchkLaunch();
+                    }
+
+                    totalThreads += state_list_size;
+                    ++j;
+                }
+            }
+
+            // Track stream id
+            j = 0;
+            // Unmap agent memory, apply condition
+            for (const std::shared_ptr<AgentFunctionData> &func_des : functions) {
+                if ((func_des->condition) || (!func_des->rtc_func_condition_name.empty())) {
+                    auto func_agent = func_des->parent.lock();
+                    if (!func_agent) {
+                        THROW InvalidAgentFunc("Agent function condition refers to expired agent.");
+                    }
+                    NVTX_RANGE(std::string("condition unmap " + func_agent->name + "::" + func_des->name).c_str());
+
+                    unsigned int flag_array_offset = 0;
+                    for (auto &instance:instance_vector) {
+                        CUDAAgent& cuda_agent = instance.getCUDAAgent(func_agent->name);
+
+                        const unsigned int state_list_size = cuda_agent.getStateSize(func_des->initial_state);
+                        if (state_list_size == 0) {
+                            continue;
+                        }
+
+                        // unmap the function variables
+                        cuda_agent.unmapRuntimeVariables(*func_des);
+
+#ifndef NO_SEATBELTS
+                        // Error check after unmap vars
+                        // This means that curve is cleaned up before we throw exception (mostly prevents curve being polluted if we catch and handle errors)
+                        this->singletons->exception.checkError("condition " + func_des->name, j);//This needs flag_array_offset passed in
+#endif
+
+                        // Process agent function condition
+                        cuda_agent.processFunctionCondition(*func_des, this->singletons->scatter, j);//This needs flag_array_offset passed in
+                        flag_array_offset += state_list_size;
+                    }
+                    ++j;
+                }
+            }
+        }
+
+        j = 0;
+        instance_offsets.clear();
+        instance_id_hashes.clear();
+        // Sum the total number of threads being launched in the layer
+        totalThreads = 0;
+        /*! for each func function - Loop through to do all mapping of agent and message variables */
+        for (const std::shared_ptr<AgentFunctionData> &func_des : functions) {
+            auto func_agent = func_des->parent.lock();
+            if (!func_agent) {
+                THROW InvalidAgentFunc("Agent function refers to expired agent.");
+            }
+            NVTX_RANGE(std::string("map" + func_agent->name + "::" + func_des->name).c_str());
+            unsigned int scan_flag_len = 0;
+            for (auto &instance:instance_vector) {
+                const CUDAAgent& cuda_agent = instance.getCUDAAgent(func_agent->name);
+                const unsigned int state_list_size = cuda_agent.getStateSize(func_des->initial_state);
+                if (state_list_size == 0) {
+                    continue;
+                }
+
+                // check if a function has an input message
+                if (auto im = func_des->message_input.lock()) {
+                    std::string inpMessage_name = im->name;
+                    CUDAMessage& cuda_message = instance.getCUDAMessage(inpMessage_name);
+                    // Construct PBM here if required!!
+                    cuda_message.buildIndex(this->singletons->scatter, j);
+                    // Map variables after, as index building can swap arrays
+                    cuda_message.mapReadRuntimeVariables(*func_des, cuda_agent);
+                }
+
+                // check if a function has an output message
+                if (auto om = func_des->message_output.lock()) {
+                    std::string outpMessage_name = om->name;
+                    CUDAMessage& cuda_message = instance.getCUDAMessage(outpMessage_name);
+                    // Resize message list if required
+                    const unsigned int existingMessages = cuda_message.getTruncateMessageListFlag() ? 0 : cuda_message.getMessageCount();
+                    cuda_message.resize(existingMessages + state_list_size, this->singletons->scatter, j);
+                    cuda_message.mapWriteRuntimeVariables(*func_des, cuda_agent, state_list_size);
+                    singletons->scatter.Scan().resize(state_list_size, CUDAScanCompaction::MESSAGE_OUTPUT, j);
+                    // Zero the scan flag that will be written to
+                    if (func_des->message_output_optional)
+                        singletons->scatter.Scan().zero(CUDAScanCompaction::MESSAGE_OUTPUT, j);
+                }
+
+                // check if a function has an output agent
+                if (auto oa = func_des->agent_output.lock()) {
+                    // This will act as a reserve word
+                    // which is added to variable hashes for agent creation on device
+                    CUDAAgent& output_agent = instance.getCUDAAgent(oa->name);
+
+                    // Map vars with curve (this allocates/requests enough new buffer space if an existing version is not available/suitable)
+                    output_agent.mapNewRuntimeVariables(cuda_agent, *func_des, state_list_size, this->singletons->scatter, j);//This needs something doing, to ensure scan array is sized for all instances properly
+                }
+
+
+                /**
+                 * Configure runtime access of the functions variables within the FLAME_API object
+                 */
+                cuda_agent.mapRuntimeVariables(*func_des);
+                
+                // Store data ready for kernel launch
+                instance_offsets.push_back(state_list_size);
+                instance_id_hashes.push_back(Curve::variableRuntimeHash(instance.getInstanceID()));
+
+                // Count total threads being launched
+                totalThreads += state_list_size;
+                scan_flag_len += state_list_size;
+            }
+            // Resize death flag array if necessary
+            singletons->scatter.Scan().resize(scan_flag_len, CUDAScanCompaction::AGENT_DEATH, j);
+            // Zero the scan flag that will be written to
+            if (func_des->has_agent_death) {
+                singletons->scatter.Scan().zero(CUDAScanCompaction::AGENT_DEATH, j);
+            }
+            // Resize message output flag if necessary
+            if (auto om = func_des->message_output.lock()) {
+                singletons->scatter.Scan().resize(scan_flag_len, CUDAScanCompaction::MESSAGE_OUTPUT, j);
+                // Zero the scan flag that will be written to
+                if (func_des->message_output_optional)
+                    singletons->scatter.Scan().zero(CUDAScanCompaction::MESSAGE_OUTPUT, j);
+            }
+            ++j;
+        }
+
+        // Update curve
+        singletons->curve.updateDevice();
+        // Ensure RandomManager is the correct size to accommodate all threads to be launched
+        curandState *d_rng = singletons->rng.resize(totalThreads);
+        // Total threads is now used to provide kernel launches an offset to thread-safe thread-index
+        totalThreads = 0;
+        j = 0;
+        //! for each func function - Loop through to launch all agent functions
+        for (const std::shared_ptr<AgentFunctionData> &func_des : functions) {
+            auto func_agent = func_des->parent.lock();
+            if (!func_agent) {
+                THROW InvalidAgentFunc("Agent function refers to expired agent.");
+            }
+            NVTX_RANGE(std::string(func_agent->name + "::" + func_des->name).c_str());
+#error What strategy will be used to pass all of the instance specific pointers to each kernel launch?
+            const void *d_in_messagelist_metadata = nullptr;
+            const void *d_out_messagelist_metadata = nullptr;
+            std::string agent_name = func_agent->name;
+            std::string func_name = func_des->name;
+            // check if a function has an input message
+            if (auto im = func_des->message_input.lock()) {
+                std::string inpMessage_name = im->name;
+                const CUDAMessage& cuda_message = getCUDAMessage(inpMessage_name);
+
+                // hash message name
+                message_name_inp_hash = Curve::variableRuntimeHash(inpMessage_name.c_str());
+
+                d_in_messagelist_metadata = cuda_message.getMetaDataDevicePtr();
+            }
+
+            // check if a function has an output message
+            if (auto om = func_des->message_output.lock()) {
+                std::string outpMessage_name = om->name;
+                const CUDAMessage& cuda_message = getCUDAMessage(outpMessage_name);
+
+                // hash message name
+                message_name_outp_hash =  Curve::variableRuntimeHash(outpMessage_name.c_str());
+                d_out_messagelist_metadata = cuda_message.getMetaDataDevicePtr();
+            }
+
+            const CUDAAgent& cuda_agent = getCUDAAgent(agent_name);
+
+            const unsigned int state_list_size = cuda_agent.getStateSize(func_des->initial_state);
+            if (state_list_size == 0) {
+                ++j;
+                continue;
+            }
+
+            int blockSize = 0;  // The launch configurator returned block size
+            int minGridSize = 0;  // The minimum grid size needed to achieve the // maximum occupancy for a full device // launch
+            int gridSize = 0;  // The actual grid size needed, based on input size
+
+            // Agent function kernel wrapper args
+            Curve::NamespaceHash agentname_hash = Curve::variableRuntimeHash(agent_name.c_str());
+            Curve::NamespaceHash funcname_hash = Curve::variableRuntimeHash(func_name.c_str());
+            Curve::NamespaceHash agent_func_name_hash = agentname_hash + funcname_hash;
+            Curve::NamespaceHash agentoutput_hash = func_des->agent_output.lock() ? singletons->curve.variableRuntimeHash("_agent_birth") + funcname_hash : 0;
+            curandState * t_rng = d_rng + totalThreads;
+            unsigned int *scanFlag_agentDeath = func_des->has_agent_death ? this->singletons->scatter.Scan().Config(CUDAScanCompaction::Type::AGENT_DEATH, j).d_ptrs.scan_flag : nullptr;
+            unsigned int *scanFlag_messageOutput = this->singletons->scatter.Scan().Config(CUDAScanCompaction::Type::MESSAGE_OUTPUT, j).d_ptrs.scan_flag;
+            unsigned int *scanFlag_agentOutput = this->singletons->scatter.Scan().Config(CUDAScanCompaction::Type::AGENT_OUTPUT, j).d_ptrs.scan_flag;
+            unsigned int sm_size = 0;
+            unsigned int total_launching_instances = instance_id_hashes.size();
+#ifndef NO_SEATBELTS
+            auto *error_buffer = this->singletons->exception.getDevicePtr(j);
+            sm_size = sizeof(error_buffer);
+#endif
+            // Fill the params to send to kernel
+            {
+                instance_offsets.push_back(state_list_size);
+                gpuErrchk(cudaMemcpy(instance_offset_vector[j].d_instance_offsets, instance_offsets.data(), sizeof(unsigned int) * instance_offsets.size(), cudaMemcpyHostToDevice));
+                gpuErrchk(cudaMemcpy(instance_offset_vector[j].d_instance_id_hashes, instance_id_hashes.data(), sizeof(Curve::NamespaceHash) * instance_id_hashes.size(), cudaMemcpyHostToDevice));
+            }
+
+            if (func_des->ensemble_func) {   // compile time specified agent function launch
+                // calculate the grid block size for main agent function
+                cudaOccupancyMaxPotentialBlockSize(&minGridSize, &blockSize, func_des->func, 0, state_list_size);
+                //! Round up according to CUDAAgent state list size
+                gridSize = (state_list_size + blockSize - 1) / blockSize;
+
+                (func_des->ensemble_func) << <gridSize, blockSize, sm_size, streams.at(j) >> > (
+#ifndef NO_SEATBELTS
+                    error_buffer,
+#endif
+                    total_launching_instances,
+                    instance_offset_vector[j].d_instance_offsets,
+                    instance_offset_vector[j].d_instance_id_hashes,
+                    agent_func_name_hash,
+                    message_name_inp_hash,
+                    message_name_outp_hash,
+                    agentoutput_hash,
+                    d_in_messagelist_metadata,
+                    d_out_messagelist_metadata,
+                    t_rng,
+                    scanFlag_agentDeath,
+                    scanFlag_messageOutput,
+                    scanFlag_agentOutput);
+                gpuErrchkLaunch();
+            } else {      // assume this is a runtime specified agent function
+                // get instantiation
+                const jitify::KernelInstantiation&  instance = cuda_agent.getRTCInstantiation(func_name);
+                // calculate the grid block size for main agent function
+                CUfunction cu_func = (CUfunction)instance;
+                cuOccupancyMaxPotentialBlockSize(&minGridSize, &blockSize, cu_func, 0, 0, state_list_size);
+                //! Round up according to CUDAAgent state list size
+                gridSize = (state_list_size + blockSize - 1) / blockSize;
+                // launch the kernel
+                CUresult a = instance.configure(gridSize, blockSize, sm_size, streams.at(j)).launch({
+#ifndef NO_SEATBELTS
+                        reinterpret_cast<void*>(&error_buffer),
+#endif
+                        reinterpret_cast<void*>(&total_launching_instances),
+                        const_cast<void*>(reinterpret_cast<const void*>(&instance_offset_vector[j].d_instance_offsets)),
+                        const_cast<void*>(reinterpret_cast<const void*>(&instance_offset_vector[j].d_instance_id_hashes)),
+                        reinterpret_cast<void*>(&agent_func_name_hash),
+                        reinterpret_cast<void*>(&message_name_inp_hash),
+                        reinterpret_cast<void*>(&message_name_outp_hash),
+                        reinterpret_cast<void*>(&agentoutput_hash),
+                        const_cast<void*>(reinterpret_cast<const void*>(&d_in_messagelist_metadata)),
+                        const_cast<void*>(reinterpret_cast<const void*>(&d_out_messagelist_metadata)),
+                        const_cast<void*>(reinterpret_cast<const void*>(&t_rng)),
+                        reinterpret_cast<void*>(&scanFlag_agentDeath),
+                        reinterpret_cast<void*>(&scanFlag_messageOutput),
+                        reinterpret_cast<void*>(&scanFlag_agentOutput)});
+                if (a != CUresult::CUDA_SUCCESS) {
+                    const char* err_str = nullptr;
+                    cuGetErrorString(a, &err_str);
+                    THROW InvalidAgentFunc("There was a problem launching the runtime agent function '%s': %s", func_name.c_str(), err_str);
+                }
+                cudaDeviceSynchronize();
+                gpuErrchkLaunch();
+            }
+
+            totalThreads += state_list_size;
+            ++j;
+            ++lyr_idx;
+        }
+
+        j = 0;
+        // for each func function - Loop through to un-map all agent and message variables
+        for (const std::shared_ptr<AgentFunctionData> &func_des : functions) {
+            auto func_agent = func_des->parent.lock();
+            if (!func_agent) {
+                THROW InvalidAgentFunc("Agent function refers to expired agent.");
+            }
+            NVTX_RANGE(std::string("unmap" + func_agent->name + "::" + func_des->name).c_str());
+            unsigned int scan_flag_offset = 0;
+            for (auto &instance:instance_vector) {
+                CUDAAgent& cuda_agent = instance.getCUDAAgent(func_agent->name);
+
+                const unsigned int state_list_size = cuda_agent.getStateSize(func_des->initial_state);
+                // If agent function wasn't executed, these are redundant
+                if (state_list_size > 0) {
+                    // check if a function has an input message
+                    if (auto im = func_des->message_input.lock()) {
+                        std::string inpMessage_name = im->name;
+                        const CUDAMessage& cuda_message = instance.getCUDAMessage(inpMessage_name);
+                        cuda_message.unmapRuntimeVariables(*func_des);
+                    }
+
+                    // check if a function has an output message
+                    if (auto om = func_des->message_output.lock()) {
+                        std::string outpMessage_name = om->name;
+                        CUDAMessage& cuda_message = instance.getCUDAMessage(outpMessage_name);
+                        cuda_message.unmapRuntimeVariables(*func_des);
+                        cuda_message.swap(func_des->message_output_optional, state_list_size, this->singletons->scatter, j);//Requires passing scan_flag_offset for optional output?
+                        cuda_message.clearTruncateMessageListFlag();
+                        cuda_message.setPBMConstructionRequiredFlag();
+                    }
+
+                    // Process agent death (has agent death check is handled by the method)
+                    // This MUST occur before agent_output, as if agent_output triggers resize then scan_flag for death will be purged
+                    cuda_agent.processDeath(*func_des, this->singletons->scatter, j);//Requires passing scan_flag_offset
+
+                    // Process agent state transition (Longer term merge this with process death?)
+                    cuda_agent.transitionState(func_des->initial_state, func_des->end_state, this->singletons->scatter, j);
+                }
+
+                // Process agent function condition
+                cuda_agent.clearFunctionCondition(func_des->initial_state);
+
+                // If agent function wasn't executed, these are redundant
+                if (state_list_size > 0) {
+                    // check if a function has an output agent
+                    if (auto oa = func_des->agent_output.lock()) {//This will need some changing to support shared flag arrays, not sure what yet
+                        // This will act as a reserve word
+                        // which is added to variable hashes for agent creation on device
+                        CUDAAgent& output_agent = instance.getCUDAAgent(oa->name);
+                        // Scatter the agent birth
+                        output_agent.scatterNew(*func_des, state_list_size, this->singletons->scatter, j);  // This must be passed the state list size prior to death
+                        // unmap vars with curve
+                        output_agent.unmapNewRuntimeVariables(*func_des);
+                    }
+
+                    // unmap the function variables
+                    cuda_agent.unmapRuntimeVariables(*func_des);
+#ifndef NO_SEATBELTS
+                    // Error check after unmap vars
+                    // This means that curve is cleaned up before we throw exception (mostly prevents curve being polluted if we catch and handle errors)
+                    this->singletons->exception.checkError(func_des->name, j);//Requires passing scan_flag_offset
+#endif
+                }
+            }
+            ++j;
+        }
+
+        NVTX_PUSH("CUDAEnsemble::step::HostFunctions");
+        // Execute all host functions attached to layer
+        // TODO: Concurrency?
+        assert(host_api.size());
+        for (auto &stepFn : (*lyr)->host_functions) {
+            for (auto &instance:instance_vector) {
+                NVTX_RANGE("hostFunc");
+                stepFn(instance.host_api.get());
+            }
+        }
+        // Execute all host function callbacks attached to layer
+        for (auto &stepFn : (*lyr)->host_functions_callbacks) {
+            for (auto &instance:instance_vector) {
+                NVTX_RANGE("hostFunc_swig");
+                stepFn->run(instance.host_api.get());
+            }
+        }
+        // If we have host layer functions, we might have host agent creation
+        if ((*lyr)->host_functions.size() || ((*lyr)->host_functions_callbacks.size()))
+            processHostAgentCreation(j);
+        // Update environment on device
+        //singletons->environment.updateDevice(getInstanceID());
+        NVTX_POP();
+
+        // cudaDeviceSynchronize();
+    }
+
+    NVTX_PUSH("CUDAEnsemble::step::StepFunctions");
+    // Execute step functions
+    for (auto &stepFn : model->stepFunctions) {
+        for (auto &instance:instance_vector) {
+            NVTX_RANGE("stepFunc");
+            stepFn(instance.host_api.get());
+        }
+    }
+    // Execute step function callbacks
+    for (auto &stepFn : model->stepFunctionCallbacks) {
+        for (auto &instance:instance_vector) {
+            NVTX_RANGE("stepFunc_swig");
+            stepFn->run(instance.host_api.get());
+        }
+    }
+    // If we have step functions, we might have host agent creation
+    if (model->stepFunctions.size() || model->stepFunctionCallbacks.size())
+        processHostAgentCreation(0);
+    NVTX_POP();
+
+    // Execute exit conditions
+    for (auto &exitCdns : model->exitConditions)
+        if (exitCdns(this->host_api.get()) == EXIT) {
+
+            // If there were any exit conditions, we also need to update the step count
+            incrementStepCounter();
+            return false;
+        }
+    // Execute exit condition callbacks
+    for (auto &exitCdns : model->exitConditionCallbacks)
+        if (exitCdns->run(this->host_api.get()) == EXIT) {
+
+            // If there were any exit conditions, we also need to update the step count
+            incrementStepCounter();
+            return false;
+        }
+    // If we have exit conditions functions, we might have host agent creation
+    if (model->exitConditions.size() || model->exitConditionCallbacks.size())
+        processHostAgentCreation(0);
+
+
+    // Update step count at the end of the step - when it has completed.
+    incrementStepCounter();
+    return true;
+}
+
+void CUDAEnsemble::simulate() {
+    //if (agent_map.size() == 0) {
+    //    THROW InvalidCudaAgentMapSize("Simulation has no agents, in CUDAEnsemble::simulate().");  // recheck if this is really required
+    //}
+
+    // Ensure singletons have been initialised
+    initialiseSingletons();
+
+    // Ensemble execution state tracking (maybe move this to class level?)
+    assert(ensemble_config.max_concurrent_runs > 2);
+    const unsigned int instances_required = ensemble_config.total_runs;
+    unsigned int instances_completed = 0;
+    unsigned int active_instances = ensemble_config.max_concurrent_runs;
+
+    // Reinitialise any unmapped agent variables
+    if (submodel) {
+        int j = 0;
+        for (auto &i:instance_vector) {
+            for (auto &a : i.agent_map) {
+                a.second->initUnmappedVars(this->singletons->scatter, j++);
+            }
+        }
+    }
+
+    // create cude events to record the elapsed time for simulate.
+    cudaEvent_t ensembleStartEvent = nullptr;
+    cudaEvent_t ensembleEndEvent = nullptr;
+    gpuErrchk(cudaEventCreate(&ensembleStartEvent));
+    gpuErrchk(cudaEventCreate(&ensembleEndEvent));
+    // Record the start event.
+    gpuErrchk(cudaEventRecord(ensembleStartEvent));
+    // Reset the elapsed time.
+    ensemble_elapsed_time = 0.f;
+
+    // CUDAAgentMap::iterator it;
+
+    // check any CUDAAgents with population size == 0
+    // if they have executable functions then these can be ignored
+    // if they have agent creations then buffer space must be allocated for them
+
+    // Execute init functions
+    NVTX_PUSH("CUDAEnsemble::step::InitFunctions");
+    for (auto &initFn : model->initFunctions) {
+        for (auto &instance:instance_vector) {
+            NVTX_RANGE("initFunc");
+            initFn(instance.host_api.get());
+        }
+    }
+    // Execute init function callbacks
+    for (auto &initFn : model->initFunctionCallbacks) {
+        for (auto &instance:instance_vector) {
+            NVTX_RANGE("initFunc_swig");
+            initFn->run(instance.host_api.get());
+        }
+    }
+    // Check if host agent creation was used in init functions
+    if (model->initFunctions.size() || model->initFunctionCallbacks.size())
+        processHostAgentCreation(0);
+    // Update environment on device
+    //singletons->environment.updateDevice(getInstanceID());
+    NVTX_POP();
+
+    if (ensemble_config.steps == 0 && model->exitConditions.size() == 0 && model->exitConditionCallbacks.size() == 0) {
+        THROW EnsembleException("Models executed as ensembles must either be executed with a fixed step count or have atleast 1 exit condition.");
+    }
+
+    for (unsigned int i = 0; ensemble_config.steps == 0 ? true : i < ensemble_config.steps; i++) {
+        // std::cout <<"step: " << i << std::endl;
+        if (!step())
+            break;
+    }
+    
+    NVTX_PUSH("CUDAEnsemble::step::ExitFunctions");
+    // Execute exit functions
+    for (auto &exitFn : model->exitFunctions) {
+        for (auto &instance:instance_vector) {
+            NVTX_RANGE("exitFunc");
+            exitFn(instance.host_api.get());
+        }
+    }
+    for (auto &exitFn : model->exitFunctionCallbacks) {
+        for (auto &instance:instance_vector) {
+            NVTX_RANGE("exitFunc_swig");
+            exitFn->run(instance.host_api.get());
+        }
+    }
+    NVTX_POP();
+
+
+    // Record and store the elapsed time
+    // if --timing was passed, output to stdout.
+    gpuErrchk(cudaEventRecord(ensembleEndEvent));
+    // Syncrhonize the stop event
+    gpuErrchk(cudaEventSynchronize(ensembleEndEvent));
+    gpuErrchk(cudaEventElapsedTime(&ensemble_elapsed_time, ensembleStartEvent, ensembleEndEvent));
+
+    gpuErrchk(cudaEventDestroy(ensembleStartEvent));
+    gpuErrchk(cudaEventDestroy(ensembleEndEvent));
+    ensembleStartEvent = nullptr;
+    ensembleEndEvent = nullptr;
+
+    if (ensemble_config.timing) {
+        // Record the end event.
+        // Resolution is 0.5 microseconds, so print to 1 us.
+        fprintf(stdout, "Total Processing time: %.3f ms\n", ensemble_elapsed_time);
+    }
+
+    // Destroy streams.
+    for (auto stream : streams) {
+        gpuErrchk(cudaStreamDestroy(stream));
+    }
+    streams.clear();
+}
+
+void CUDAEnsemble::reset(bool submodelReset) {
+    // Reset step counter
+    //resetStepCounter();
+
+    if (singletonsInitialised) {
+        //// Reset environment properties
+        //singletons->environment.resetModel(instance_id, *model->environment);
+
+        //// Reseed random, unless performing submodel reset
+        //if (!submodelReset) {
+        //    singletons->rng.reseed(ensemble_config.random_seed);
+        //}
+    }
+
+    // Cull agents
+    if (submodel) {
+        // Submodels only want to reset unmapped states, otherwise they will break parent model
+        for (auto &instance:instance_vector) {
+            for (auto &a : instance.agent_map) {
+                a.second->cullUnmappedStates();
+            }
+        }
+    } else {
+        for (auto &instance:instance_vector) {
+            for (auto &a : instance.agent_map) {
+                a.second->cullAllStates();
+            }
+        }
+    }
+
+    // Cull messagelists
+    for (auto &instance:instance_vector) {
+        for (auto &a : instance.message_map) {
+            a.second->setMessageCount(0);
+            a.second->setTruncateMessageListFlag();
+        }
+    }
+
+
+    // Trigger reset in all submodels, propagation is not necessary when performing submodel reset
+    if (!submodelReset) {
+        for (auto &s : submodel_map) {
+            s.second->reset(false);
+        }
+    }
+}
+
+void CUDAEnsemble::setPopulationData(AgentPopulation& population) {
+    // Ensure singletons have been initialised
+    initialiseSingletons();
+
+    auto it = agent_map.find(population.getAgentName());
+
+    if (it == agent_map.end()) {
+        THROW InvalidCudaAgent("Error: Agent ('%s') was not found, "
+            "in CUDAEnsemble::setPopulationData()",
+            population.getAgentName().c_str());
+    }
+
+    /*! create agent state lists */
+    it->second->setPopulationData(population, this->singletons->scatter, 0);  // Streamid shouldn't matter here
+
+}
+
+void CUDAEnsemble::getPopulationData(AgentPopulation& population) {
+    // Ensure singletons have been initialised
+    initialiseSingletons();
+
+    auto it = agent_map.find(population.getAgentName());
+
+    if (it == agent_map.end()) {
+        THROW InvalidCudaAgent("Error: Agent ('%s') was not found, "
+            "in CUDAEnsemble::getPopulationData()",
+            population.getAgentName().c_str());
+    }
+
+    /*!create agent state lists */
+    it->second->getPopulationData(population);
+}
+
+void CUDAEnsemble::reseed(const unsigned int &seed) {
+    //SimulationConfig().random_seed = seed;
+    //singletons->rng.reseed(seed);
+
+    //// Propagate to submodels
+    //int i = 7;
+    //for (auto &sm : submodel_map) {
+    //    // Pass random seed on to submodels
+    //    sm.second->singletons->rng.reseed(getSimulationConfig().random_seed * i * 23);
+    //    // Mutate seed
+    //    i *= 13;
+    //}
+}
+/**
+ * These values are ony used by CUDAEnsemble::initialiseSingletons()
+ * Can't put a __device__ symbol method static
+ */
+namespace {
+    __device__ unsigned int DEVICE_HAS_RESET = 0xDEADBEEF;
+    const unsigned int DEVICE_HAS_RESET_FLAG = 0xDEADBEEF;
+}  // namespace
+
+void CUDAEnsemble::initialiseSingletons() {
+    // Only do this once.
+    if (!singletonsInitialised) {
+        // If the device has not been specified, also check the compute capability is OK
+        // Check the compute capability of the device, throw an exception if not valid for the executable.
+        if (!util::compute_capability::checkComputeCapability(static_cast<int>(cuda_config.device_id))) {
+            int min_cc = util::compute_capability::minimumCompiledComputeCapability();
+            int cc = util::compute_capability::getComputeCapability(static_cast<int>(cuda_config.device_id));
+            THROW InvalidCUDAComputeCapability("Error application compiled for CUDA Compute Capability %d and above. Device %u is compute capability %d. Rebuild for SM_%d.", min_cc, cuda_config.device_id, cc, cc);
+        }
+        // Check if device has been reset
+        unsigned int DEVICE_HAS_RESET_CHECK = 0;
+        cudaMemcpyFromSymbol(&DEVICE_HAS_RESET_CHECK, DEVICE_HAS_RESET, sizeof(unsigned int));
+        if (DEVICE_HAS_RESET_CHECK == DEVICE_HAS_RESET_FLAG) {
+            // Device has been reset, purge host mirrors of static objects/singletons
+            Curve::getInstance().purge();
+            if (singletons) {
+                singletons->rng.purge();
+                singletons->scatter.purge();
+            }
+            EnvironmentManager::getInstance().purge();
+            // Reset flag
+            DEVICE_HAS_RESET_CHECK = 0;  // Any value that doesnt match DEVICE_HAS_RESET_FLAG
+            cudaMemcpyToSymbol(DEVICE_HAS_RESET, &DEVICE_HAS_RESET_CHECK, sizeof(unsigned int));
+        }
+        // Get references to all required singleton and store in the instance.
+        singletons = new Singletons(
+            Curve::getInstance(),
+            EnvironmentManager::getInstance());
+
+        // Reinitialise random for this simulation instance
+        //singletons->rng.reseed(getSimulationConfig().random_seed);
+
+        for (auto &cm : message_map) {
+            cm.second->init(singletons->scatter, 0);
+        }
+
+        // Propagate singleton init to submodels
+        for (auto &sm : submodel_map) {
+            sm.second->initialiseSingletons();
+        }
+
+        singletonsInitialised = true;
+    }
+
+    // Ensure RTC is set up.
+    initialiseRTC();
+
+    // Update environment on device
+    //singletons->environment.updateDevice(getInstanceID());
+}
+
+void CUDAEnsemble::initialiseRTC() {
+    // Only do this once.
+    if (!rtcInitialised) {
+        // Create jitify cache
+        if (!rtc_kernel_cache) {
+            rtc_kernel_cache = new jitify::JitCache();
+        }
+        // Build any RTC functions
+        const auto& am = model->agents;
+        // iterate agents and then agent functions to find any rtc functions or function conditions
+        for (auto it = am.cbegin(); it != am.cend(); ++it) {
+            auto a_it = agent_map.find(it->first);
+            const auto& mf = it->second->functions;
+            for (auto it_f = mf.cbegin(); it_f != mf.cend(); ++it_f) {
+                // check rtc source to see if this is a RTC function
+                if (!it_f->second->rtc_source.empty()) {
+                    // create CUDA agent RTC function by calling addInstantitateRTCFunction on CUDAAgent with AgentFunctionData
+                    a_it->second->addInstantitateRTCFunction(*rtc_kernel_cache, *it_f->second);
+                }
+                // check rtc source to see if the function condition is an rtc condition
+                if (!it_f->second->rtc_condition_source.empty()) {
+                    // create CUDA agent RTC function condition by calling addInstantitateRTCFunction on CUDAAgent with AgentFunctionData
+                    a_it->second->addInstantitateRTCFunction(*rtc_kernel_cache, *it_f->second, true);
+                }
+            }
+        }
+
+        // Initialise device environment for RTC
+        singletons->environment.initRTC(*this);
+
+        rtcInitialised = true;
+    }
+}
+
+
+
+CUDAEnsemble::CConfig &CUDAEnsemble::CUDAConfig() {
+    return cuda_config;
+}
+const CUDAEnsemble::CConfig &CUDAEnsemble::getCUDAConfig() const {
+    return cuda_config;
+}
+CUDAEnsemble::EConfig &CUDAEnsemble::EnsembleConfig() {
+    return ensemble_config;
+}
+const CUDAEnsemble::EConfig &CUDAEnsemble::getEnsembleConfig() const {
+    return ensemble_config;
+}
+
+void CUDAEnsemble::initOffsetsAndMap() {
+    const auto &md = *model.get();
+    // Build offsets
+    agentOffsets.clear();
+    for (const auto &agent : md.agents) {
+        agentOffsets.emplace(agent.first, VarOffsetStruct(agent.second->variables));
+    }
+}
+
+void CUDAEnsemble::processHostAgentCreation(const unsigned int &streamId) {
+    for (auto &instance:instance_vector) {
+        size_t t_bufflen = 0;
+        char *t_buff = nullptr;
+        char *dt_buff = nullptr;
+        // For each agent type
+        for (auto &agent : instance.agentData) {
+            // We need size of agent
+            const VarOffsetStruct &offsets = agentOffsets.at(agent.first);
+            // For each state within the agent
+            for (auto &state : agent.second) {
+                // If the buffer has data
+                if (state.second.size()) {
+                    size_t size_req = offsets.totalSize * state.second.size();
+                    {  // Ensure we have enough temp memory
+                        if (size_req > t_bufflen) {
+                            if (t_buff) {
+                                free(t_buff);
+                                gpuErrchk(cudaFree(dt_buff));
+                            }
+                            t_buff = reinterpret_cast<char*>(malloc(size_req));
+                            gpuErrchk(cudaMalloc(&dt_buff, size_req));
+                            t_bufflen = size_req;
+                        }
+                    }
+                    // Copy buffer memory into a single block
+                    for (unsigned int i = 0; i < state.second.size(); ++i) {
+                        memcpy(t_buff + (i*offsets.totalSize), state.second[i].data, offsets.totalSize);
+                    }
+                    // Copy t_buff to device
+                    gpuErrchk(cudaMemcpy(dt_buff, t_buff, size_req, cudaMemcpyHostToDevice));
+                    // Scatter to device
+                    auto &cudaagent = instance.agent_map.at(agent.first);
+                    cudaagent->scatterHostCreation(state.first, static_cast<unsigned int>(state.second.size()), dt_buff, offsets, this->singletons->scatter, streamId);
+                    // Clear buffer
+                    state.second.clear();
+                }
+            }
+        }
+        // Release temp memory
+        if (t_buff) {
+            free(t_buff);
+            gpuErrchk(cudaFree(dt_buff));
+        }
+    }
+}
+
+void CUDAEnsemble::RTCSafeCudaMemcpyToSymbol(const void* symbol, const char* rtc_symbol_name, const void* src, size_t count, size_t offset) const {
+    // make the mem copy to runtime API symbol
+    gpuErrchk(cudaMemcpyToSymbol(symbol, src, count, offset));
+    // loop through agents
+    for (const auto& agent_pair : agent_map) {
+        // loop through any agent functions
+        for (const CUDAAgent::CUDARTCFuncMapPair& rtc_func_pair : agent_pair.second->getRTCFunctions()) {
+            CUdeviceptr rtc_dev_ptr = 0;
+            // get the RTC device symbol
+            rtc_dev_ptr = rtc_func_pair.second->get_global_ptr(rtc_symbol_name);
+            // make the memcpy to the rtc version of the symbol
+            gpuErrchkDriverAPI(cuMemcpyHtoD(rtc_dev_ptr + offset, src, count));
+        }
+    }
+}
+
+void CUDAEnsemble::RTCSafeCudaMemcpyToSymbolAddress(void* ptr, const char* rtc_symbol_name, const void* src, size_t count, size_t offset) const {
+    // offset the device pointer by casting to char
+    void* offset_ptr = reinterpret_cast<void*>(reinterpret_cast<char*>(ptr) + offset);
+    // make the mem copy to runtime API symbol
+    gpuErrchk(cudaMemcpy(offset_ptr, src, count, cudaMemcpyHostToDevice));
+    // loop through agents
+    for (const auto& agent_pair : agent_map) {
+        // loop through any agent functions
+        for (const CUDAAgent::CUDARTCFuncMapPair& rtc_func_pair : agent_pair.second->getRTCFunctions()) {
+            CUdeviceptr rtc_dev_ptr = 0;
+            // get the RTC device symbol
+            rtc_dev_ptr = rtc_func_pair.second->get_global_ptr(rtc_symbol_name);
+            // make the memcpy to the rtc version of the symbol
+            gpuErrchkDriverAPI(cuMemcpyHtoD(rtc_dev_ptr + offset, src, count));
+        }
+    }
+}
+
+void CUDAEnsemble::RTCUpdateEnvironmentVariables(const void* src, size_t count) const {
+    // loop through agents
+    for (const auto& agent_pair : agent_map) {
+        // loop through any agent functions
+        for (const CUDAAgent::CUDARTCFuncMapPair& rtc_func_pair : agent_pair.second->getRTCFunctions()) {
+            CUdeviceptr rtc_dev_ptr = 0;
+            // get the RTC device symbol
+            std::string rtc_symbol_name = CurveRTCHost::getEnvVariableSymbolName();
+            rtc_dev_ptr = rtc_func_pair.second->get_global_ptr(rtc_symbol_name.c_str());
+            // make the memcpy to the rtc version of the symbol
+            gpuErrchkDriverAPI(cuMemcpyHtoD(rtc_dev_ptr, src, count));
+        }
+    }
+}
+
+void CUDAEnsemble::incrementStepCounter() {
+    this->step_count++;
+    //this->singletons->environment.setProperty({instance_id, "_stepCount"}, this->step_count);
+}
+
+void CUDAEnsemble::initEnvironmentMgr() {
+    // Populate the environment properties
+    //if (!submodel) {
+    //    EnvironmentManager::getInstance().init(instance_id, *model->environment);
+    //} else {
+    //    EnvironmentManager::getInstance().init(instance_id, *model->environment, mastermodel->getInstanceID(), *submodel->subenvironment);
+    //}
+
+    //// Add the CUDAEnsemble specific variables(s)
+    //EnvironmentManager::getInstance().newProperty({instance_id, "_stepCount"}, 0u, false);
+}
+
+
+int CUDAEnsemble::checkArgs(int argc, const char** argv) {
+    // Required args
+    if (argc < 1) {
+        printHelp(argv[0]);
+        return false;
+    }
+
+    // First pass only looks for and handles input files
+    // Remaining arguments can override args passed via input file
+    int i = 1;
+    for (; i < argc; i++) {
+    //    // -in <string>, Specifies the input state file
+    //    if (arg.compare("--in") == 0 || arg.compare("-i") == 0) {
+    //        if (i + 1 >= argc) {
+    //            fprintf(stderr, "%s requires a trailing argument\n", arg.c_str());
+    //            return false;
+    //        }
+    //        const std::string new_input_file = std::string(argv[++i]);
+    //        config.input_file = new_input_file;
+    //        // Load the input file
+    //        {
+    //            // Build population vector
+    //            std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> pops;
+    //            for (auto &agent : model->agents) {
+    //                auto a = std::make_shared<AgentPopulation>(*agent.second->description);
+    //                pops.emplace(agent.first, a);
+    //            }
+    //            StateReader *read__ = ReaderFactory::createReader(model->name, getInstanceID(), pops, config.input_file.c_str(), this);
+    //            if (read__) {
+    //                read__->parse();
+    //                for (auto &agent : pops) {
+    //                    setPopulationData(*agent.second);
+    //                }
+    //            }
+    //        }
+    //        // Reset input file (we don't support input file recursion)
+    //        config.input_file = new_input_file;
+    //        // Set flag so input file isn't reloaded via apply_config
+    //        loaded_input_file = new_input_file;
+    //        // Break, we have loaded an input file
+    //        break;
+    //    }
+    }
+
+    // Parse optional args
+    i = 1;
+    for (; i < argc; i++) {
+        // Get arg as lowercase
+        std::string arg(argv[i]);
+        std::transform(arg.begin(), arg.end(), arg.begin(), [](unsigned char c) { return std::use_facet< std::ctype<char>>(std::locale()).tolower(c); });
+        // -in <string>, Specifies the input state file
+        if (arg.compare("--in") == 0 || arg.compare("-i") == 0) {
+            // We already processed input file above, skip here
+            ++i;
+            continue;
+        }
+        // -out <string>, Specifies the output directory
+        if (arg.compare("--out") == 0 || arg.compare("-o") == 0) {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "%s requires a trailing argument\n", arg.c_str());
+                return false;
+            }
+        }
+        // -steps <uint>, Number of simulation iterations per model instance
+        if (arg.compare("--steps") == 0 || arg.compare("-s") == 0) {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "%s requires a trailing argument\n", arg.c_str());
+                return false;
+            }
+            ensemble_config.steps = static_cast<int>(strtoul(argv[++i], nullptr, 0));
+            continue;
+        }
+        // -instances <uint>, Number of model instances to execute
+        if (arg.compare("--instances") == 0 || arg.compare("-i") == 0) {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "%s requires a trailing argument\n", arg.c_str());
+                return false;
+            }
+            ensemble_config.total_runs = static_cast<int>(strtoul(argv[++i], nullptr, 0));
+            continue;
+        }
+        // -concurrent <uint>, Number of instances to execute concurrently
+        if (arg.compare("--concurrent") == 0 || arg.compare("-c") == 0) {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "%s requires a trailing argument\n", arg.c_str());
+                return false;
+            }
+            ensemble_config.max_concurrent_runs = static_cast<int>(strtoul(argv[++i], nullptr, 0));
+            continue;
+        }
+        //// -random <uint>, Uses the specified random seed, defaults to clock
+        //if (arg.compare("--random") == 0 || arg.compare("-r") == 0) {
+        //    if (i + 1 >= argc) {
+        //        fprintf(stderr, "%s requires a trailing argument\n", arg.c_str());
+        //        return false;
+        //    }
+        //    // Reinitialise RandomManager state
+        //    config.random_seed = static_cast<unsigned int>(strtoul(argv[++i], nullptr, 0));
+        //    continue;
+        //}
+        // -v/--verbose, Verbose FLAME GPU output.
+        if (arg.compare("--verbose") == 0 || arg.compare("-v") == 0) {
+            ensemble_config.verbose = true;
+            continue;
+        }
+        // -t/--timing, Output timing information to stdout
+        if (arg.compare("--timing") == 0 || arg.compare("-t") == 0) {
+            ensemble_config.timing = true;
+            continue;
+        }
+#ifdef VISUALISATION
+        // // -c/--console, Renders the visualisation inert
+        // if (arg.compare("--console") == 0 || arg.compare("-c") == 0) {
+        //     config.console_mode = true;
+        //     continue;
+        // }
+#endif
+        // Test this arg with the derived class
+        if (checkArgs_derived(argc, argv, i)) {
+            continue;
+        }
+        fprintf(stderr, "Unexpected argument: %s\n", arg.c_str());
+        printHelp(argv[0]);
+        return false;
+    }
+    return true;
+}
+
+void CUDAEnsemble::initialise(int argc, const char** argv) {
+    NVTX_RANGE("CUDAEnsemble::initialise");
+    // Reset to defaults
+    cuda_config = CConfig();
+    ensemble_config = EConfig();
+    // check input args
+    if (argc)
+        if (!checkArgs(argc, argv))
+            exit(EXIT_FAILURE);
+    applyConfig();
+}
+
+void CUDAEnsemble::printHelp(const char* executable) {
+    printf("Usage: %s [-s steps] [-d device_id] [-r random_seed]\n", executable);
+    printf("Optional Arguments:\n");
+    const char *line_fmt = "%-18s %s\n";
+    // printf(line_fmt, "-i, --in <file.xml/file.json>", "Initial state file (XML or JSON)");
+    printf(line_fmt, "-o, --out <directory>", "Directory to store outputs");
+    printf(line_fmt, "-s, --steps <steps>", "Number of simulation iterations per model instance");
+    printf(line_fmt, "-i, --instances <instances>", "Total number of model instances to execute");
+    printf(line_fmt, "-c, --concurrent <concurrent instances>", "Number of instances to execute concurrently");
+    // printf(line_fmt, "-r, --random <seed>", "RandomManager seed");
+    printf(line_fmt, "-v, --verbose", "Verbose FLAME GPU output");
+    printf(line_fmt, "-t, --timing", "Output timing information to stdout");
+
+    printf("CUDA Model Optional Arguments:\n");
+    printf(line_fmt, "-d, --device", "GPU index");
+}
+
+void CUDAEnsemble::applyConfig() {
+    //if (!config.input_file.empty() && config.input_file != loaded_input_file) {
+    //    const std::string current_input_file = config.input_file;
+    //    // Build population vector
+    //    std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> pops;
+    //    for (auto &agent : model->agents) {
+    //        auto a = std::make_shared<AgentPopulation>(*agent.second->description);
+    //        pops.emplace(agent.first, a);
+    //    }
+    //    StateReader *read__ = ReaderFactory::createReader(model->name, getInstanceID(), pops, config.input_file.c_str(), this);
+    //    if (read__) {
+    //        read__->parse();
+    //        for (auto &agent : pops) {
+    //            setPopulationData(*agent.second);
+    //        }
+    //    }
+    //    // Reset input file (we don't support input file recursion)
+    //    config.input_file = current_input_file;
+    //    // Set flag so we don't reload this in future
+    //    loaded_input_file = current_input_file;
+    //}
+
+    cudaError_t cudaStatus;
+    int device_count;
+
+    // default device
+    cudaStatus = cudaGetDeviceCount(&device_count);
+
+    if (cudaStatus != cudaSuccess) {
+        THROW InvalidCUDAdevice("Error finding CUDA devices!  Do you have a CUDA-capable GPU installed?");
+    }
+    if (device_count == 0) {
+        THROW InvalidCUDAdevice("Error no CUDA devices found!");
+    }
+
+    // Select device
+    if (cuda_config.device_id >= device_count) {
+        THROW InvalidCUDAdevice("Error setting CUDA device to '%d', only %d available!", cuda_config.device_id, device_count);
+    }
+
+    // Check the compute capability of the device, throw an exception if not valid for the executable.
+    if (!util::compute_capability::checkComputeCapability(static_cast<int>(cuda_config.device_id))) {
+        int min_cc = util::compute_capability::minimumCompiledComputeCapability();
+        int cc = util::compute_capability::getComputeCapability(static_cast<int>(cuda_config.device_id));
+        THROW InvalidCUDAComputeCapability("Error application compiled for CUDA Compute Capability %d and above. Device %u is compute capability %d. Rebuild for SM_%d.", min_cc, cuda_config.device_id, cc, cc);
+    }
+
+    cudaStatus = cudaSetDevice(static_cast<int>(cuda_config.device_id));
+    if (cudaStatus != cudaSuccess) {
+        THROW InvalidCUDAdevice("Unknown error setting CUDA device to '%d'. (%d available)", cuda_config.device_id, device_count);
+    }
+    // Call cudaFree to initialise the context early
+    gpuErrchk(cudaFree(nullptr));
+
+    // Apply changes to submodels
+    for (auto &sm : submodel_map) {
+        // We're not actually going to use this value, but it might be useful there later
+        // Calling apply config a second time would reinit GPU, which might clear existing gpu allocations etc
+        sm.second->CUDAConfig().device_id = cuda_config.device_id;
+    }
+
+    // Initialise singletons once a device has been selected.
+    // @todo - if this has already been called, before the device was selected an error should occur.
+    initialiseSingletons();
+
+    // We init Random through submodel hierarchy after singletons
+    // Currently random is fixed seed
+    reseed(12);
+
+    releaseCUDAInstances();
+    initCUDAInstances(ensemble_config.max_concurrent_runs);
+}
+
+
+CUDAEnsemble::CUDAEnsembleInstance::CUDAEnsembleInstance(
+    std::shared_ptr<const ModelData> modelddata,
+    std::map<std::string, std::unique_ptr<CUDAEnsemble>> &submodels,
+    RandomManager &rng,
+    const AgentOffsetMap &agentOffsets,
+    const unsigned int &_instance_id)
+        : model(modelddata)
+        , submodel_map(submodels)
+        , instance_id(_instance_id)
+{
+    // populate the CUDA agent map
+    const auto &am = model->agents;
+    // create new cuda agent and add to the map
+    for (auto it = am.cbegin(); it != am.cend(); ++it) {
+        // Find matching vector and fill it with CUDAAgents
+        for (int i = 0; i < active_instances; ++i) {
+            agent_map.emplace(it->first, std::make_unique<CUDAAgent>(*it->second, i));//For the time being we use instance_id 0+, this is obviously unsafe
+        }
+    }
+    // populate the CUDA message map
+    const auto &mm = model->messages;
+    // create new cuda message and add to the map
+    for (auto it_m = mm.cbegin(); it_m != mm.cend(); ++it_m) {
+        // Find matching vector and fill it with CUDAMessages
+        auto _mm = message_map.find(it_m->first);
+        assert(_mm != message_map.end());
+        assert(_mm->second.size() == 0);
+        for (int i = 0; i < active_instances; ++i) {
+            message_map.emplace(it_m->first, std::make_unique<CUDAMessage>(*it_m->second));
+        }
+    }
+    // Build data
+    for (const auto &agent : model->agents) {
+        AgentDataBufferStateMap agent_states;
+        for (const auto&state : agent.second->states)
+            agent_states.emplace(state, AgentDataBuffer());
+        agentData.emplace(agent.first, agent_states);
+    }
+    host_api = std::make_unique<FLAMEGPU_HOST_API>(*this, rng, agentOffsets, agentData);
+}
+
+void CUDAEnsemble::initCUDAInstances(const unsigned int &active_instances) {    
+    // recursively forward init to submodels
+    const auto &smm = model->submodels;
+    // create new cuda message and add to the map
+    for (auto it_sm = smm.cbegin(); it_sm != smm.cend(); ++it_sm) {
+        // Find matching submodel and initialise it's submodel
+        auto _sm = submodel_map.find(it_sm->first);
+        assert(_sm != submodel_map.end());
+        _sm->second->initCUDAInstances(active_instances);
+    }
+
+    // Build Simulation_vector (We need an AoS view to sim data too)
+    for (int i = 0; i <active_instances; ++i) {
+        instance_vector.push_back(CUDAEnsembleInstance(model, submodel_map, singletons->rng, agentOffsets, i));
+    }
+}
+
+void CUDAEnsemble::releaseCUDAInstances() {   
+    // recursively forward init to submodels
+    const auto &smm = model->submodels;
+    // create new cuda message and add to the map
+    for (auto it_sm = smm.cbegin(); it_sm != smm.cend(); ++it_sm) {
+        // Find matching submodel and initialise it's submodel
+        auto _sm = submodel_map.find(it_sm->first);
+        assert(_sm != submodel_map.end());
+        _sm->second->releaseCUDAInstances();
+    }
+
+    instance_vector.clear();
+    instance_offset_vector.clear();
+}
+CUDAEnsemble::InstanceOffsetData::InstanceOffsetData(const unsigned int& activeInstances)
+    : d_instance_offsets(static_cast<unsigned int * const>(cmalloc((activeInstances + 1) * sizeof(unsigned int))))
+    , d_instance_id_hashes(static_cast<Curve::NamespaceHash * const>(cmalloc(activeInstances * sizeof(Curve::NamespaceHash)))) {
+}
+CUDAEnsemble::InstanceOffsetData::~InstanceOffsetData() {
+    gpuErrchk(cudaFree(d_instance_offsets)); 
+    gpuErrchk(cudaFree(d_instance_id_hashes));
+}
+void * const CUDAEnsemble::InstanceOffsetData::cmalloc(const size_t &len) {
+    void *d_t;
+    gpuErrchk(cudaMalloc(&d_t, len));
+    return d_t;
+}
+

--- a/src/flamegpu/gpu/CUDAMessage.cu
+++ b/src/flamegpu/gpu/CUDAMessage.cu
@@ -37,14 +37,13 @@
 * CUDAMessage class
 * @brief allocates the hash table/list for message variables and copy the list to device
 */
-CUDAMessage::CUDAMessage(const MsgBruteForce::Data& description, const CUDASimulation& cuda_model)
+CUDAMessage::CUDAMessage(const MsgBruteForce::Data& description)
     : message_description(description)
     , message_count(0)
     , max_list_size(0)
     , truncate_messagelist_flag(true)
     , pbm_construction_required(false)
-    , specialisation_handler(description.getSpecialisationHander(*this))
-    , cuda_model(cuda_model) {
+    , specialisation_handler(description.getSpecialisationHander(*this)) {
     // resize(0); // Think this call is redundant
 }
 

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -418,6 +418,11 @@ bool CUDASimulation::step() {
 
                 // Map vars with curve (this allocates/requests enough new buffer space if an existing version is not available/suitable)
                 output_agent.mapNewRuntimeVariables(cuda_agent, *func_des, state_list_size, this->singletons->scatter, j);
+                // Notify scan flag that it might need resizing
+                // We need a 3rd array, because a function might combine agent birth, agent death and message output
+                singletons->scatter.Scan().resize(state_list_size, CUDAScanCompaction::AGENT_OUTPUT, j);
+                // Ensure the scan flag is zeroed
+                singletons->scatter.Scan().zero(CUDAScanCompaction::AGENT_OUTPUT, j);
             }
 
 

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -46,14 +46,14 @@ CUDASimulation::CUDASimulation(const ModelDescription& _model, int argc, const c
     // create new cuda agent and add to the map
     for (auto it = am.cbegin(); it != am.cend(); ++it) {
         // insert into map using value_type and store a reference to the map pair
-        agent_map.emplace(it->first, std::make_unique<CUDAAgent>(*it->second, *this)).first;
+        agent_map.emplace(it->first, std::make_unique<CUDAAgent>(*it->second, instance_id)).first;
     }
 
     // populate the CUDA message map
     const auto &mm = model->messages;
     // create new cuda message and add to the map
     for (auto it_m = mm.cbegin(); it_m != mm.cend(); ++it_m) {
-        message_map.emplace(it_m->first, std::make_unique<CUDAMessage>(*it_m->second, *this));
+        message_map.emplace(it_m->first, std::make_unique<CUDAMessage>(*it_m->second));
     }
 
     // populate the CUDA submodel map

--- a/src/flamegpu/model/AgentFunctionData.cpp
+++ b/src/flamegpu/model/AgentFunctionData.cpp
@@ -4,8 +4,9 @@
 #include "flamegpu/model/AgentFunctionDescription.h"
 #include "flamegpu/runtime/cuRVE/curve_rtc.h"
 
-AgentFunctionData::AgentFunctionData(std::shared_ptr<AgentData> _parent, const std::string &function_name, AgentFunctionWrapper *agent_function, const std::string &in_type, const std::string &out_type)
+AgentFunctionData::AgentFunctionData(std::shared_ptr<AgentData> _parent, const std::string &function_name, AgentFunctionWrapper *agent_function, AgentFunctionEnsembleWrapper *agent_ensemble_function, const std::string &in_type, const std::string &out_type)
     : func(agent_function)
+    , ensemble_func(agent_ensemble_function)
     , rtc_source("")
     , rtc_func_name("")
     , initial_state(_parent->initial_state)
@@ -21,7 +22,8 @@ AgentFunctionData::AgentFunctionData(std::shared_ptr<AgentData> _parent, const s
     , msg_in_type(in_type)
     , msg_out_type(out_type) { }
 AgentFunctionData::AgentFunctionData(std::shared_ptr<AgentData> _parent, const std::string& function_name, const std::string &rtc_function_src, const std::string &in_type, const std::string& out_type, const std::string& code_func_name)
-    : func(0)
+    : func(nullptr)
+    , ensemble_func(nullptr)
     , rtc_source(rtc_function_src)
     , rtc_func_name(code_func_name)
     , initial_state(_parent->initial_state)

--- a/src/flamegpu/runtime/flamegpu_host_api.cu
+++ b/src/flamegpu/runtime/flamegpu_host_api.cu
@@ -5,7 +5,7 @@
 #include "flamegpu/util/nvtx.h"
 #include "flamegpu/gpu/CUDASimulation.h"
 
-FLAMEGPU_HOST_API::FLAMEGPU_HOST_API(CUDASimulation &_agentModel,
+FLAMEGPU_HOST_API::FLAMEGPU_HOST_API(SimInterface &_agentModel,
     RandomManager &rng,
     const AgentOffsetMap &_agentOffsets,
     AgentDataMap &_agentData)


### PR DESCRIPTION
This is mostly a place to make notes/thoughts whilst I fiddle with ensembles. Specifically, looking at the class '1', type where multiple instances of the same model run in lock-step, sharing kernel launches (but not variable arrays).

**Concerns**
* We have spoken about memory limitations. How will set/get pop work if memory is limited (e.g. if we want to run 100 ensembles, how can we pre-set their populations if it will outstrip even host memory). Presumably we need towards flat file/init functions being first class citizens (#329). This is less of an issue, if we intend to run multiple copies from the same init, with differing random seeds (similar to primage validation).
* Runs should have different random seeds, this however makes management of random state awkward, so isn't currently a priority for current tests.
* How do methods like get/reset step count work, surely these should be per model instance, rather than whole ensemble, Although i lean to not having them at all and only having `simulate()`.
* How will input files work, 1 per instance, 1 input file + different random seeds?
* If loading config from input file, we will need to have some changes to how loader works.
* Need to move the `Simulation` instance id mechanic out of `Simulation` if we are abandoning shared inheritance. It is required that these Ids are unique per model instance for environment manager. Currently using 0+ as instance ID rather than proper calculating anything (This almost certainly won't work for submodels).
* Host API object requires access to `CUDASimulation`. It uses this for getting model description hierarchy, instance id, and access to CUDAAgent objects.
* Need to pass a flag to RTC to compile the other ensemble wrapper
* `InstanceOffsetData`, `InstanceOffsetData_cdn` need some work, currently consist of 4 memcyps per agent function launch, and use of SoA, means we don't need two separate device buffers as we are currently using.

Relates to #245 