### PR TITLE
Remove code related to old Environment errors.

### DIFF
--- a/include/flamegpu/runtime/utility/DeviceEnvironment.cuh
+++ b/include/flamegpu/runtime/utility/DeviceEnvironment.cuh
@@ -6,18 +6,14 @@
 #include <string>
 #include <cassert>
 
-namespace flamegpu_internal {
 #ifndef __CUDACC_RTC__
+namespace flamegpu_internal {
     /**
      * Defined in EnvironmentManager.cu
      */
     extern __constant__ char c_envPropBuffer[EnvironmentManager::MAX_BUFFER_SIZE];
-#endif
-    /**
-     * Managed by HostEnvironment, returned whenever a failure state is reached
-     */
-    extern __constant__ uint64_t c_deviceEnvErrorPattern;
 }  // namespace flamegpu_internal
+#endif
 
 /**
  * Utility for accessing environmental properties
@@ -50,10 +46,6 @@ class DeviceEnvironment {
         : modelname_hash(_modelname_hash) { }
 
  public:
-    /**
-     * Recognisable error pattern returned by methods on failure
-     */
-    __host__ __device__ static constexpr uint64_t ERROR_PATTERN() { return 0XDEADBEEFDEAFBABEllu; }
     /**
      * Gets an environment property
      * @param name name used for accessing the property, this value should be a string literal e.g. "foobar"

--- a/src/flamegpu/runtime/cuRVE/curve_rtc.cpp
+++ b/src/flamegpu/runtime/cuRVE/curve_rtc.cpp
@@ -397,7 +397,7 @@ void CurveRTCHost::initHeaderEnvironment() {
                     // getEnvArrayVariableImpl << "              } else if (N != " << element.second.elements << ") {\n";
                     // getEnvArrayVariableImpl << "                  DTHROW(\"Environment array property '%s' length mismatch.\\n\", name);\n";
                     // getEnvArrayVariableImpl << "                  return 0;\n";
-                    getEnvArrayVariableImpl << "              } else if (index >= " << element.second.elements << "|| index < 0) {\n";
+                    getEnvArrayVariableImpl << "              } else if (index >= " << element.second.elements << ") {\n";
                     getEnvArrayVariableImpl << "                  DTHROW(\"Environment array property '%s', index %d is out of bounds.\\n\", name, index);\n";
                     getEnvArrayVariableImpl << "                  return 0;\n";
                     getEnvArrayVariableImpl << "              }\n";
@@ -534,7 +534,7 @@ void CurveRTCHost::initHeaderSetters() {
                 setAgentArrayVariableImpl << "              } else if (N != " << element.second.elements << ") {\n";
                 setAgentArrayVariableImpl << "                  DTHROW(\"Agent array variable '%s' length mismatch during setVariable().\\n\", name);\n";
                 setAgentArrayVariableImpl << "                  return;\n";
-                setAgentArrayVariableImpl << "              } else if (array_index >= " << element.second.elements << "|| array_index < 0) {\n";
+                setAgentArrayVariableImpl << "              } else if (array_index >= " << element.second.elements << ") {\n";
                 setAgentArrayVariableImpl << "                  DTHROW(\"Agent array variable '%s', index %d is out of bounds during setVariable().\\n\", name, array_index);\n";
                 setAgentArrayVariableImpl << "                  return;\n";
                 setAgentArrayVariableImpl << "              }\n";
@@ -565,7 +565,7 @@ void CurveRTCHost::initHeaderSetters() {
                 setNewAgentArrayVariableImpl << "              } else if (N != " << element.second.elements << ") {\n";
                 setNewAgentArrayVariableImpl << "                  DTHROW(\"New agent array variable '%s' length mismatch during setVariable().\\n\", name);\n";
                 setNewAgentArrayVariableImpl << "                  return;\n";
-                setNewAgentArrayVariableImpl << "              } else if (array_index >= " << element.second.elements << "|| array_index < 0) {\n";
+                setNewAgentArrayVariableImpl << "              } else if (array_index >= " << element.second.elements << ") {\n";
                 setNewAgentArrayVariableImpl << "                  DTHROW(\"New agent array variable '%s', index %d is out of bounds during setVariable().\\n\", name, array_index);\n";
                 setNewAgentArrayVariableImpl << "                  return;\n";
                 setNewAgentArrayVariableImpl << "              }\n";
@@ -690,7 +690,7 @@ void CurveRTCHost::initHeaderGetters() {
                 getAgentArrayVariableImpl << "              } else if (N != " << element.second.elements << ") {\n";
                 getAgentArrayVariableImpl << "                  DTHROW(\"Agent array variable '%s' length mismatch during getVariable().\\n\", name);\n";
                 getAgentArrayVariableImpl << "                  return 0;\n";
-                getAgentArrayVariableImpl << "              } else if (array_index >= " << element.second.elements << "|| array_index < 0) {\n";
+                getAgentArrayVariableImpl << "              } else if (array_index >= " << element.second.elements << ") {\n";
                 getAgentArrayVariableImpl << "                  DTHROW(\"Agent array variable '%s', index %d is out of bounds during getVariable().\\n\", name, array_index);\n";
                 getAgentArrayVariableImpl << "                  return 0;\n";
                 getAgentArrayVariableImpl << "              }\n";
@@ -721,7 +721,7 @@ void CurveRTCHost::initHeaderGetters() {
                 getAgentArrayVariableLDGImpl << "              } else if (N != " << element.second.elements << ") {\n";
                 getAgentArrayVariableLDGImpl << "                  DTHROW(\"Agent array variable '%s' length mismatch during getVariable().\\n\", name);\n";
                 getAgentArrayVariableLDGImpl << "                  return 0;\n";
-                getAgentArrayVariableLDGImpl << "              } else if (array_index >= " << element.second.elements << "|| array_index < 0) {\n";
+                getAgentArrayVariableLDGImpl << "              } else if (array_index >= " << element.second.elements << ") {\n";
                 getAgentArrayVariableLDGImpl << "                  DTHROW(\"Agent array variable '%s', index %d is out of bounds during getVariable().\\n\", name, array_index);\n";
                 getAgentArrayVariableLDGImpl << "                  return 0;\n";
                 getAgentArrayVariableLDGImpl << "              }\n";

--- a/src/flamegpu/runtime/utility/EnvironmentManager.cu
+++ b/src/flamegpu/runtime/utility/EnvironmentManager.cu
@@ -17,11 +17,6 @@ namespace flamegpu_internal {
      * Managed by HostEnvironment, holds all environment properties
      */
     __constant__ char c_envPropBuffer[EnvironmentManager::MAX_BUFFER_SIZE];
-    /**
-     * Managed by HostEnvironment, returned whenever a failure state is reached
-     * Think this exists because we cant return a reference to a constexpr
-     */
-    __constant__ uint64_t c_deviceEnvErrorPattern;
 }  // namespace flamegpu_internal
 
 const char EnvironmentManager::CURVE_NAMESPACE_STRING[23] = "ENVIRONMENT_PROPERTIES";
@@ -157,9 +152,6 @@ void EnvironmentManager::initialiseDevice() {
         c_buffer = reinterpret_cast<char*>(t_c_buffer);
         // printf("Env Prop Constant Cache Buffer: %p - %p\n", c_buffer, c_buffer + MAX_BUFFER_SIZE);
         assert(CURVE_NAMESPACE_HASH == DeviceEnvironment::CURVE_NAMESPACE_HASH());  // Host and Device namespace const's do not match
-        // Setup device-side error pattern
-        const uint64_t h_errorPattern = DeviceEnvironment::ERROR_PATTERN();
-        gpuErrchk(cudaMemcpyToSymbol(flamegpu_internal::c_deviceEnvErrorPattern, reinterpret_cast<const void*>(&h_errorPattern), sizeof(uint64_t), 0, cudaMemcpyHostToDevice));
         deviceInitialised = true;
     }
 }


### PR DESCRIPTION
This stopped being used when DeviceExceptions were added.

Removing this reduces warnings during RTC compilation.