### PR TITLE
Multi thread/device support

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -1,4 +1,5 @@
 message(STATUS "-----Configuring Project: ${PROJECT_NAME}-----")
+include_guard(DIRECTORY)
 if(NOT CMAKE_VERSION VERSION_LESS 3.18)
     cmake_policy(SET CMP0105 NEW) # Use separate device link options
 endif()
@@ -152,7 +153,12 @@ set(CMAKE_CUDA_FLAGS_RELEASE "${CMAKE_CUDA_FLAGS_RELEASE} -lineinfo")
 set(CMAKE_CUDA_FLAGS_PROFILE "${CMAKE_CUDA_FLAGS_PROFILE} -lineinfo -DPROFILE -D_PROFILE")
 # Addresses a cub::histogram warning
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
-
+# Enable default stream per thread for target, in-case of ensembles
+# This removes implicit syncs in default stream, using it has only been tested for basic models
+# It has not been tested with host functions, agent death, optional messages etc
+# Hence using it is unsafe
+#set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --default-stream per-thread")    
+    
 # Host Compiler version specific high warnings
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # Only set W4 for MSVC, WAll is more like Wall, Wextra and Wpedantic

--- a/include/flamegpu/gpu/CUDAAgent.h
+++ b/include/flamegpu/gpu/CUDAAgent.h
@@ -64,16 +64,18 @@ class CUDAAgent : public AgentInterface {
      * Uses the cuRVE runtime to map the variables used by the agent function to the cuRVE
      * library so that can be accessed by name within a n agent function
      * @param func The function.
+     * @param instance_id The CUDASimulation instance_id of the parent instance. This is added to the hash, to differentiate instances
      * @note TODO: This could be improved by iterating the variable list within the state_list, rather than individually looking up vars (the two lists should have all the same vars)
      * @note This should probably be addressed when curve is updated to not use individual memcpys
      */
-    void mapRuntimeVariables(const AgentFunctionData& func) const;
+    void mapRuntimeVariables(const AgentFunctionData& func, const unsigned int &instance_id) const;
     /**
      * Uses the cuRVE runtime to unmap the variables used by the agent function to the cuRVE
      * library so that they are unavailable to be accessed by name within an agent function.
      * @param func The function.
+     * @param instance_id The CUDASimulation instance_id of the parent instance. This is added to the hash, to differentiate instances
      */
-    void unmapRuntimeVariables(const AgentFunctionData& func) const;
+    void unmapRuntimeVariables(const AgentFunctionData& func, const unsigned int &instance_id) const;
     /**
      * Copies population data from the provided host object
      * To the device buffers held by this object (overwriting any existing agent data)
@@ -166,15 +168,17 @@ class CUDAAgent : public AgentInterface {
      * @param func The agent function being processed
      * @param maxLen The maximum number of new agents (this will be the size of the agent state executing func)
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
+     * @param instance_id The CUDASimulation instance_id of the parent instance. This is added to the hash, to differentiate instances
      * @param streamId This is required for scan compaction arrays and async
      */
-    void mapNewRuntimeVariables(const CUDAAgent& func_agent, const AgentFunctionData& func, const unsigned int &maxLen, CUDAScatter &scatter, const unsigned int &streamId);
+    void mapNewRuntimeVariables(const CUDAAgent& func_agent, const AgentFunctionData& func, const unsigned int &maxLen, CUDAScatter &scatter, const unsigned int &instance_id, const unsigned int &streamId);
     /**
      * Uses the cuRVE runtime to unmap the variables used by agent birth and
      * releases the buffer that was storing the data
      * @param func The function.
+     * @param instance_id The CUDASimulation instance_id of the parent instance. This is added to the hash, to differentiate instances
      */
-    void unmapNewRuntimeVariables(const AgentFunctionData& func);
+    void unmapNewRuntimeVariables(const AgentFunctionData& func, const unsigned int &instance_id);
     /**
      * Scatters agents from the currently assigned device agent birth buffer (see member variable newBuffs)
      * The device buffer must be packed in the same format as mapNewRuntimeVariables(const AgentFunctionData&, const unsigned int &, const unsigned int &)

--- a/include/flamegpu/gpu/CUDAErrorChecking.h
+++ b/include/flamegpu/gpu/CUDAErrorChecking.h
@@ -45,5 +45,10 @@ inline void gpuLaunchAssert(const char *file, int line) {
 #endif
     gpuAssert(cudaPeekAtLastError(), file, line);
 }
+/**
+ * Maximum number of CUDA devices supported
+ * This affects how singletons are handed out
+ */
+constexpr int MAX_CUDA_DEVICES = 8;
 
 #endif  // INCLUDE_FLAMEGPU_GPU_CUDAERRORCHECKING_H_

--- a/include/flamegpu/gpu/CUDAMessage.h
+++ b/include/flamegpu/gpu/CUDAMessage.h
@@ -79,22 +79,25 @@ class CUDAMessage {
      * Uses the cuRVE runtime to map the variables used by the agent function to the cuRVE library so that can be accessed by name within a n agent function
      * The read runtime variables are to be used when reading messages
      * @param func The agent function, this is used for the cuRVE hash mapping
+     * @param instance_id The CUDASimulation instance_id of the parent instance. This is added to the hash, to differentiate instances
      */
-    void mapReadRuntimeVariables(const AgentFunctionData& func, const CUDAAgent& cuda_agent) const;
+    void mapReadRuntimeVariables(const AgentFunctionData& func, const CUDAAgent& cuda_agent, const unsigned int &instance_id) const;
     /**
      * Uses the cuRVE runtime to map the variables used by the agent function to the cuRVE library so that can be accessed by name within a n agent function
      * The write runtime variables are to be used when creating messages, as they are output to swap space
      * @param func The agent function, this is used for the cuRVE hash mapping
-     * @param writeLen The number of messages to be output, as the length isn't updated till after ouput
+     * @param writeLen The number of messages to be output, as the length isn't updated till after output
+     * @param instance_id The CUDASimulation instance_id of the parent instance. This is added to the hash, to differentiate instances
      * @note swap() or scatter() should be called after the agent function has written messages
      */
-    void mapWriteRuntimeVariables(const AgentFunctionData& func, const CUDAAgent& cuda_agent, const unsigned int &writeLen) const;
+    void mapWriteRuntimeVariables(const AgentFunctionData& func, const CUDAAgent& cuda_agent, const unsigned int &writeLen, const unsigned int &instance_id) const;
     /**
      * Uses the cuRVE runtime to unmap the variables used by the agent function to the cuRVE
      * library so that they are unavailable to be accessed by name within an agent function.
      * @param func The agent function, this is used for the cuRVE hash mapping
+     * @param instance_id The CUDASimulation instance_id of the parent instance. This is added to the hash, to differentiate instances
      */
-    void unmapRuntimeVariables(const AgentFunctionData& func) const;
+    void unmapRuntimeVariables(const AgentFunctionData& func, const unsigned int &instance_id) const;
     void *getReadPtr(const std::string &var_name);
     const CUDAMsgMap &getReadList() { return message_list->getReadList(); }
     const CUDAMsgMap &getWriteList() { return message_list->getWriteList(); }

--- a/include/flamegpu/gpu/CUDASimulation.h
+++ b/include/flamegpu/gpu/CUDASimulation.h
@@ -292,6 +292,11 @@ class CUDASimulation : public Simulation {
      * Flag indicating that RTC functions have been compiled
      */
     bool rtcInitialised;
+    /**
+     * Set to the ID of the device on which the simulation was initialised
+     * Cannot change device after this point
+     */
+    int deviceInitialised = -1;
 
     /**
      * Initialise the instances singletons.
@@ -347,6 +352,14 @@ class CUDASimulation : public Simulation {
      * When the last is destructed, cudaDeviceReset is triggered();
      */
     static std::atomic<int> active_instances;
+    /**
+     * Active instances, but linked to the device each instance has been initialised on
+     */
+    static std::array<std::atomic<int>, MAX_CUDA_DEVICES> active_device_instances;
+    /**
+     * These exist to prevent us doing device reset in the short period between checking last sim of device, and reset
+     */
+    static std::array<std::shared_timed_mutex, MAX_CUDA_DEVICES> active_device_mutex;
 
  public:
     /**

--- a/include/flamegpu/io/factory.h
+++ b/include/flamegpu/io/factory.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include "flamegpu/io/statereader.h"
 #include "flamegpu/io/statewriter.h"
@@ -43,7 +44,8 @@ class ReaderFactory {
      * Environment properties will be read into the Simulation instance pointed to by 'sim_instance_id'
      * Agent data will be read into 'model_state'
      * @param model_name Name from the model description hierarchy of the model to be loaded
-     * @param sim_instance_id Instance is from the Simulation instance to load the environment properties into
+     * @param env_desc Environment description for validating property data on load
+     * @param env_init Dictionary of loaded values map:<{name, index}, value>
      * @param model_state Map of AgentPopulation to load the agent data into per agent, key should be agent name
      * @param input Filename of the input file (This will be used to determine which reader to return)
      * @param sim_instance Instance of the Simulation object (This is used for setting/getting config)
@@ -51,16 +53,17 @@ class ReaderFactory {
      */
     static StateReader *createReader(
         const std::string &model_name,
-        const unsigned int &sim_instance_id,
+        const std::unordered_map<std::string, EnvironmentDescription::PropData> &env_desc,
+        std::unordered_map<std::pair<std::string, unsigned int>, EnvironmentDescription::Any> &env_init,
         const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &model_state,
         const std::string &input,
         Simulation *sim_instance) {
         const std::string extension = getFileExt(input);
 
         if (extension == "xml") {
-            return new xmlReader(model_name, sim_instance_id, model_state, input, sim_instance);
+            return new xmlReader(model_name, env_desc, env_init, model_state, input, sim_instance);
         } else if (extension == "json") {
-            return new jsonReader(model_name, sim_instance_id, model_state, input, sim_instance);
+            return new jsonReader(model_name, env_desc, env_init, model_state, input, sim_instance);
         }
         /*
         if (extension == "bin") {

--- a/include/flamegpu/io/jsonReader.h
+++ b/include/flamegpu/io/jsonReader.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include "flamegpu/io/statereader.h"
 #include "flamegpu/model/ModelDescription.h"
@@ -16,14 +17,16 @@ class jsonReader : public StateReader {
      * Environment properties will be read into the Simulation instance pointed to by 'sim_instance_id'
      * Agent data will be read into 'model_state'
      * @param model_name Name from the model description hierarchy of the model to be loaded
-     * @param sim_instance_id Instance is from the Simulation instance to load the environment properties into
+     * @param env_desc Environment description for validating property data on load
+     * @param env_init Dictionary of loaded values map:<{name, index}, value>
      * @param model_state Map of AgentPopulation to load the agent data into per agent, key should be agent name
      * @param input_file Filename of the input file (This will be used to determine which reader to return)
      * @param sim_instance Instance of the Simulation object (This is used for setting/getting config)
      */
     jsonReader(
         const std::string &model_name,
-        const unsigned int &sim_instance_id,
+        const std::unordered_map<std::string, EnvironmentDescription::PropData> &env_desc,
+        std::unordered_map<std::pair<std::string, unsigned int>, EnvironmentDescription::Any> &env_init,
         const std::unordered_map<std::string,
         std::shared_ptr<AgentPopulation>> &model_state,
         const std::string &input_file,

--- a/include/flamegpu/io/statereader.h
+++ b/include/flamegpu/io/statereader.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include "flamegpu/model/ModelDescription.h"
 
@@ -24,20 +25,23 @@ class StateReader {
      * Environment properties will be read into the Simulation instance pointed to by 'sim_instance_id'
      * Agent data will be read into 'model_state'
      * @param _model_name Name from the model description hierarchy of the model to be loaded
-     * @param _sim_instance_id Instance is from the Simulation instance to load the environment properties into
+     * @param _env_desc Environment description for validating property data on load
+     * @param _env_init Dictionary of loaded values map:<{name, index}, value>
      * @param _model_state Map of AgentPopulation to load the agent data into per agent, key should be agent name
      * @param input Filename of the input file (This will be used to determine which reader to return)
      */
     StateReader(
         const std::string &_model_name,
-        const unsigned int &_sim_instance_id,
+        const std::unordered_map<std::string, EnvironmentDescription::PropData> &_env_desc,
+        std::unordered_map<std::pair<std::string, unsigned int>, EnvironmentDescription::Any> &_env_init,
         const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &_model_state,
         const std::string &input,
         Simulation *_sim_instance)
     : model_state(_model_state)
     , inputFile(input)
     , model_name(_model_name)
-    , sim_instance_id(_sim_instance_id)
+    , env_desc(_env_desc)
+    , env_init(_env_init)
     , sim_instance(_sim_instance) {}
     ~StateReader() {}
 
@@ -74,7 +78,8 @@ class StateReader {
     const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &model_state;
     std::string inputFile;
     const std::string model_name;
-    const unsigned int sim_instance_id;
+    const std::unordered_map<std::string, EnvironmentDescription::PropData> &env_desc;
+    std::unordered_map<std::pair<std::string, unsigned int>, EnvironmentDescription::Any> &env_init;
     Simulation *sim_instance;
 };
 

--- a/include/flamegpu/io/xmlReader.h
+++ b/include/flamegpu/io/xmlReader.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include "flamegpu/io/statereader.h"
 #include "flamegpu/model/ModelDescription.h"
@@ -25,13 +26,15 @@ class xmlReader : public StateReader {
      * Environment properties will be read into the Simulation instance pointed to by 'sim_instance_id'
      * Agent data will be read into 'model_state'
      * @param model_name Name from the model description hierarchy of the model to be loaded
-     * @param sim_instance_id Instance is from the Simulation instance to load the environment properties into
+     * @param env_desc Environment description for validating property data on load
+     * @param env_init Dictionary of loaded values map:<{name, index}, value>
      * @param model_state Map of AgentPopulation to load the agent data into per agent, key should be agent name
      * @param input_file Filename of the input file (This will be used to determine which reader to return)
      */
     xmlReader(
         const std::string &model_name,
-        const unsigned int &sim_instance_id,
+        const std::unordered_map<std::string, EnvironmentDescription::PropData> &env_desc,
+        std::unordered_map<std::pair<std::string, unsigned int>, EnvironmentDescription::Any> &env_init,
         const std::unordered_map<std::string,
         std::shared_ptr<AgentPopulation>> &model_state,
         const std::string &input_file,

--- a/include/flamegpu/model/EnvironmentDescription.h
+++ b/include/flamegpu/model/EnvironmentDescription.h
@@ -30,6 +30,13 @@ class EnvironmentDescription {
      */
     friend class SubEnvironmentDescription;
     /**
+     * Constructor has access to privately add reserved items
+     * Might be a cleaner way to do this
+     */
+    friend class CUDASimulation;
+
+ public:
+    /**
      * Minimal std::any replacement, works pre c++17
      * We don't care about type, so it isn't tracked
      */
@@ -73,8 +80,6 @@ class EnvironmentDescription {
          */
         const size_t length;
     };
-
- public:
     /**
      * Holds all of the properties required to add a value to EnvironmentManager
      */

--- a/include/flamegpu/runtime/AgentFunction.h
+++ b/include/flamegpu/runtime/AgentFunction.h
@@ -71,7 +71,9 @@ __global__ void agent_function_wrapper(
 #ifndef NO_SEATBELTS
     // We place this at the start of shared memory, so we can locate it anywhere in device code without a reference
     extern __shared__ DeviceExceptionBuffer *buff[];
-    buff[0] = error_buffer;
+    if (threadIdx.x == 0) {
+        buff[0] = error_buffer;
+    }
 #endif
     // Must be terminated here, else AgentRandom has bounds issues inside FLAMEGPU_DEVICE_API constructor
     if (FLAMEGPU_DEVICE_API<MsgIn, MsgOut>::TID() >= popNo)

--- a/include/flamegpu/runtime/AgentFunctionCondition.h
+++ b/include/flamegpu/runtime/AgentFunctionCondition.h
@@ -43,7 +43,9 @@ __global__ void agent_function_condition_wrapper(
 #ifndef NO_SEATBELTS
     // We place this at the start of shared memory, so we can locate it anywhere in device code without a reference
     extern __shared__ DeviceExceptionBuffer *shared_mem[];
-    shared_mem[0] = error_buffer;
+    if (threadIdx.x == 0) {
+        shared_mem[0] = error_buffer;
+    }
 #endif
     // Must be terminated here, else AgentRandom has bounds issues inside FLAMEGPU_DEVICE_API constructor
     if (FLAMEGPU_READ_ONLY_DEVICE_API::TID() >= popNo)

--- a/include/flamegpu/sim/Simulation.h
+++ b/include/flamegpu/sim/Simulation.h
@@ -4,6 +4,8 @@
 #include <memory>
 #include <string>
 #include <ctime>
+#include <utility>
+#include <unordered_map>
 
 #include "flamegpu/sim/AgentInterface.h"
 
@@ -11,6 +13,26 @@ class FLAMEGPU_HOST_API;
 class ModelDescription;
 class AgentPopulation;
 struct ModelData;
+
+
+namespace std {
+/**
+ * Required so this pair type can be key in an unordered_map
+ */
+template <>
+struct hash<std::pair<std::string, unsigned int>> {
+    std::size_t operator()(const std::pair<std::string, unsigned int>& k) const noexcept {
+        using std::string;
+
+        // Compute individual hash values for first,
+        // second and combine them using XOR
+        // and bit shifting:
+
+        return ((hash<string>()(k.first)
+            ^ (hash<unsigned int>()(k.second) << 1)) >> 1);
+    }
+};
+}  // namespace std
 
 class Simulation {
  public:
@@ -127,6 +149,10 @@ class Simulation {
      * Unique index of Simulation instance
      */
     const unsigned int instance_id;
+    /**
+     * Initial environment items if they have been loaded from file, prior to device selection
+     */
+    std::unordered_map<std::pair<std::string, unsigned int>, EnvironmentDescription::Any> env_init;
 
  private:
     /**

--- a/src/flamegpu/exception/FGPUDeviceException.cu
+++ b/src/flamegpu/exception/FGPUDeviceException.cu
@@ -25,6 +25,7 @@ DeviceExceptionBuffer *DeviceExceptionManager::getDevicePtr(const unsigned int &
     if (!d_buffer[streamId]) {
         gpuErrchk(cudaMalloc(&d_buffer[streamId], sizeof(DeviceExceptionBuffer)));
     }
+    gpuErrchk(cudaDeviceSynchronize());
     // Memset and return buffer
     gpuErrchk(cudaMemset(d_buffer[streamId], 0, sizeof(DeviceExceptionBuffer)));
     memset(&hd_buffer[streamId], 0, sizeof(DeviceExceptionBuffer));

--- a/src/flamegpu/io/jsonWriter.cpp
+++ b/src/flamegpu/io/jsonWriter.cpp
@@ -91,6 +91,7 @@ void jsonWriter::doWrite(T &writer) {
     {
         // for each environment property
         EnvironmentManager &env_manager = EnvironmentManager::getInstance();
+        auto lock = env_manager.getSharedLock();
         const char *env_buffer = reinterpret_cast<const char *>(env_manager.getHostBuffer());
         for (auto &a : env_manager.getPropertiesMap()) {
             // If it is from this model

--- a/src/flamegpu/io/xmlWriter.cpp
+++ b/src/flamegpu/io/xmlWriter.cpp
@@ -138,6 +138,7 @@ int xmlWriter::writeStates(bool prettyPrint) {
     pElement = doc.NewElement("environment");
     // for each environment property
     EnvironmentManager &env_manager = EnvironmentManager::getInstance();
+    auto lock = env_manager.getSharedLock();
     const char *env_buffer = reinterpret_cast<const char *>(env_manager.getHostBuffer());
     for (auto &a : env_manager.getPropertiesMap()) {
         // If it is from this model

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -42,7 +42,10 @@ void Simulation::applyConfig() {
             auto a = std::make_shared<AgentPopulation>(*agent.second->description);
             pops.emplace(agent.first, a);
         }
-        StateReader *read__ = ReaderFactory::createReader(model->name, getInstanceID(), pops, config.input_file.c_str(), this);
+
+        env_init.clear();
+        const auto env_desc = model->environment->getPropertiesMap();  // For some reason this method returns a copy, not a reference
+        StateReader *read__ = ReaderFactory::createReader(model->name, env_desc, env_init, pops, config.input_file.c_str(), this);
         if (read__) {
             read__->parse();
             for (auto &agent : pops) {
@@ -109,7 +112,9 @@ int Simulation::checkArgs(int argc, const char** argv) {
                     auto a = std::make_shared<AgentPopulation>(*agent.second->description);
                     pops.emplace(agent.first, a);
                 }
-                StateReader *read__ = ReaderFactory::createReader(model->name, getInstanceID(), pops, config.input_file.c_str(), this);
+                env_init.clear();
+                const auto env_desc = model->environment->getPropertiesMap();  // For some reason this method returns a copy, not a reference
+                StateReader *read__ = ReaderFactory::createReader(model->name, env_desc, env_init, pops, config.input_file.c_str(), this);
                 if (read__) {
                     read__->parse();
                     for (auto &agent : pops) {
@@ -214,5 +219,5 @@ void Simulation::reset() {
 
 unsigned int Simulation::get_instance_id() {
     static unsigned int i = 0;
-    return i++;
+    return 641 * (i++);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,6 +100,8 @@ SET(TEST_CASE_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/util/test_compute_capability.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/util/test_nvtx.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/util/test_dependency_versions.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/util/test_multi_thread_device.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/util/test_rtc_multi_thread_device.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_rtc_device_api.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/exception/test_rtc_device_exception.cu
 )

--- a/tests/test_cases/util/test_multi_thread_device.cu
+++ b/tests/test_cases/util/test_multi_thread_device.cu
@@ -1,0 +1,857 @@
+#include <thread>
+#include <vector>
+#include <memory>
+
+#include "flamegpu/flame_api.h"
+#include "gtest/gtest.h"
+#include "flamegpu/util/compute_capability.cuh"
+
+namespace test_multi_thread_device {
+const char *MODEL_NAME = "Model";
+const char *AGENT_NAME = "Agent1";
+const char *MESSAGE_NAME = "Message1";
+const char *FUNCTION_NAME1 = "Fn1";
+const char *FUNCTION_NAME2 = "Fn2";
+
+void runSim(CUDASimulation &sim, bool &exception_thrown) {
+    exception_thrown = false;
+    try {
+        sim.simulate();
+    } catch(std::exception &e) {
+        exception_thrown = true;
+        printf("%s\n", e.what());
+    }
+}
+
+FLAMEGPU_AGENT_FUNCTION(SlowFn, MsgNone, MsgNone) {
+    int x = FLAMEGPU->getVariable<int>("x");
+    // Do nothing, just waste time. Get values from environment to prevent optimisation
+    for (int i = 0; i < FLAMEGPU->environment.getProperty<int>("ten thousand"); ++i) {
+        x += FLAMEGPU->environment.getProperty<int>("zero");
+    }
+    FLAMEGPU->setVariable<int>("x", x + 1);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(FastFn, MsgNone, MsgNone) {
+    const int x = FLAMEGPU->getVariable<int>("x");
+    FLAMEGPU->setVariable<int>("x", x + 1);
+    return ALIVE;
+}
+TEST(MultiThreadDeviceTest, SameModelSeperateThread_Agent) {
+    const unsigned int POP_SIZE = 10000;
+    // The purpose of this test is to try and catch whether CURVE will hit collisions if two identical models execute at the same time.
+    // Success of this test does not mean there isn't a problem
+    // This test covers agent variable set/get
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<int>("x", 0);
+    a.newFunction(FUNCTION_NAME1, SlowFn);
+    a.newFunction(FUNCTION_NAME2, FastFn);
+    m.newLayer().addAgentFunction(SlowFn);
+    m.newLayer().addAgentFunction(FastFn);
+
+    m.Environment().newProperty<int>("ten thousand", 10000);
+    m.Environment().newProperty<int>("zero", 0);
+
+    AgentPopulation pop_in1(a, POP_SIZE);
+    AgentPopulation pop_in2(a, POP_SIZE);
+    AgentPopulation pop_in3(a, POP_SIZE);
+    for (unsigned int i = 0; i < POP_SIZE; ++i) {
+        pop_in1.getNextInstance().setVariable<int>("x", 1);
+        pop_in2.getNextInstance().setVariable<int>("x", 2);
+        pop_in3.getNextInstance().setVariable<int>("x", 3);
+    }
+
+    CUDASimulation sim1(m);
+    sim1.SimulationConfig().steps = 10;
+    sim1.setPopulationData(pop_in1);
+    CUDASimulation sim2(m);
+    sim2.SimulationConfig().steps = 10;
+    sim2.setPopulationData(pop_in2);
+    CUDASimulation sim3(m);
+    sim3.SimulationConfig().steps = 10;
+    sim3.setPopulationData(pop_in3);
+
+    bool has_error_1 = false, has_error_2 = false, has_error_3 = false;
+    std::thread thread1(runSim, std::ref(sim1), std::ref(has_error_1));
+    std::thread thread2(runSim, std::ref(sim2), std::ref(has_error_2));
+    std::thread thread3(runSim, std::ref(sim3), std::ref(has_error_3));
+    // synchronize threads:
+    thread1.join();
+    thread2.join();
+    thread3.join();
+    // Check exceptions
+    ASSERT_FALSE(has_error_1);
+    ASSERT_FALSE(has_error_2);
+    ASSERT_FALSE(has_error_3);
+    // Check results
+    AgentPopulation pop1(a, POP_SIZE);
+    AgentPopulation pop2(a, POP_SIZE);
+    AgentPopulation pop3(a, POP_SIZE);
+    sim1.getPopulationData(pop1);
+    sim2.getPopulationData(pop2);
+    sim3.getPopulationData(pop3);
+    // Use expect, rather than assert for first 3 agents.
+    for (unsigned int i = 0; i < 3; ++i) {
+        int x1 = pop1.getInstanceAt(i).getVariable<int>("x");
+        int x2 = pop2.getInstanceAt(i).getVariable<int>("x");
+        int x3 = pop3.getInstanceAt(i).getVariable<int>("x");
+        // 10 steps with 2x +1 each.
+        EXPECT_EQ(x1, 21);
+        EXPECT_EQ(x2, 22);
+        EXPECT_EQ(x3, 23);
+    }
+    for (unsigned int i = 3; i < POP_SIZE; ++i) {
+        int x1 = pop1.getInstanceAt(i).getVariable<int>("x");
+        int x2 = pop2.getInstanceAt(i).getVariable<int>("x");
+        int x3 = pop3.getInstanceAt(i).getVariable<int>("x");
+        // 10 steps with 2x +1 each.
+        ASSERT_EQ(x1, 21);
+        ASSERT_EQ(x2, 22);
+        ASSERT_EQ(x3, 23);
+    }
+}
+
+FLAMEGPU_AGENT_FUNCTION(SlowFnMsg, MsgBruteForce, MsgNone) {
+    int x = FLAMEGPU->getVariable<int>("x");
+    int y = 0;
+    // Do nothing, just waste time. Get values from environment to prevent optimisation
+    for (auto &m : FLAMEGPU->message_in) {
+        y += m.getVariable<int>("x");
+    }
+    FLAMEGPU->setVariable<int>("x", x + y);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(FastFnMsg, MsgNone, MsgBruteForce) {
+    const int x = FLAMEGPU->getVariable<int>("x");
+    FLAMEGPU->message_out.setVariable<int>("x", 1);
+    return ALIVE;
+}
+TEST(MultiThreadDeviceTest, SameModelSeperateThread_Message) {
+    const unsigned int POP_SIZE = 10000;
+    // The purpose of this test is to try and catch whether CURVE will hit collisions if two identical models execute at the same time.
+    // Success of this test does not mean there isn't a problem
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    MsgBruteForce::Description &msg = m.newMessage(MESSAGE_NAME);
+    msg.newVariable<int>("x");
+    a.newVariable<int>("x", 0);
+    a.newFunction(FUNCTION_NAME1, FastFnMsg).setMessageOutput(msg);
+    a.newFunction(FUNCTION_NAME2, SlowFnMsg).setMessageInput(msg);
+    m.newLayer().addAgentFunction(FastFnMsg);
+    m.newLayer().addAgentFunction(SlowFnMsg);
+
+    AgentPopulation pop_in1(a, POP_SIZE);
+    AgentPopulation pop_in2(a, POP_SIZE);
+    AgentPopulation pop_in3(a, POP_SIZE);
+    for (unsigned int i = 0; i < POP_SIZE; ++i) {
+        pop_in1.getNextInstance().setVariable<int>("x", 1);
+        pop_in2.getNextInstance().setVariable<int>("x", 2);
+        pop_in3.getNextInstance().setVariable<int>("x", 3);
+    }
+
+    CUDASimulation sim1(m);
+    sim1.SimulationConfig().steps = 10;
+    sim1.setPopulationData(pop_in1);
+    CUDASimulation sim2(m);
+    sim2.SimulationConfig().steps = 10;
+    sim2.setPopulationData(pop_in2);
+    CUDASimulation sim3(m);
+    sim3.SimulationConfig().steps = 10;
+    sim3.setPopulationData(pop_in3);
+
+    bool has_error_1 = false, has_error_2 = false, has_error_3 = false;
+    std::thread thread1(runSim, std::ref(sim1), std::ref(has_error_1));
+    std::thread thread2(runSim, std::ref(sim2), std::ref(has_error_2));
+    std::thread thread3(runSim, std::ref(sim3), std::ref(has_error_3));
+    // synchronize threads:
+    thread1.join();
+    thread2.join();
+    thread3.join();
+    // Check exceptions
+    ASSERT_FALSE(has_error_1);
+    ASSERT_FALSE(has_error_2);
+    ASSERT_FALSE(has_error_3);
+    // Check results
+    AgentPopulation pop1(a, POP_SIZE);
+    AgentPopulation pop2(a, POP_SIZE);
+    AgentPopulation pop3(a, POP_SIZE);
+    sim1.getPopulationData(pop1);
+    sim2.getPopulationData(pop2);
+    sim3.getPopulationData(pop3);
+    // Use expect, rather than assert for first 3 agents.
+    for (unsigned int i = 0; i < 3; ++i) {
+        int x1 = pop1.getInstanceAt(i).getVariable<int>("x");
+        int x2 = pop2.getInstanceAt(i).getVariable<int>("x");
+        int x3 = pop3.getInstanceAt(i).getVariable<int>("x");
+        // 10 steps with 1x +10000 each.
+        EXPECT_EQ(x1, 100001);
+        EXPECT_EQ(x2, 100002);
+        EXPECT_EQ(x3, 100003);
+    }
+    for (unsigned int i = 3; i < POP_SIZE; ++i) {
+        int x1 = pop1.getInstanceAt(i).getVariable<int>("x");
+        int x2 = pop2.getInstanceAt(i).getVariable<int>("x");
+        int x3 = pop3.getInstanceAt(i).getVariable<int>("x");
+        // 10 steps with 1x +10000 each.
+        ASSERT_EQ(x1, 100001);
+        ASSERT_EQ(x2, 100002);
+        ASSERT_EQ(x3, 100003);
+    }
+}
+
+FLAMEGPU_AGENT_FUNCTION(SlowFn2, MsgNone, MsgNone) {
+    int x = FLAMEGPU->getVariable<int>("x");
+    // Do nothing, just waste time. Get values from environment to prevent optimisation
+    for (int i = 0; i < FLAMEGPU->environment.getProperty<int>("ten thousand"); ++i) {
+        x += FLAMEGPU->environment.getProperty<int>("zero");
+    }
+    FLAMEGPU->setVariable<int>("x", x + FLAMEGPU->environment.getProperty<int>("one"));
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(FastFn2, MsgNone, MsgNone) {
+    const int x = FLAMEGPU->getVariable<int>("x");
+    FLAMEGPU->setVariable<int>("x", x + FLAMEGPU->environment.getProperty<int>("three"));
+    return ALIVE;
+}
+TEST(MultiThreadDeviceTest, SameModelSeperateThread_Environment) {
+    const unsigned int POP_SIZE = 10000;
+    // The purpose of this test is to try and catch whether CURVE will hit collisions if two identical models execute at the same time.
+    // Success of this test does not mean there isn't a problem
+    // This test covers environment variable get
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<int>("x", 0);
+    a.newFunction(FUNCTION_NAME1, SlowFn2);
+    a.newFunction(FUNCTION_NAME2, FastFn2);
+    m.newLayer().addAgentFunction(SlowFn2);
+    m.newLayer().addAgentFunction(FastFn2);
+
+    m.Environment().newProperty<int>("ten thousand", 10000);
+    m.Environment().newProperty<int>("zero", 0);
+    m.Environment().newProperty<int>("one", 1);
+    m.Environment().newProperty<int>("three", 3);
+
+    AgentPopulation pop_in1(a, POP_SIZE);
+    AgentPopulation pop_in2(a, POP_SIZE);
+    AgentPopulation pop_in3(a, POP_SIZE);
+    for (unsigned int i = 0; i < POP_SIZE; ++i) {
+        pop_in1.getNextInstance().setVariable<int>("x", 1);
+        pop_in2.getNextInstance().setVariable<int>("x", 2);
+        pop_in3.getNextInstance().setVariable<int>("x", 3);
+    }
+
+    CUDASimulation sim1(m);
+    sim1.SimulationConfig().steps = 10;
+    sim1.setPopulationData(pop_in1);
+    m.Environment().setProperty<int>("one", 10);
+    m.Environment().setProperty<int>("three", 30);
+    CUDASimulation sim2(m);
+    sim2.SimulationConfig().steps = 10;
+    sim2.setPopulationData(pop_in2);
+    m.Environment().setProperty<int>("one", 100);
+    m.Environment().setProperty<int>("three", 300);
+    CUDASimulation sim3(m);
+    sim3.SimulationConfig().steps = 10;
+    sim3.setPopulationData(pop_in3);
+
+    bool has_error_1 = false, has_error_2 = false, has_error_3 = false;
+    std::thread thread1(runSim, std::ref(sim1), std::ref(has_error_1));
+    std::thread thread2(runSim, std::ref(sim2), std::ref(has_error_2));
+    std::thread thread3(runSim, std::ref(sim3), std::ref(has_error_3));
+    // synchronize threads:
+    thread1.join();
+    thread2.join();
+    thread3.join();
+    // Check exceptions
+    ASSERT_FALSE(has_error_1);
+    ASSERT_FALSE(has_error_2);
+    ASSERT_FALSE(has_error_3);
+    // Check results
+    AgentPopulation pop1(a, POP_SIZE);
+    AgentPopulation pop2(a, POP_SIZE);
+    AgentPopulation pop3(a, POP_SIZE);
+    sim1.getPopulationData(pop1);
+    sim2.getPopulationData(pop2);
+    sim3.getPopulationData(pop3);
+    // Use expect, rather than assert for first 3 agents.
+    for (unsigned int i = 0; i < 3; ++i) {
+        int x1 = pop1.getInstanceAt(i).getVariable<int>("x");
+        int x2 = pop2.getInstanceAt(i).getVariable<int>("x");
+        int x3 = pop3.getInstanceAt(i).getVariable<int>("x");
+        // 10 steps with 1x +4 each.
+        EXPECT_EQ(x1, 41);
+        EXPECT_EQ(x2, 402);
+        EXPECT_EQ(x3, 4003);
+    }
+    for (unsigned int i = 3; i < POP_SIZE; ++i) {
+        int x1 = pop1.getInstanceAt(i).getVariable<int>("x");
+        int x2 = pop2.getInstanceAt(i).getVariable<int>("x");
+        int x3 = pop3.getInstanceAt(i).getVariable<int>("x");
+        // 10 steps with 1x +4 each.
+        ASSERT_EQ(x1, 41);
+        ASSERT_EQ(x2, 402);
+        ASSERT_EQ(x3, 4003);
+    }
+}
+FLAMEGPU_AGENT_FUNCTION(SlowFn3, MsgNone, MsgNone) {
+    int x = FLAMEGPU->getVariable<int>("x");
+    // Do nothing, just waste time. Get values from environment to prevent optimisation
+    for (int i = 0; i < FLAMEGPU->environment.getProperty<int>("ten thousand"); ++i) {
+        x += FLAMEGPU->environment.getProperty<int>("zero");
+    }
+    FLAMEGPU->setVariable<int>("x", x + 1);
+    FLAMEGPU->agent_out.setVariable<int>("x", 0);
+    return ALIVE;
+}
+TEST(MultiThreadDeviceTest, SameModelSeperateThread_AgentOutput) {
+    const unsigned int POP_SIZE = 1000;
+    // The purpose of this test is to try and catch whether CURVE will hit collisions if two identical models execute at the same time.
+    // Success of this test does not mean there isn't a problem
+    // This test covers agent output
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<int>("x", 0);
+    a.newFunction(FUNCTION_NAME1, SlowFn3).setAgentOutput(a);
+    a.newFunction(FUNCTION_NAME2, FastFn);
+    m.newLayer().addAgentFunction(SlowFn3);
+    m.newLayer().addAgentFunction(FastFn);
+
+    m.Environment().newProperty<int>("ten thousand", 10000);
+    m.Environment().newProperty<int>("zero", 0);
+
+    AgentPopulation pop_in1(a, POP_SIZE);
+    AgentPopulation pop_in2(a, POP_SIZE);
+    AgentPopulation pop_in3(a, POP_SIZE);
+    for (unsigned int i = 0; i < POP_SIZE; ++i) {
+        pop_in1.getNextInstance().setVariable<int>("x", 1);
+        pop_in2.getNextInstance().setVariable<int>("x", 2);
+        pop_in3.getNextInstance().setVariable<int>("x", 3);
+    }
+
+    CUDASimulation sim1(m);
+    sim1.SimulationConfig().steps = 5;
+    sim1.setPopulationData(pop_in1);
+    CUDASimulation sim2(m);
+    sim2.SimulationConfig().steps = 5;
+    sim2.setPopulationData(pop_in2);
+    CUDASimulation sim3(m);
+    sim3.SimulationConfig().steps = 5;
+    sim3.setPopulationData(pop_in3);
+
+    bool has_error_1 = false, has_error_2 = false, has_error_3 = false;
+    std::thread thread1(runSim, std::ref(sim1), std::ref(has_error_1));
+    std::thread thread2(runSim, std::ref(sim2), std::ref(has_error_2));
+    std::thread thread3(runSim, std::ref(sim3), std::ref(has_error_3));
+    // synchronize threads:
+    thread1.join();
+    thread2.join();
+    thread3.join();
+    // Check exceptions
+    ASSERT_FALSE(has_error_1);
+    ASSERT_FALSE(has_error_2);
+    ASSERT_FALSE(has_error_3);
+    // Check results
+    // 1000 * 2^5
+    AgentPopulation pop1(a, 32 * POP_SIZE);
+    AgentPopulation pop2(a, 32 * POP_SIZE);
+    AgentPopulation pop3(a, 32 * POP_SIZE);
+    sim1.getPopulationData(pop1);
+    sim2.getPopulationData(pop2);
+    sim3.getPopulationData(pop3);
+    EXPECT_EQ(pop1.getCurrentListSize(), 32 * POP_SIZE);
+    EXPECT_EQ(pop2.getCurrentListSize(), 32 * POP_SIZE);
+    EXPECT_EQ(pop3.getCurrentListSize(), 32 * POP_SIZE);
+    for (unsigned int i = 0; i < POP_SIZE; ++i) {
+        int x1 = pop1.getInstanceAt(i).getVariable<int>("x");
+        int x2 = pop2.getInstanceAt(i).getVariable<int>("x");
+        int x3 = pop3.getInstanceAt(i).getVariable<int>("x");
+        // 5 steps with 2x +1 each.
+        ASSERT_EQ(x1, 11);
+        ASSERT_EQ(x2, 12);
+        ASSERT_EQ(x3, 13);
+    }
+    // Check all the new agents
+    for (int step = 0; step < 5; ++step) {
+        const unsigned int initial_pop = POP_SIZE * static_cast<unsigned int>(pow(2, step));
+        const unsigned int next_pop = POP_SIZE * static_cast<unsigned int>(pow(2, step+1));
+        for (unsigned int i = initial_pop; i < next_pop; ++i) {
+            int x1 = pop1.getInstanceAt(i).getVariable<int>("x");
+            int x2 = pop2.getInstanceAt(i).getVariable<int>("x");
+            int x3 = pop3.getInstanceAt(i).getVariable<int>("x");
+            ASSERT_EQ(x1, 9 - (step * 2));
+            ASSERT_EQ(x2, 9 - (step * 2));
+            ASSERT_EQ(x3, 9 - (step * 2));
+        }
+    }
+}
+FLAMEGPU_AGENT_FUNCTION_CONDITION(AllowEvenOnly) {
+    return FLAMEGPU->getVariable<int>("x")%2 == 0;
+}
+TEST(MultiThreadDeviceTest, SameModelSeperateThread_AgentFunctionCondition) {
+    const unsigned int POP_SIZE = 10000;
+    // The purpose of this test is to try and catch whether CURVE will hit collisions if two identical models execute at the same time.
+    // Success of this test does not mean there isn't a problem
+    // This test covers agent variable set/get within agent function conditions
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<int>("x", 0);
+    a.newFunction(FUNCTION_NAME1, SlowFn).setFunctionCondition(AllowEvenOnly);
+    a.newFunction(FUNCTION_NAME2, FastFn);
+    m.newLayer().addAgentFunction(SlowFn);
+    m.newLayer().addAgentFunction(FastFn);
+
+    m.Environment().newProperty<int>("ten thousand", 10000);
+    m.Environment().newProperty<int>("zero", 0);
+
+    AgentPopulation pop_in1(a, POP_SIZE);
+    AgentPopulation pop_in2(a, POP_SIZE);
+    AgentPopulation pop_in3(a, POP_SIZE);
+    for (unsigned int i = 0; i < POP_SIZE; ++i) {
+        pop_in1.getNextInstance().setVariable<int>("x", 1);
+        pop_in2.getNextInstance().setVariable<int>("x", 2);
+        pop_in3.getNextInstance().setVariable<int>("x", 3);
+    }
+
+    CUDASimulation sim1(m);
+    sim1.SimulationConfig().steps = 10;
+    sim1.setPopulationData(pop_in1);
+    CUDASimulation sim2(m);
+    sim2.SimulationConfig().steps = 10;
+    sim2.setPopulationData(pop_in2);
+    CUDASimulation sim3(m);
+    sim3.SimulationConfig().steps = 10;
+    sim3.setPopulationData(pop_in3);
+
+    bool has_error_1 = false, has_error_2 = false, has_error_3 = false;
+    std::thread thread1(runSim, std::ref(sim1), std::ref(has_error_1));
+    std::thread thread2(runSim, std::ref(sim2), std::ref(has_error_2));
+    std::thread thread3(runSim, std::ref(sim3), std::ref(has_error_3));
+    // synchronize threads:
+    thread1.join();
+    thread2.join();
+    thread3.join();
+    // Check exceptions
+    ASSERT_FALSE(has_error_1);
+    ASSERT_FALSE(has_error_2);
+    ASSERT_FALSE(has_error_3);
+    // Check results
+    AgentPopulation pop1(a, POP_SIZE);
+    AgentPopulation pop2(a, POP_SIZE);
+    AgentPopulation pop3(a, POP_SIZE);
+    sim1.getPopulationData(pop1);
+    sim2.getPopulationData(pop2);
+    sim3.getPopulationData(pop3);
+    // Use expect, rather than assert for first 3 agents.
+    for (unsigned int i = 0; i < 3; ++i) {
+        int x1 = pop1.getInstanceAt(i).getVariable<int>("x");
+        int x2 = pop2.getInstanceAt(i).getVariable<int>("x");
+        int x3 = pop3.getInstanceAt(i).getVariable<int>("x");
+        // 1, +1, +2*9
+        // 2, +2*10
+        // 3, +1, +2*9
+        EXPECT_EQ(x1, 20);
+        EXPECT_EQ(x2, 22);
+        EXPECT_EQ(x3, 22);
+    }
+    for (unsigned int i = 3; i < POP_SIZE; ++i) {
+        int x1 = pop1.getInstanceAt(i).getVariable<int>("x");
+        int x2 = pop2.getInstanceAt(i).getVariable<int>("x");
+        int x3 = pop3.getInstanceAt(i).getVariable<int>("x");
+        // 5 steps with 1x +1, 1x +2 each.
+        ASSERT_EQ(x1, 20);
+        ASSERT_EQ(x2, 22);
+        ASSERT_EQ(x3, 22);
+    }
+}
+void initRunSim(std::shared_ptr<CUDASimulation> sim, const AgentDescription &a, int offset, int device, unsigned int POP_SIZE, int &exception_thrown, int steps = 10) {
+    exception_thrown = 0;
+    try {
+        AgentPopulation pop_in(a, POP_SIZE);
+        for (unsigned int i = 0; i < POP_SIZE; ++i) {
+            pop_in.getNextInstance().setVariable<int>("x", offset);
+        }
+        sim->SimulationConfig().steps = steps;
+        sim->CUDAConfig().device_id = device;
+        sim->applyConfig();
+        sim->setPopulationData(pop_in);
+        sim->simulate();
+    } catch(std::exception &e) {
+        exception_thrown = 1;
+        printf("%s\n", e.what());
+    }
+}
+TEST(MultiThreadDeviceTest, SameModelMultiDevice_Agent) {
+    const unsigned int POP_SIZE = 10000;
+    const int SIMS_PER_DEVICE = 3;
+    const int STEPS = 10;
+    // The purpose of this test is to try and catch whether CURVE will hit collisions if two identical models execute at the same time.
+    // Success of this test does not mean there isn't a problem
+    // This test covers agent variable set/get
+
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<int>("x", 0);
+    a.newFunction(FUNCTION_NAME1, SlowFn);
+    a.newFunction(FUNCTION_NAME2, FastFn);
+    m.newLayer().addAgentFunction(SlowFn);
+    m.newLayer().addAgentFunction(FastFn);
+
+    m.Environment().newProperty<int>("ten thousand", 10000);
+    m.Environment().newProperty<int>("zero", 0);
+
+    int devices = 0;
+    if (cudaSuccess != cudaGetDeviceCount(&devices) || devices <= 0) {
+        // Skip the test, if no CUDA or GPUs.
+        return;
+    }
+    std::vector<std::shared_ptr<CUDASimulation>> sims;
+    sims.reserve(devices * 3);
+    std::vector<int> results;
+    results.reserve(devices * 3);
+    std::vector<std::thread> threads;
+    int offset = 0;
+    // For each device
+    for (int device = 0; device < devices; ++device) {
+        // If built with a suitable compute capability
+        if (util::compute_capability::checkComputeCapability(device)) {
+            for (int i = 0; i < SIMS_PER_DEVICE; ++i) {
+                // Set sim Running
+                sims.emplace(sims.end(), std::make_shared<CUDASimulation>(m));
+                results.push_back(false);
+                auto thread = std::thread(initRunSim, std::ref(sims[offset]), std::ref(a), offset, device, POP_SIZE, std::ref(results[offset]), STEPS);
+                threads.push_back(std::move(thread));
+                // Use this version for debugging without threads
+                // initRunSim(std::ref(sims[offset]), std::ref(a), offset, device, POP_SIZE, std::ref(results[offset]));
+                offset++;
+            }
+        }
+    }
+    // Wait for all to finish
+    for (auto &th : threads) {
+        th.join();
+    }
+    AgentPopulation pop(a, POP_SIZE);
+    // Check results
+    for (unsigned int i = 0; i < results.size(); ++i) {
+        // Check exceptions
+        ASSERT_FALSE(results[i]);
+        // Get agent data
+        ASSERT_EQ(cudaSetDevice(sims[i]->CUDAConfig().device_id), cudaSuccess);
+        sims[i]->getPopulationData(pop);
+        for (unsigned int j = 0; j < POP_SIZE; ++j) {
+            int x = pop.getInstanceAt(j).getVariable<int>("x");
+            ASSERT_EQ(x, static_cast<int>(2 * STEPS + i));
+        }
+    }
+    ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+}
+TEST(MultiThreadDeviceTest, SameModelMultiDevice_Message) {
+    const unsigned int POP_SIZE = 10000;
+    const int SIMS_PER_DEVICE = 3;
+    const int STEPS = 10;
+    // The purpose of this test is to try and catch whether CURVE will hit collisions if two identical models execute at the same time.
+    // Success of this test does not mean there isn't a problem
+    // This test covers agent variable set/get
+
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    MsgBruteForce::Description &msg = m.newMessage(MESSAGE_NAME);
+    msg.newVariable<int>("x");
+    a.newVariable<int>("x", 0);
+    a.newFunction(FUNCTION_NAME1, FastFnMsg).setMessageOutput(msg);
+    a.newFunction(FUNCTION_NAME2, SlowFnMsg).setMessageInput(msg);
+    m.newLayer().addAgentFunction(FastFnMsg);
+    m.newLayer().addAgentFunction(SlowFnMsg);
+
+    int devices = 0;
+    if (cudaSuccess != cudaGetDeviceCount(&devices) || devices <= 0) {
+        // Skip the test, if no CUDA or GPUs.
+        return;
+    }
+    std::vector<std::shared_ptr<CUDASimulation>> sims;
+    sims.reserve(devices * 3);
+    std::vector<int> results;
+    results.reserve(devices * 3);
+    std::vector<std::thread> threads;
+    int offset = 0;
+    // For each device
+    for (int device = 0; device < devices; ++device) {
+        // If built with a suitable compute capability
+        if (util::compute_capability::checkComputeCapability(device)) {
+            for (int i = 0; i < SIMS_PER_DEVICE; ++i) {
+                // Set sim Running
+                sims.emplace(sims.end(), std::make_shared<CUDASimulation>(m));
+                results.push_back(false);
+                auto thread = std::thread(initRunSim, std::ref(sims[offset]), std::ref(a), offset, device, POP_SIZE, std::ref(results[offset]), STEPS);
+                threads.push_back(std::move(thread));
+                // Use this version for debugging without threads
+                // initRunSim(std::ref(sims[offset]), std::ref(a), offset, device, POP_SIZE, std::ref(results[offset]));
+                offset++;
+            }
+        }
+    }
+    // Wait for all to finish
+    for (auto &th : threads) {
+        th.join();
+    }
+    AgentPopulation pop(a, POP_SIZE);
+    // Check results
+    for (unsigned int i = 0; i < results.size(); ++i) {
+        // Check exceptions
+        ASSERT_FALSE(results[i]);
+        // Get agent data
+        ASSERT_EQ(cudaSetDevice(sims[i]->CUDAConfig().device_id), cudaSuccess);
+        sims[i]->getPopulationData(pop);
+        for (unsigned int j = 0; j < POP_SIZE; ++j) {
+            int x = pop.getInstanceAt(j).getVariable<int>("x");
+            ASSERT_EQ(x, static_cast<int>(POP_SIZE * STEPS + i));
+        }
+    }
+    ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+}
+TEST(MultiThreadDeviceTest, SameModelMultiDevice_Environment) {
+    const unsigned int POP_SIZE = 10000;
+    const int SIMS_PER_DEVICE = 10;
+    const int STEPS = 10;
+    const int MAX_DEVICES = 4;
+    // The purpose of this test is to try and catch whether CURVE will hit collisions if two identical models execute at the same time.
+    // Success of this test does not mean there isn't a problem
+    // This test covers agent variable set/get
+
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<int>("x", 0);
+    a.newFunction(FUNCTION_NAME1, SlowFn2);
+    a.newFunction(FUNCTION_NAME2, FastFn2);
+    m.newLayer().addAgentFunction(SlowFn2);
+    m.newLayer().addAgentFunction(FastFn2);
+
+    m.Environment().newProperty<int>("ten thousand", 10000);
+    m.Environment().newProperty<int>("zero", 0);
+    m.Environment().newProperty<int>("one", 1);
+    m.Environment().newProperty<int>("three", 3);
+
+    int devices = 0;
+    if (cudaSuccess != cudaGetDeviceCount(&devices) || devices <= 0) {
+        // Skip the test, if no CUDA or GPUs.
+        return;
+    }
+    devices = devices > MAX_DEVICES ? MAX_DEVICES : devices;
+    // BEGIN: Attempt to pre init contexts
+    for (int device = 0; device < devices; ++device) {
+        ASSERT_EQ(cudaSetDevice(device), cudaSuccess);
+        ASSERT_EQ(cudaFree(nullptr), cudaSuccess);
+    }
+    ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+    // END: Attempt to pre init contexts
+    std::vector<std::shared_ptr<CUDASimulation>> sims;
+    sims.reserve(devices * SIMS_PER_DEVICE);
+    std::vector<int> results;
+    results.reserve(devices * SIMS_PER_DEVICE);
+    std::vector<std::thread> threads;
+    int offset = 0;
+    // For each device
+    for (int device = 0; device < devices; ++device) {
+        // If built with a suitable compute capability
+        if (util::compute_capability::checkComputeCapability(device)) {
+            for (int i = 0; i < SIMS_PER_DEVICE; ++i) {
+                // Set sim Running
+                m.Environment().setProperty<int>("one", 1 * (offset + 1));
+                m.Environment().setProperty<int>("three", 3 * (offset + 1));
+                sims.emplace(sims.end(), std::make_shared<CUDASimulation>(m));
+                results.push_back(false);
+                auto thread = std::thread(initRunSim, std::ref(sims[offset]), std::ref(a), offset, device, POP_SIZE, std::ref(results[offset]), STEPS);
+                threads.push_back(std::move(thread));
+                // Use this version for debugging without threads
+                // initRunSim(std::ref(sims[offset]), std::ref(a), offset, device, POP_SIZE, std::ref(results[offset]));
+                offset++;
+            }
+        }
+    }
+    // Wait for all to finish
+    for (auto &th : threads) {
+        th.join();
+    }
+    AgentPopulation pop(a, POP_SIZE);
+    // Check results
+    for (unsigned int i = 0; i < results.size(); ++i) {
+        // Check exceptions
+        ASSERT_FALSE(results[i]);
+        // Get agent data
+        ASSERT_EQ(cudaSetDevice(sims[i]->CUDAConfig().device_id), cudaSuccess);
+        sims[i]->getPopulationData(pop);
+        int bad = 0;
+        int x = static_cast<int>(4 * STEPS * (i + 1) + i);
+        for (unsigned int j = 0; j < POP_SIZE; ++j) {
+            x = pop.getInstanceAt(j).getVariable<int>("x");
+            if (x != static_cast<int>(4 * STEPS * (i + 1) + i)) {
+                bad++;
+            }
+        }
+        if (bad > 0) {
+            printf("Device: %d, Thread: %d: %d failures.   Expected: %d, Received: %d\n", sims[i]->CUDAConfig().device_id, i%SIMS_PER_DEVICE, bad, static_cast<int>(4 * STEPS * (i + 1) + i), x);
+        }
+    }
+    for (unsigned int i = 0; i < results.size(); ++i) {
+        // Check exceptions
+        ASSERT_FALSE(results[i]);
+        // Get agent data
+        ASSERT_EQ(cudaSetDevice(sims[i]->CUDAConfig().device_id), cudaSuccess);
+        sims[i]->getPopulationData(pop);
+        for (unsigned int j = 0; j < POP_SIZE; ++j) {
+            int x = pop.getInstanceAt(j).getVariable<int>("x");
+            ASSERT_EQ(x, static_cast<int>(4 * STEPS * (i + 1) + i));
+        }
+    }
+    ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+}
+TEST(MultiThreadDeviceTest, SameModelMultiDevice_AgentOutput) {
+    const unsigned int POP_SIZE = 1000;
+    const int SIMS_PER_DEVICE = 3;
+    const int STEPS = 5;
+    // The purpose of this test is to try and catch whether CURVE will hit collisions if two identical models execute at the same time.
+    // Success of this test does not mean there isn't a problem
+    // This test covers agent variable set/get
+
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<int>("x", 0);
+    a.newFunction(FUNCTION_NAME1, SlowFn3).setAgentOutput(a);
+    a.newFunction(FUNCTION_NAME2, FastFn);
+    m.newLayer().addAgentFunction(SlowFn3);
+    m.newLayer().addAgentFunction(FastFn);
+
+    m.Environment().newProperty<int>("ten thousand", 10000);
+    m.Environment().newProperty<int>("zero", 0);
+
+    int devices = 0;
+    if (cudaSuccess != cudaGetDeviceCount(&devices) || devices <= 0) {
+        // Skip the test, if no CUDA or GPUs.
+        return;
+    }
+    std::vector<std::shared_ptr<CUDASimulation>> sims;
+    sims.reserve(devices * 3);
+    std::vector<int> results;
+    results.reserve(devices * 3);
+    std::vector<std::thread> threads;
+    int offset = 0;
+    // For each device
+    for (int device = 0; device < devices; ++device) {
+        // If built with a suitable compute capability
+        if (util::compute_capability::checkComputeCapability(device)) {
+            for (int i = 0; i < SIMS_PER_DEVICE; ++i) {
+                // Set sim Running
+                sims.emplace(sims.end(), std::make_shared<CUDASimulation>(m));
+                results.push_back(false);
+                auto thread = std::thread(initRunSim, std::ref(sims[offset]), std::ref(a), offset, device, POP_SIZE, std::ref(results[offset]), STEPS);
+                threads.push_back(std::move(thread));
+                // Use this version for debugging without threads
+                // initRunSim(std::ref(sims[offset]), std::ref(a), offset, device, POP_SIZE, std::ref(results[offset]));
+                offset++;
+            }
+        }
+    }
+    // Wait for all to finish
+    for (auto &th : threads) {
+        th.join();
+    }
+    AgentPopulation pop(a, POP_SIZE);
+    // Check results
+    for (unsigned int i = 0; i < results.size(); ++i) {
+        // Check exceptions
+        ASSERT_FALSE(results[i]);
+        // Get agent data
+        ASSERT_EQ(cudaSetDevice(sims[i]->CUDAConfig().device_id), cudaSuccess);
+        sims[i]->getPopulationData(pop);
+        for (unsigned int j = 0; j < POP_SIZE; ++j) {
+            int x = pop.getInstanceAt(j).getVariable<int>("x");
+            // 5 steps with 2x +1 each.
+            ASSERT_EQ(x, static_cast<int>(10 + i));
+        }
+        // Check all the new agents
+        for (int step = 0; step < STEPS; ++step) {
+            const unsigned int initial_pop = POP_SIZE * static_cast<unsigned int>(pow(2, step));
+            const unsigned int next_pop = POP_SIZE * static_cast<unsigned int>(pow(2, step+1));
+            for (unsigned int j = initial_pop; j < next_pop; ++j) {
+                int x = pop.getInstanceAt(j).getVariable<int>("x");
+                ASSERT_EQ(x, 9 - (step * 2));
+            }
+        }
+    }
+    ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+}
+TEST(MultiThreadDeviceTest, SameModelMultiDevice_AgentFunctionCondition) {
+    const unsigned int POP_SIZE = 10000;
+    const int SIMS_PER_DEVICE = 3;
+    const int STEPS = 10;
+    // The purpose of this test is to try and catch whether CURVE will hit collisions if two identical models execute at the same time.
+    // Success of this test does not mean there isn't a problem
+    // This test covers agent variable set/get
+
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<int>("x", 0);
+    a.newFunction(FUNCTION_NAME1, SlowFn).setFunctionCondition(AllowEvenOnly);
+    a.newFunction(FUNCTION_NAME2, FastFn);
+    m.newLayer().addAgentFunction(SlowFn);
+    m.newLayer().addAgentFunction(FastFn);
+
+    m.Environment().newProperty<int>("ten thousand", 10000);
+    m.Environment().newProperty<int>("zero", 0);
+
+    int devices = 0;
+    if (cudaSuccess != cudaGetDeviceCount(&devices) || devices <= 0) {
+        // Skip the test, if no CUDA or GPUs.
+        return;
+    }
+    std::vector<std::shared_ptr<CUDASimulation>> sims;
+    sims.reserve(devices * 3);
+    std::vector<int> results;
+    results.reserve(devices * 3);
+    std::vector<std::thread> threads;
+    int offset = 0;
+    // For each device
+    for (int device = 0; device < devices; ++device) {
+        // If built with a suitable compute capability
+        if (util::compute_capability::checkComputeCapability(device)) {
+            for (int i = 0; i < SIMS_PER_DEVICE; ++i) {
+                // Set sim Running
+                sims.emplace(sims.end(), std::make_shared<CUDASimulation>(m));
+                results.push_back(false);
+                auto thread = std::thread(initRunSim, std::ref(sims[offset]), std::ref(a), offset, device, POP_SIZE, std::ref(results[offset]), STEPS);
+                threads.push_back(std::move(thread));
+                // Use this version for debugging without threads
+                // initRunSim(std::ref(sims[offset]), std::ref(a), offset, device, POP_SIZE, std::ref(results[offset]));
+                offset++;
+            }
+        }
+    }
+    // Wait for all to finish
+    for (auto &th : threads) {
+        th.join();
+    }
+    AgentPopulation pop(a, POP_SIZE);
+    // Check results
+    for (unsigned int i = 0; i < results.size(); ++i) {
+        // Check exceptions
+        ASSERT_FALSE(results[i]);
+        // Get agent data
+        cudaSetDevice(sims[i]->CUDAConfig().device_id);
+        sims[i]->getPopulationData(pop);
+        for (unsigned int j = 0; j < POP_SIZE; ++j) {
+            int x = pop.getInstanceAt(j).getVariable<int>("x");
+            // 0, +2*10
+            // 1, +1, +2*9
+            // 2, +2*10
+            // 3, +1, +2*9
+            if (i%2 == 0) {
+                ASSERT_EQ(x, static_cast<int>(2 * STEPS + i));
+            } else {
+                ASSERT_EQ(x, static_cast<int>(2 * STEPS - 1 + i));
+            }
+        }
+    }
+    ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+}
+}  // namespace test_multi_thread_device

--- a/tests/test_cases/util/test_rtc_multi_thread_device.cu
+++ b/tests/test_cases/util/test_rtc_multi_thread_device.cu
@@ -1,0 +1,416 @@
+#include <thread>
+#include <vector>
+#include <memory>
+
+#include "flamegpu/flame_api.h"
+#include "gtest/gtest.h"
+#include "flamegpu/util/compute_capability.cuh"
+
+namespace test_rtc_multi_thread_device {
+const char *MODEL_NAME = "Model";
+const char *AGENT_NAME = "Agent1";
+const char *MESSAGE_NAME = "Message1";
+const char *FUNCTION_NAME1 = "Fn1";
+const char *FUNCTION_NAME2 = "Fn2";
+const char* rtc_SlowFn = R"###(
+FLAMEGPU_AGENT_FUNCTION(SlowFn, MsgNone, MsgNone) {
+    int x = FLAMEGPU->getVariable<int>("x");
+    // Do nothing, just waste time. Get values from environment to prevent optimisation
+    for (int i = 0; i < FLAMEGPU->environment.getProperty<int>("ten thousand"); ++i) {
+        x += FLAMEGPU->environment.getProperty<int>("zero");
+    }
+    FLAMEGPU->setVariable<int>("x", x + 1);
+    return ALIVE;
+}
+)###";
+const char* rtc_FastFn = R"###(
+FLAMEGPU_AGENT_FUNCTION(FastFn, MsgNone, MsgNone) {
+    const int x = FLAMEGPU->getVariable<int>("x");
+    FLAMEGPU->setVariable<int>("x", x + 1);
+    return ALIVE;
+}
+)###";
+const char* rtc_SlowFnMsg = R"###(
+FLAMEGPU_AGENT_FUNCTION(SlowFnMsg, MsgBruteForce, MsgNone) {
+    int x = FLAMEGPU->getVariable<int>("x");
+    int y = 0;
+    // Do nothing, just waste time. Get values from environment to prevent optimisation
+    for (auto &m : FLAMEGPU->message_in) {
+        y += m.getVariable<int>("x");
+    }
+    FLAMEGPU->setVariable<int>("x", x + y);
+    return ALIVE;
+}
+)###";
+const char* rtc_FastFnMsg = R"###(
+FLAMEGPU_AGENT_FUNCTION(FastFnMsg, MsgNone, MsgBruteForce) {
+    const int x = FLAMEGPU->getVariable<int>("x");
+    FLAMEGPU->message_out.setVariable<int>("x", 1);
+    return ALIVE;
+}
+)###";
+const char* rtc_SlowFn2 = R"###(
+FLAMEGPU_AGENT_FUNCTION(SlowFn2, MsgNone, MsgNone) {
+    int x = FLAMEGPU->getVariable<int>("x");
+    // Do nothing, just waste time. Get values from environment to prevent optimisation
+    for (int i = 0; i < FLAMEGPU->environment.getProperty<int>("ten thousand"); ++i) {
+        x += FLAMEGPU->environment.getProperty<int>("zero");
+    }
+    FLAMEGPU->setVariable<int>("x", x + FLAMEGPU->environment.getProperty<int>("one"));
+    return ALIVE;
+}
+)###";
+const char* rtc_FastFn2 = R"###(
+FLAMEGPU_AGENT_FUNCTION(FastFn2, MsgNone, MsgNone) {
+    const int x = FLAMEGPU->getVariable<int>("x");
+    FLAMEGPU->setVariable<int>("x", x + FLAMEGPU->environment.getProperty<int>("three"));
+    return ALIVE;
+}
+)###";
+const char* rtc_SlowFn3 = R"###(
+FLAMEGPU_AGENT_FUNCTION(SlowFn3, MsgNone, MsgNone) {
+    int x = FLAMEGPU->getVariable<int>("x");
+    // Do nothing, just waste time. Get values from environment to prevent optimisation
+    for (int i = 0; i < FLAMEGPU->environment.getProperty<int>("ten thousand"); ++i) {
+        x += FLAMEGPU->environment.getProperty<int>("zero");
+    }
+    FLAMEGPU->setVariable<int>("x", x + 1);
+    FLAMEGPU->agent_out.setVariable<int>("x", 0);
+    return ALIVE;
+}
+)###";
+const char* rtc_AllowEvenOnly = R"###(
+FLAMEGPU_AGENT_FUNCTION_CONDITION(AllowEvenOnly) {
+    return FLAMEGPU->getVariable<int>("x")%2 == 0;
+}
+)###";
+void initRunSim(std::shared_ptr<CUDASimulation> sim, const AgentDescription &a, int offset, int device, unsigned int POP_SIZE, int &exception_thrown, int steps = 10) {
+    exception_thrown = 0;
+    try {
+        AgentPopulation pop_in(a, POP_SIZE);
+        for (unsigned int i = 0; i < POP_SIZE; ++i) {
+            pop_in.getNextInstance().setVariable<int>("x", offset);
+        }
+        sim->SimulationConfig().steps = steps;
+        sim->CUDAConfig().device_id = device;
+        sim->applyConfig();
+        sim->setPopulationData(pop_in);
+        sim->simulate();
+    } catch(std::exception &e) {
+        exception_thrown = 1;
+        printf("%s\n", e.what());
+    }
+}
+TEST(RTCMultiThreadDeviceTest, SameModelMultiDevice_Message) {
+    const unsigned int POP_SIZE = 10000;
+    const int SIMS_PER_DEVICE = 3;
+    const int STEPS = 10;
+    // The purpose of this test is to try and catch whether CURVE will hit collisions if two identical models execute at the same time.
+    // Success of this test does not mean there isn't a problem
+    // This test covers agent variable set/get
+
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    MsgBruteForce::Description &msg = m.newMessage(MESSAGE_NAME);
+    msg.newVariable<int>("x");
+    a.newVariable<int>("x", 0);
+    auto &fn1 = a.newRTCFunction(FUNCTION_NAME1, rtc_FastFnMsg);
+    auto &fn2 = a.newRTCFunction(FUNCTION_NAME2, rtc_SlowFnMsg);
+    fn1.setMessageOutput(msg);
+    fn2.setMessageInput(msg);
+    m.newLayer().addAgentFunction(fn1);
+    m.newLayer().addAgentFunction(fn2);
+
+    int devices = 0;
+    if (cudaSuccess != cudaGetDeviceCount(&devices) || devices <= 0) {
+        // Skip the test, if no CUDA or GPUs.
+        return;
+    }
+    std::vector<std::shared_ptr<CUDASimulation>> sims;
+    sims.reserve(devices * 3);
+    std::vector<int> results;
+    results.reserve(devices * 3);
+    std::vector<std::thread> threads;
+    int offset = 0;
+    // For each device
+    for (int device = 0; device < devices; ++device) {
+        // If built with a suitable compute capability
+        if (util::compute_capability::checkComputeCapability(device)) {
+            for (int i = 0; i < SIMS_PER_DEVICE; ++i) {
+                // Set sim Running
+                sims.emplace(sims.end(), std::make_shared<CUDASimulation>(m));
+                results.push_back(false);
+                auto thread = std::thread(initRunSim, std::ref(sims[offset]), std::ref(a), offset, device, POP_SIZE, std::ref(results[offset]), STEPS);
+                threads.push_back(std::move(thread));
+                // Use this version for debugging without threads
+                // initRunSim(std::ref(sims[offset]), std::ref(a), offset, device, POP_SIZE, std::ref(results[offset]));
+                offset++;
+            }
+        }
+    }
+    // Wait for all to finish
+    for (auto &th : threads) {
+        th.join();
+    }
+    AgentPopulation pop(a, POP_SIZE);
+    // Check results
+    for (unsigned int i = 0; i < results.size(); ++i) {
+        // Check exceptions
+        ASSERT_FALSE(results[i]);
+        // Get agent data
+        ASSERT_EQ(cudaSetDevice(sims[i]->CUDAConfig().device_id), cudaSuccess);
+        sims[i]->getPopulationData(pop);
+        for (unsigned int j = 0; j < POP_SIZE; ++j) {
+            int x = pop.getInstanceAt(j).getVariable<int>("x");
+            ASSERT_EQ(x, static_cast<int>(POP_SIZE * STEPS + i));
+        }
+    }
+    ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+}
+TEST(RTCMultiThreadDeviceTest, SameModelMultiDevice_Environment) {
+    const unsigned int POP_SIZE = 10000;
+    const int SIMS_PER_DEVICE = 3;
+    const int STEPS = 10;
+    const int MAX_DEVICES = 4;
+    // The purpose of this test is to try and catch whether CURVE will hit collisions if two identical models execute at the same time.
+    // Success of this test does not mean there isn't a problem
+    // This test covers agent variable set/get
+
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<int>("x", 0);
+    auto &fn1 = a.newRTCFunction(FUNCTION_NAME1, rtc_SlowFn2);
+    auto &fn2 = a.newRTCFunction(FUNCTION_NAME2, rtc_FastFn2);
+    m.newLayer().addAgentFunction(fn1);
+    m.newLayer().addAgentFunction(fn2);
+
+    m.Environment().newProperty<int>("ten thousand", 10000);
+    m.Environment().newProperty<int>("zero", 0);
+    m.Environment().newProperty<int>("one", 1);
+    m.Environment().newProperty<int>("three", 3);
+
+    int devices = 0;
+    if (cudaSuccess != cudaGetDeviceCount(&devices) || devices <= 0) {
+        // Skip the test, if no CUDA or GPUs.
+        return;
+    }
+    devices = devices > MAX_DEVICES ? MAX_DEVICES : devices;
+    // BEGIN: Attempt to pre init contexts
+    for (int device = 0; device < devices; ++device) {
+        ASSERT_EQ(cudaSetDevice(device), cudaSuccess);
+        ASSERT_EQ(cudaFree(nullptr), cudaSuccess);
+    }
+    ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+    // END: Attempt to pre init contexts
+    std::vector<std::shared_ptr<CUDASimulation>> sims;
+    sims.reserve(devices * SIMS_PER_DEVICE);
+    std::vector<int> results;
+    results.reserve(devices * SIMS_PER_DEVICE);
+    std::vector<std::thread> threads;
+    int offset = 0;
+    // For each device
+    for (int device = 0; device < devices; ++device) {
+        // If built with a suitable compute capability
+        if (util::compute_capability::checkComputeCapability(device)) {
+            for (int i = 0; i < SIMS_PER_DEVICE; ++i) {
+                // Set sim Running
+                m.Environment().setProperty<int>("one", 1 * (offset + 1));
+                m.Environment().setProperty<int>("three", 3 * (offset + 1));
+                sims.emplace(sims.end(), std::make_shared<CUDASimulation>(m));
+                results.push_back(false);
+                auto thread = std::thread(initRunSim, std::ref(sims[offset]), std::ref(a), offset, device, POP_SIZE, std::ref(results[offset]), STEPS);
+                threads.push_back(std::move(thread));
+                // Use this version for debugging without threads
+                // initRunSim(std::ref(sims[offset]), std::ref(a), offset, device, POP_SIZE, std::ref(results[offset]));
+                offset++;
+            }
+        }
+    }
+    // Wait for all to finish
+    for (auto &th : threads) {
+        th.join();
+    }
+    AgentPopulation pop(a, POP_SIZE);
+    // Check results
+    for (unsigned int i = 0; i < results.size(); ++i) {
+        // Check exceptions
+        ASSERT_FALSE(results[i]);
+        // Get agent data
+        ASSERT_EQ(cudaSetDevice(sims[i]->CUDAConfig().device_id), cudaSuccess);
+        sims[i]->getPopulationData(pop);
+        int bad = 0;
+        int x = static_cast<int>(4 * STEPS * (i + 1) + i);
+        for (unsigned int j = 0; j < POP_SIZE; ++j) {
+            x = pop.getInstanceAt(j).getVariable<int>("x");
+            if (x != static_cast<int>(4 * STEPS * (i + 1) + i)) {
+                bad++;
+            }
+        }
+        if (bad > 0) {
+            printf("Device: %d, Thread: %d: %d failures.   Expected: %d, Received: %d\n", sims[i]->CUDAConfig().device_id, i%SIMS_PER_DEVICE, bad, static_cast<int>(4 * STEPS * (i + 1) + i), x);
+        }
+    }
+    for (unsigned int i = 0; i < results.size(); ++i) {
+        // Check exceptions
+        ASSERT_FALSE(results[i]);
+        // Get agent data
+        ASSERT_EQ(cudaSetDevice(sims[i]->CUDAConfig().device_id), cudaSuccess);
+        sims[i]->getPopulationData(pop);
+        for (unsigned int j = 0; j < POP_SIZE; ++j) {
+            int x = pop.getInstanceAt(j).getVariable<int>("x");
+            ASSERT_EQ(x, static_cast<int>(4 * STEPS * (i + 1) + i));
+        }
+    }
+    ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+}
+TEST(RTCMultiThreadDeviceTest, SameModelMultiDevice_AgentOutput) {
+    const unsigned int POP_SIZE = 1000;
+    const int SIMS_PER_DEVICE = 3;
+    const int STEPS = 5;
+    // The purpose of this test is to try and catch whether CURVE will hit collisions if two identical models execute at the same time.
+    // Success of this test does not mean there isn't a problem
+    // This test covers agent variable set/get
+
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<int>("x", 0);
+    auto &fn1 = a.newRTCFunction(FUNCTION_NAME1, rtc_SlowFn3);
+    auto &fn2 = a.newRTCFunction(FUNCTION_NAME2, rtc_FastFn);
+    fn1.setAgentOutput(a);
+    m.newLayer().addAgentFunction(fn1);
+    m.newLayer().addAgentFunction(fn2);
+
+    m.Environment().newProperty<int>("ten thousand", 10000);
+    m.Environment().newProperty<int>("zero", 0);
+
+    int devices = 0;
+    if (cudaSuccess != cudaGetDeviceCount(&devices) || devices <= 0) {
+        // Skip the test, if no CUDA or GPUs.
+        return;
+    }
+    std::vector<std::shared_ptr<CUDASimulation>> sims;
+    sims.reserve(devices * 3);
+    std::vector<int> results;
+    results.reserve(devices * 3);
+    std::vector<std::thread> threads;
+    int offset = 0;
+    // For each device
+    for (int device = 0; device < devices; ++device) {
+        // If built with a suitable compute capability
+        if (util::compute_capability::checkComputeCapability(device)) {
+            for (int i = 0; i < SIMS_PER_DEVICE; ++i) {
+                // Set sim Running
+                sims.emplace(sims.end(), std::make_shared<CUDASimulation>(m));
+                results.push_back(false);
+                auto thread = std::thread(initRunSim, std::ref(sims[offset]), std::ref(a), offset, device, POP_SIZE, std::ref(results[offset]), STEPS);
+                threads.push_back(std::move(thread));
+                // Use this version for debugging without threads
+                // initRunSim(std::ref(sims[offset]), std::ref(a), offset, device, POP_SIZE, std::ref(results[offset]));
+                offset++;
+            }
+        }
+    }
+    // Wait for all to finish
+    for (auto &th : threads) {
+        th.join();
+    }
+    AgentPopulation pop(a, POP_SIZE);
+    // Check results
+    for (unsigned int i = 0; i < results.size(); ++i) {
+        // Check exceptions
+        ASSERT_FALSE(results[i]);
+        // Get agent data
+        ASSERT_EQ(cudaSetDevice(sims[i]->CUDAConfig().device_id), cudaSuccess);
+        sims[i]->getPopulationData(pop);
+        for (unsigned int j = 0; j < POP_SIZE; ++j) {
+            int x = pop.getInstanceAt(j).getVariable<int>("x");
+            // 5 steps with 2x +1 each.
+            ASSERT_EQ(x, static_cast<int>(10 + i));
+        }
+        // Check all the new agents
+        for (int step = 0; step < STEPS; ++step) {
+            const unsigned int initial_pop = POP_SIZE * static_cast<unsigned int>(pow(2, step));
+            const unsigned int next_pop = POP_SIZE * static_cast<unsigned int>(pow(2, step+1));
+            for (unsigned int j = initial_pop; j < next_pop; ++j) {
+                int x = pop.getInstanceAt(j).getVariable<int>("x");
+                ASSERT_EQ(x, 9 - (step * 2));
+            }
+        }
+    }
+    ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+}
+TEST(RTCMultiThreadDeviceTest, SameModelMultiDevice_AgentFunctionCondition) {
+    const unsigned int POP_SIZE = 10000;
+    const int SIMS_PER_DEVICE = 3;
+    const int STEPS = 10;
+    // The purpose of this test is to try and catch whether CURVE will hit collisions if two identical models execute at the same time.
+    // Success of this test does not mean there isn't a problem
+    // This test covers agent variable set/get
+
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<int>("x", 0);
+    auto &fn1 = a.newRTCFunction(FUNCTION_NAME1, rtc_SlowFn);
+    auto &fn2 = a.newRTCFunction(FUNCTION_NAME2, rtc_FastFn);
+    fn1.setRTCFunctionCondition(rtc_AllowEvenOnly);
+    m.newLayer().addAgentFunction(fn1);
+    m.newLayer().addAgentFunction(fn2);
+
+    m.Environment().newProperty<int>("ten thousand", 10000);
+    m.Environment().newProperty<int>("zero", 0);
+
+    int devices = 0;
+    if (cudaSuccess != cudaGetDeviceCount(&devices) || devices <= 0) {
+        // Skip the test, if no CUDA or GPUs.
+        return;
+    }
+    std::vector<std::shared_ptr<CUDASimulation>> sims;
+    sims.reserve(devices * 3);
+    std::vector<int> results;
+    results.reserve(devices * 3);
+    std::vector<std::thread> threads;
+    int offset = 0;
+    // For each device
+    for (int device = 0; device < devices; ++device) {
+        // If built with a suitable compute capability
+        if (util::compute_capability::checkComputeCapability(device)) {
+            for (int i = 0; i < SIMS_PER_DEVICE; ++i) {
+                // Set sim Running
+                sims.emplace(sims.end(), std::make_shared<CUDASimulation>(m));
+                results.push_back(false);
+                auto thread = std::thread(initRunSim, std::ref(sims[offset]), std::ref(a), offset, device, POP_SIZE, std::ref(results[offset]), STEPS);
+                threads.push_back(std::move(thread));
+                // Use this version for debugging without threads
+                // initRunSim(std::ref(sims[offset]), std::ref(a), offset, device, POP_SIZE, std::ref(results[offset]));
+                offset++;
+            }
+        }
+    }
+    // Wait for all to finish
+    for (auto &th : threads) {
+        th.join();
+    }
+    AgentPopulation pop(a, POP_SIZE);
+    // Check results
+    for (unsigned int i = 0; i < results.size(); ++i) {
+        // Check exceptions
+        ASSERT_FALSE(results[i]);
+        // Get agent data
+        cudaSetDevice(sims[i]->CUDAConfig().device_id);
+        sims[i]->getPopulationData(pop);
+        for (unsigned int j = 0; j < POP_SIZE; ++j) {
+            int x = pop.getInstanceAt(j).getVariable<int>("x");
+            // 0, +2*10
+            // 1, +1, +2*9
+            // 2, +2*10
+            // 3, +1, +2*9
+            if (i%2 == 0) {
+                ASSERT_EQ(x, static_cast<int>(2 * STEPS + i));
+            } else {
+                ASSERT_EQ(x, static_cast<int>(2 * STEPS - 1 + i));
+            }
+        }
+    }
+    ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+}
+}  // namespace test_rtc_multi_thread_device


### PR DESCRIPTION
**ToDo**
- [x] Make `EnvironmentManager` thread-safe
- [x] Make `Curve` thread-safe
- [x] Encode `CudaSimulation` instance id, into Curve hashes.
- [x] Make `EnvironmentManager` multi-device aware
- [x] Make `Curve` multi-device aware
- [x] Make `CUDASimulation` multi-device aware
    * *It contains a runtime check which purges device data if it is detected corrupted, changing device currently breaks this.*
- [x] Add nvcc arg `--default-stream per-thread` to CMake
     * https://developer.nvidia.com/blog/gpu-pro-tip-cuda-7-streams-simplify-concurrency/
* Fix RTC
    - [x] Does the dynamic header need changing (or will it for ensembles)
    * ~I think Pete said jitify complains about compiling in anything other than the main thread,~ *(RTC compile works, doesn't print any warning it's just noticeably slower)*
* Write a bunch of test cases to ensure model integrity isn't harmed during multi device/thread `CUDASimulation` execution.
    * multi-threaded
        - [x] Agent set/getVariable
        - [x] MessageIn getVariable
        - [x] MessageOut setVariable
        - [x] AgentOut setVariable
        - [x] Environment getProperty
        - [x] AgentFunctionCondition Agent getProperty
    * multi-device
        - [x] Agent set/getVariable
        - [x] MessageIn getVariable
        - [x] MessageOut setVariable
        - [x] AgentOut setVariable
        - [x] Environment getProperty
        - [x] AgentFunctionCondition Agent  getProperty
    * RTC multi-device
        - [x] Agent set/getVariable
        - [x] MessageIn getVariable
        - [x] MessageOut setVariable
        - [x] AgentOut setVariable
        - [x] Environment getProperty
        - [x] AgentFunctionCondition Agent  getProperty
- [x] Regular tests work
- [x] RTC tests work
- [x] Reset `tests_dev` cmake

**ChangeLog**
* Make `Curve` singleton thread-safe and unique per-device
* Make `EnvironmentManager` singleton thread-safe and unique per-device
* Add mutex locks around agent function execution, to prevent environment data getting changed by defragment during before execution).
* Add nvcc arg `--default-stream per-thread` to CMake  (and then comment out as it would require far more testing)
* Fix double inclusion of `common.cmake` if configuring with an example as root.
* Modify initialisation of `CUDASimulation` so that `EnvironmentManager` is not used before device has been selected.
* Add tests for multi-threading and multi-device `CUDASimulation` execution.
* Adds a reduced set of multi-thread and multi-device tests for RTC.
* Fix a bug, where rtc_offsets were reset to 0 when `EnvironmentManager:defragment()` was called.

**Known Issues**
*  Curve collision handling (#356) is often triggered if running new tests for multi-device mode. The state of this is dependent on the order of test execution and the number of devices within the machine. This is due to the `CUDASimulation` instance id incrementing each time, and this mutating the hashes used. The test does not collide in isolation, but atleast 1 test from the series always seems to collide if ran as a set. Might be trouble with hashes bunching, as there should only be a max of around 24/1024 hashes in use at any time during these tests.
* `nsys` timeline for one of the multi-device test cases, appears to show the context creation for tertiary devices waiting for CUDA to become idle on already initialised devices. Seems important to initialise CUDA on all devices before launching sims. Calling `cudaFree(nullptr)` on every device at the start of the test appears to work,
* The new compile arg `--default-stream per-thread` removes some implicit device syncs that would otherwise be expected. Very important to sync on either side of agent functions.

Relevant to #245 
Closes #395 (if done properly)