### PR TITLE
Update minimum CUDA version to 10.0

### DIFF
--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-18.04
-            cuda: "10.2"
+            cuda: "11.1"
     env:
       build_dir: "build"
       build_tests: "ON"

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -21,31 +21,18 @@ jobs:
           # - os: ubuntu-18.04
           #   cuda: "11.0"
           #   gcc: 9
-          - os: ubuntu-18.04
-            cuda: "10.2"
-            gcc: 8
+          # - os: ubuntu-18.04
+          #   cuda: "10.2"
+          #   gcc: 8
           # - os: ubuntu-18.04
           #   cuda: "10.1"
           #   gcc: 8
 
-          # 16.04 supports CUDA 8+, we require 9.2+ due to gcc 7+ dependency (gtest+nvcc combo)
-          # - os: ubuntu-16.04
-          #   cuda: "11.0"
-          #   gcc: 7
-          # - os: ubuntu-16.04
-          #   cuda: "10.0"
-          #   gcc: 7
-          # - os: ubuntu-16.04
-          #   cuda: "9.2"
-          #   gcc: 7
-          
-          # CUDA 9.1 and below cannot build tests, but should build the library
-          # - os: ubuntu-16.04
-          #   cuda: "9.1"
-          #   gcc: 6
-          # - os: ubuntu-16.04
-          #   cuda: "9.0"
-          #   gcc: 6
+          # 16.04 supports CUDA 8+, but we only support 10.0+
+          - os: ubuntu-16.04
+            cuda: "10.0"
+            gcc: 7          
+
     env:
       cuda_arch: "35;75"
       build_dir: "build"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -15,31 +15,19 @@ jobs:
         include:
           # Windows2019 & VS 2019 supports 10.1+
           - os: windows-2019
-            cuda: "11.1.0"
+            cuda: "11.1.1"
             visual_studio: "Visual Studio 16 2019"
           # - os: windows-2019
           #   cuda: "11.0.3"
           #   visual_studio: "Visual Studio 16 2019"
-          - os: windows-2019
-            cuda: "10.2.89"
-            visual_studio: "Visual Studio 16 2019"
+          # - os: windows-2019
+          #   cuda: "10.2.89"
+          #   visual_studio: "Visual Studio 16 2019"
           # - os: windows-2019
           #   cuda: "10.1.243"
           #   visual_studio: "Visual Studio 16 2019"
 
           # Windows2016 & VS 2017 supports 10.0+
-          # - os: windows-2016
-          #   cuda: "11.1.0"
-          #   visual_studio: "Visual Studio 15 2017"
-          # - os: windows-2016
-          #   cuda: "11.0.3"
-          #   visual_studio: "Visual Studio 15 2017"
-          # - os: windows-2016
-          #   cuda: "10.2.89"
-          #   visual_studio: "Visual Studio 15 2017"
-          # - os: windows-2016
-          #   cuda: "10.1.243"
-          #   visual_studio: "Visual Studio 15 2017"
           # - os: windows-2016
           #   cuda: "10.0.130"
           #   visual_studio: "Visual Studio 15 2017"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Set the minimum cmake version to that which supports cuda natively.
-# 3.10 required for cuda -std=c++14, however 3.12 fixes some device linker errors
-cmake_minimum_required(VERSION VERSION 3.12 FATAL_ERROR)
+# CMake 3.15+ for Thrust/Cub support
+cmake_minimum_required(VERSION VERSION 3.15 FATAL_ERROR)
 
 project(FLAMEGPU2 LANGUAGES NONE)
 set(FLAMEGPU_PROJECT_VERSION "2.0.0")
@@ -10,7 +9,7 @@ set(CMAKE_SKIP_INSTALL_RULES TRUE)
 set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}" CACHE INTERNAL ""  FORCE)
 
 # See if the minimum CUDA version is available. If not, only enable documentation building.
-set(MINIMUM_SUPPORTED_CUDA_VERSION 9.0)
+set(MINIMUM_SUPPORTED_CUDA_VERSION 10.0)
 include(CheckLanguage)
 # See if CUDA is available
 check_language(CUDA)

--- a/README.md
+++ b/README.md
@@ -23,23 +23,28 @@ Only documentation can be built without the required dependencies (however Doxyg
 
 #### Required
 
-* [CMake](https://cmake.org/) >= 3.12
-  * CMake 3.16 is known to have issues on certain platforms
-* [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit) >= 9.0
-* *Linux:*
-  * [make](https://www.gnu.org/software/make/)
-  * gcc/g++ >= 6 (version requirements [here](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#system-requirements))
-      * gcc/g++ >= 7 required for the test suite 
-* *Windows:*
-  * Visual Studio 2015 or higher (2019 preferred)
++ [CMake](https://cmake.org/) `>= 3.15` (`>= 3.18` recommended) 
++ [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit) `>= 10.0`
++ [git](https://git-scm.com/) (Used for dependency management)
++ *Linux:*
+  + [make](https://www.gnu.org/software/make/)
+  + gcc/g++ `>= 7` (version requirements [here](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#system-requirements))
++ *Windows:*
+  + Visual Studio 2017 or higher (2019 recommended)
 
 #### Optional
-* [cpplint](https://github.com/cpplint/cpplint): Required for linting code
-* [Doxygen](http://www.doxygen.nl/): Required for building documentation
-* [git](https://git-scm.com/): Required by CMake for preparing GoogleTest, to build the test suite
-* [Python](https://www.python.org/) >= 3.x: required for python integration
-* [swig](http://www.swig.org/) >= 4: Required for python integration
-  * Swig 4.x will be automatically downloaded by CMake if not provided (if possible).
++ [cpplint](https://github.com/cpplint/cpplint): Required for linting code
++ [Doxygen](http://www.doxygen.nl/): Required for building documentation
++ [Python](https://www.python.org/) `>= 3.x`: required for python integration
++ [swig](http://www.swig.org/) `>= 4.0.2`: Required for python integration
+  + Swig 4.x will be automatically downloaded by CMake if not provided (if possible).
+
+#### Known Issues
+<!-- Thrust issue https://github.com/NVIDIA/thrust/issues/1090 -->
++ Windows/MSVC and CUDA < 11.0
+  + There may be intermittent compilation errors due to an NVCC+MSVC bug exposed by Thrust/CUB. 
+  + Re-running the build appears to work in most cases, Otherwise consider upgrading to CUDA 11.0+ if possible.
++ CMake 3.16 has known issues on some platforms.
 
 ### Building FLAME GPU 2
 
@@ -88,11 +93,11 @@ Alternatively using `-G` the desired version of Visual studio can be specified:
 
 ```
 mkdir build && cd build
-cmake .. -G "Visual Studio 14 2015" -A x64
+cmake .. -G "Visual Studio 16 2019" -A x64
 FLAMEGPU2.sln
 ```
 
-`Visual Studio 14 2015` can be replaced with any supported [Visual studio generator](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#visual-studio-generators) that is installed.
+`Visual Studio 16 2019` can be replaced with any supported [Visual studio generator](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#visual-studio-generators) that is installed.
 
 #### Configuring CMake
 
@@ -118,10 +123,10 @@ On Windows this will then automatically download the visualisation repository an
 On Linux you may need to install additional packages, refer to the CMake configure output for clarification of which packages are missing from your system.
 
 **Visualisation Dependencies:**
-* [SDL](https://www.libsdl.org/)
-* [GLM](http://glm.g-truc.net/) *(consistent C++/GLSL vector maths functionality)*
-* [GLEW](http://glew.sourceforge.net/) *(GL extension loader)*
-* [FreeType](http://www.freetype.org/)  *(font loading)*
++ [SDL](https://www.libsdl.org/)
++ [GLM](http://glm.g-truc.net/) *(consistent C++/GLSL vector maths functionality)*
++ [GLEW](http://glew.sourceforge.net/) *(GL extension loader)*
++ [FreeType](http://www.freetype.org/)  *(font loading)*
 
 The visualisation codebase can be found at [this location](https://github.com/FLAMEGPU/FLAMEGPU2_visualiser) and is a fork of [sdl_exp](https://github.com/Robadob/sdl_exp).
 
@@ -138,8 +143,6 @@ make -j8
 The first time CMake is configured with `-DBUILD_TESTS=ON` an internet connection is required, as [GoogleTest](https://github.com/google/googletest) is downloaded and built. 
 Subsequent reconfigures will attempt to update this copy, but will continue if updating fails.
 Automatic updating of GoogleTest can be disabled by passing `-DBUILD_TESTS=OFF`.
-
-*Known Issues:* The tests do not build under the combination of Visual Studio 2015 and CUDA 9.0 or 9.1. Use CUDA 9.2 or newer if you require the tests.
 
 GoogleTest runtime documentation can be found [here](https://github.com/google/googletest/blob/master/googletest/docs/advanced.md).
 In particular `--gtest_catch_exceptions=0` may be useful during test development, so that unhandled exceptions are passed straight to the debugger.

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -137,9 +137,13 @@ endif()
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -DJITIFY_PRINT_LOG")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DJITIFY_PRINT_LOG")
 
+# Set the minimum supported cuda version, if not already set. Currently duplicated due to docs only build logic.
+if(NOT DEFINED MINIMUM_SUPPORTED_CUDA_VERSION)
+    set(MINIMUM_SUPPORTED_CUDA_VERSION 10.0)
+endif()
 # Require a minimum cuda version
-if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 7.0)
-    message(FATAL_ERROR "CUDA version must be at least 7.0")
+if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS ${MINIMUM_SUPPORTED_CUDA_VERSION})
+    message(FATAL_ERROR "CUDA version must be at least ${MINIMUM_SUPPORTED_CUDA_VERSION}")
 endif()
 
 # Specify some additional compiler flags

--- a/examples/boids_bruteforce/CMakeLists.txt
+++ b/examples/boids_bruteforce/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Set the minimum cmake version to that which supports cuda natively.
-# 3.10 required for cuda -std=c++14, however 3.12 fixes some device linker errors
-cmake_minimum_required(VERSION VERSION 3.12 FATAL_ERROR)
+# CMake 3.15+ for Thrust/Cub support
+cmake_minimum_required(VERSION VERSION 3.15 FATAL_ERROR)
 
 # Name the project and set languages
 project(boids_bruteforce CUDA CXX)

--- a/examples/boids_rtc_bruteforce/CMakeLists.txt
+++ b/examples/boids_rtc_bruteforce/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Set the minimum cmake version to that which supports cuda natively.
-# 3.10 required for cuda -std=c++14, however 3.12 fixes some device linker errors
-cmake_minimum_required(VERSION VERSION 3.12 FATAL_ERROR)
+# CMake 3.15+ for Thrust/Cub support
+cmake_minimum_required(VERSION VERSION 3.15 FATAL_ERROR)
 
 # Name the project and set languages
 project(boids_rtc_bruteforce CUDA CXX)

--- a/examples/boids_rtc_spatial3D/CMakeLists.txt
+++ b/examples/boids_rtc_spatial3D/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Set the minimum cmake version to that which supports cuda natively.
-# 3.10 required for cuda -std=c++14, however 3.12 fixes some device linker errors
-cmake_minimum_required(VERSION VERSION 3.12 FATAL_ERROR)
+# CMake 3.15+ for Thrust/Cub support
+cmake_minimum_required(VERSION VERSION 3.15 FATAL_ERROR)
 
 # Name the project and set languages
 project(boids_rtc_spatial3D CUDA CXX)

--- a/examples/boids_spatial3D/CMakeLists.txt
+++ b/examples/boids_spatial3D/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Set the minimum cmake version to that which supports cuda natively.
-# 3.10 required for cuda -std=c++14, however 3.12 fixes some device linker errors
-cmake_minimum_required(VERSION VERSION 3.12 FATAL_ERROR)
+# CMake 3.15+ for Thrust/Cub support
+cmake_minimum_required(VERSION VERSION 3.15 FATAL_ERROR)
 
 # Name the project and set languages
 project(boids_spatial3D CUDA CXX)

--- a/examples/circles_bruteforce/CMakeLists.txt
+++ b/examples/circles_bruteforce/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Set the minimum cmake version to that which supports cuda natively.
-# 3.10 required for cuda -std=c++14, however 3.12 fixes some device linker errors
-cmake_minimum_required(VERSION VERSION 3.12 FATAL_ERROR)
+# CMake 3.15+ for Thrust/Cub support
+cmake_minimum_required(VERSION VERSION 3.15 FATAL_ERROR)
 
 # Name the project and set languages
 project(circles_bruteforce CUDA CXX)

--- a/examples/circles_spatial3D/CMakeLists.txt
+++ b/examples/circles_spatial3D/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Set the minimum cmake version to that which supports cuda natively.
-# 3.10 required for cuda -std=c++14, however 3.12 fixes some device linker errors
-cmake_minimum_required(VERSION VERSION 3.12 FATAL_ERROR)
+# CMake 3.15+ for Thrust/Cub support
+cmake_minimum_required(VERSION VERSION 3.15 FATAL_ERROR)
 
 # Name the project and set languages
 project(circles_spatial3D CUDA CXX)

--- a/examples/game_of_life/CMakeLists.txt
+++ b/examples/game_of_life/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Set the minimum cmake version to that which supports cuda natively.
-# 3.10 required for cuda -std=c++14, however 3.12 fixes some device linker errors
-cmake_minimum_required(VERSION VERSION 3.12 FATAL_ERROR)
+# CMake 3.15+ for Thrust/Cub support
+cmake_minimum_required(VERSION VERSION 3.15 FATAL_ERROR)
 
 # Name the project and set languages
 project(game_of_life CUDA CXX)

--- a/examples/host_functions/CMakeLists.txt
+++ b/examples/host_functions/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Set the minimum cmake version to that which supports cuda natively.
-# 3.10 required for cuda -std=c++14, however 3.12 fixes some device linker errors
-cmake_minimum_required(VERSION VERSION 3.12 FATAL_ERROR)
+# CMake 3.15+ for Thrust/Cub support
+cmake_minimum_required(VERSION VERSION 3.15 FATAL_ERROR)
 
 # Name the project and set languages
 project(host_functions CUDA CXX)

--- a/scripts/actions/install_cuda_windows.ps1
+++ b/scripts/actions/install_cuda_windows.ps1
@@ -16,10 +16,11 @@ $CUDA_KNOWN_URLS = @{
     "10.1.168" = "http://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.168_win10_network.exe";
     "10.1.243" = "http://developer.download.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.243_win10_network.exe";
     "10.2.89" = "http://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe";
-    "11.0.1" = "http://developer.download.nvidia.com/compute/cuda/11.0.1/network_installers/cuda_11.0.1_win10_network.exe"
-    "11.0.2" = "http://developer.download.nvidia.com/compute/cuda/11.0.2/network_installers/cuda_11.0.2_win10_network.exe"
-    "11.0.3" = "http://developer.download.nvidia.com/compute/cuda/11.0.3/network_installers/cuda_11.0.3_win10_network.exe"
-    "11.1.0" = "https://developer.download.nvidia.com/compute/cuda/11.1.0/network_installers/cuda_11.1.0_win10_network.exe"
+    "11.0.1" = "http://developer.download.nvidia.com/compute/cuda/11.0.1/network_installers/cuda_11.0.1_win10_network.exe";
+    "11.0.2" = "http://developer.download.nvidia.com/compute/cuda/11.0.2/network_installers/cuda_11.0.2_win10_network.exe";
+    "11.0.3" = "http://developer.download.nvidia.com/compute/cuda/11.0.3/network_installers/cuda_11.0.3_win10_network.exe";
+    "11.1.0" = "https://developer.download.nvidia.com/compute/cuda/11.1.0/network_installers/cuda_11.1.0_win10_network.exe";
+    "11.1.1" = "https://developer.download.nvidia.com/compute/cuda/11.1.1/network_installers/cuda_11.1.1_win10_network.exe";
 }
 
 # @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead?

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
-# 3.10 required for cuda -std=c++14, however 3.12 fixes some device linker errors
-cmake_minimum_required(VERSION VERSION 3.12 FATAL_ERROR)
+# CMake 3.15+ for Thrust/Cub support
+cmake_minimum_required(VERSION VERSION 3.15 FATAL_ERROR)
 
 # Cmake 3.16 has issues with CUB and Thrust due to the order of the include path it generates.
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.16 AND CMAKE_VERSION VERSION_LESS 3.17)

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Required a version of cmake which has Fetch Content (3.11 maybe, but 3.12 elsewhere)
-cmake_minimum_required(VERSION VERSION 3.12 FATAL_ERROR)
+# CMake 3.15+ for Thrust/Cub support
+cmake_minimum_required(VERSION VERSION 3.15 FATAL_ERROR)
 include(FetchContent)
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Set the minimum cmake version to that which supports cuda natively.
-# 3.10 required for cuda -std=c++14, however 3.12 fixes some device linker errors
-cmake_minimum_required(VERSION VERSION 3.12 FATAL_ERROR)
+# CMake 3.15+ for Thrust/Cub support
+cmake_minimum_required(VERSION VERSION 3.15 FATAL_ERROR)
 
 # Tests require GTest
 


### PR DESCRIPTION
Updates minimum supported CUDA version to 10.0, removing mentions of 9.x issues.
Removes Windows CUDA 10.x CI job due to intermittent compiler failures fixed by CUDA 11.0
Simplifies CI workflows with fewer disabled CUDA combinations
Updates Readme with agreed dependency versions
Applies some markdown tweaks to the readme
Adds CUDA 11.1.1 as a download target for windows CI.

Closes #406