### PR TITLE
Ensemble 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ option(BUILD_EXAMPLE_CIRCLES_BRUTEFORCE "Enable building examples/circles_brutef
 option(BUILD_EXAMPLE_CIRCLES_SPATIAL3D "Enable building examples/circles_spatial3D" OFF)
 option(BUILD_EXAMPLE_GAME_OF_LIFE "Enable building examples/game_of_life" OFF)
 option(BUILD_EXAMPLE_HOST_FUNCTIONS "Enable building examples/host_functions" OFF)
+option(BUILD_EXAMPLE_ENSEMBLE "Enable building examples/ensemble" OFF)
 option(BUILD_SWIG_PYTHON "Enable python bindings via SWIG" OFF)
 cmake_dependent_option(BUILD_SWIG_PYTHON_VIRTUALENV "Enable building of SWIG Python Virtual Env for Python Testing" OFF
                        "BUILD_SWIG_PYTHON" OFF)
@@ -105,10 +106,6 @@ endif()
 
 # Add each example
 
-if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_HOST_FUNCTIONS)
-    add_subdirectory(examples/host_functions)
-endif()
-
 if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_BOIDS_BRUTEFORCE)
     add_subdirectory(examples/boids_bruteforce)
 endif()
@@ -136,6 +133,15 @@ endif()
 if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_GAME_OF_LIFE)
     add_subdirectory(examples/game_of_life)
 endif()
+
+if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_HOST_FUNCTIONS)
+    add_subdirectory(examples/host_functions)
+endif()
+
+if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_ENSEMBLE)
+    add_subdirectory(examples/ensemble)
+endif()
+
 # Add the tests directory (if required)
 if(BUILD_TESTS)
     add_subdirectory(tests)

--- a/examples/ensemble/CMakeLists.txt
+++ b/examples/ensemble/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Set the minimum cmake version to that which supports cuda natively.
+# 3.10 required for cuda -std=c++14, however 3.12 fixes some device linker errors
+cmake_minimum_required(VERSION VERSION 3.12 FATAL_ERROR)
+
+# Name the project and set languages
+project(ensemble CUDA CXX)
+
+# Set the location of the ROOT flame gpu project relative to this CMakeList.txt
+get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../.. REALPATH)
+
+# Include common rules.
+include(${FLAMEGPU_ROOT}/cmake/common.cmake)
+
+# Define output location of binary files
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    # If top level project
+    SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin/${CMAKE_SYSTEM_NAME_LOWER}-x64/${CMAKE_BUILD_TYPE}/)
+else()
+    # If called via add_subdirectory()
+    SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../../bin/${CMAKE_SYSTEM_NAME_LOWER}-x64/${CMAKE_BUILD_TYPE}/)
+endif()
+
+# Prepare list of source files
+# Can't do this automatically, as CMake wouldn't know when to regen (as CMakeLists.txt would be unchanged)
+SET(ALL_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cu
+)
+
+# Option to enable/disable building the static library
+# option(VISUALISATION "Enable visualisation support" OFF) # This example is unlikely to have a visualisation
+
+# Add the executable and set required flags for the target
+add_flamegpu_executable("${PROJECT_NAME}" "${ALL_SRC}" "${FLAMEGPU_ROOT}" "${PROJECT_BINARY_DIR}" TRUE)
+
+# Also set as startup project (if top level project)
+set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"  PROPERTY VS_STARTUP_PROJECT "${PROJECT_NAME}")

--- a/examples/ensemble/src/main.cu
+++ b/examples/ensemble/src/main.cu
@@ -1,0 +1,91 @@
+#include "flamegpu/flame_api.h"
+
+FLAMEGPU_AGENT_FUNCTION(AddOffset, MsgNone, MsgNone) {
+    // Output each agents publicly visible properties.
+    FLAMEGPU->setVariable<int>("x", FLAMEGPU->getVariable<int>("x") + FLAMEGPU->environment.getProperty<int>("offset"));
+    return ALIVE;
+}
+FLAMEGPU_INIT_FUNCTION(Init) {
+    const unsigned int POPULATION_TO_GENERATE = FLAMEGPU->environment.getProperty<unsigned int>("POPULATION_TO_GENERATE");
+    const int init = FLAMEGPU->environment.getProperty<int>("init");
+    const int init_offset = FLAMEGPU->environment.getProperty<int>("init_offset");
+    for (unsigned int i = 0; i < POPULATION_TO_GENERATE; ++i) {
+        auto agent = FLAMEGPU->newAgent("Agent");
+        agent.setVariable<int>("x", init + i * init_offset);
+    }
+}
+std::atomic<unsigned int> atomic_init;
+std::atomic<uint64_t> atomic_result;
+FLAMEGPU_EXIT_FUNCTION(Exit) {
+    atomic_init += FLAMEGPU->environment.getProperty<int>("init");
+    atomic_result += FLAMEGPU->agent("Agent").sum<int>("x");
+}
+int main(int argc, const char ** argv) {
+    ModelDescription model("boids_spatial3D");
+    const unsigned int POPULATION_TO_GENERATE = 100000;
+    const unsigned int STEPS = 10;
+    /**
+     * GLOBALS
+     */
+     {
+        EnvironmentDescription &env = model.Environment();
+
+        env.newProperty<unsigned int>("POPULATION_TO_GENERATE", POPULATION_TO_GENERATE, true);
+
+        env.newProperty<int>("init", 0);
+        env.newProperty<int>("init_offset", 0);
+        env.newProperty<int>("offset", 1);
+    }
+    {   // Boid agent
+        AgentDescription &agent = model.newAgent("Agent");
+        agent.newVariable<int>("x");
+        agent.newFunction("AddOffset", AddOffset);
+    }
+
+    /**
+     * Control flow
+     */     
+    {   // Layer #1
+        LayerDescription &layer = model.newLayer();
+        layer.addAgentFunction(AddOffset);
+
+        model.addInitFunction(Init);
+        model.addExitFunction(Exit);
+    }
+
+    /**
+     * Create a run plan
+     */
+    RunPlanVec runs(model, 100);
+    {
+        runs.setSteps(STEPS);
+        runs.setRandomSimulationSeed(12, 1);
+        runs.setPropertyUniformDistribution<int>("init", 0, 9);
+        runs.setPropertyUniformDistribution<int>("init_offset", 1, 0);
+        runs.setPropertyUniformDistribution<int>("offset", 0, 99);
+    }
+
+    /**
+     * Create Model Runner
+     */
+    CUDAEnsemble cuda_ensemble(model, argc, argv);
+
+    cuda_ensemble.simulate(runs);
+
+    // Check result
+    // Don't currently have logging
+    unsigned int init_sum = 0;
+    uint64_t result_sum = 0;
+    for (int i = 0 ; i < 100; ++i) {
+        const int init = i/10;
+        const int init_offset = 1 - i/50;
+        init_sum += init;
+        result_sum += POPULATION_TO_GENERATE * init + init_offset * ((POPULATION_TO_GENERATE-1)*POPULATION_TO_GENERATE/2);  // Initial agent values
+        result_sum += POPULATION_TO_GENERATE * STEPS * i;  // Agent values added by steps
+    }
+    printf("Ensemble init: %u, calculated init %u\n", atomic_init.load(), init_sum);
+    printf("Ensemble result: %zu, calculated result %zu\n", atomic_result.load(), result_sum);
+
+
+    return 0;
+}

--- a/include/flamegpu/flame_api.h
+++ b/include/flamegpu/flame_api.h
@@ -24,5 +24,10 @@
 #include "flamegpu/runtime/AgentFunction_shim.h"
 #include "flamegpu/runtime/AgentFunctionCondition_shim.h"
 #include "flamegpu/visualiser/ModelVis.h"
+#include "flamegpu/gpu/CUDAEnsemble.h"
+#include "flamegpu/sim/RunPlanVec.h"
+#include "flamegpu/sim/LoggingConfig.h"
+#include "flamegpu/sim/AgentLoggingConfig.h"
+#include "flamegpu/sim/LogFrame.h"
 
 #endif  // INCLUDE_FLAMEGPU_FLAME_API_H_

--- a/include/flamegpu/gpu/CUDAEnsemble.h
+++ b/include/flamegpu/gpu/CUDAEnsemble.h
@@ -1,0 +1,123 @@
+#ifndef INCLUDE_FLAMEGPU_GPU_CUDAENSEMBLE_H_
+#define INCLUDE_FLAMEGPU_GPU_CUDAENSEMBLE_H_
+
+#include <string>
+#include <memory>
+#include <set>
+#include <vector>
+
+
+struct ModelData;
+class ModelDescription;
+class RunPlanVec;
+class LoggingConfig;
+class StepLoggingConfig;
+struct RunLog;
+/**
+ * Manager for automatically executing multiple copies of a model simultaneously
+ * This can be used to conveniently execute parameter sweeps and batch validation runs
+ */
+class CUDAEnsemble {
+ public:
+    struct EnsembleConfig {
+        // std::string in = "";
+        std::string out_directory = "";
+        std::string out_format = "json";
+        unsigned int concurrent_runs = 4;
+        std::set<int> devices;
+        bool silent = false;
+        bool timing = false;
+    };
+    /**
+     * Initialise CUDA Ensemble
+     * If provided, you can pass runtime arguments to this constructor, to automatically call initialise()
+     * This is not required, you can call initialise() manually later, or not at all.
+     * @param model The model description to initialise the runner to execute
+     * @param argc Runtime argument count
+     * @param argv Runtime argument list ptr
+     */
+    explicit CUDAEnsemble(const ModelDescription& model, int argc = 0, const char** argv = nullptr);
+    /**
+     * Inverse operation of constructor
+     */
+    ~CUDAEnsemble();
+
+    /**
+     * Execute the ensemble of simulations.
+     * This call will block until all simulations have completed or MAX_ERRORS simulations exit with an error
+     * @param plan The plan of individual runs to execute during the ensemble
+     */
+    void simulate(const RunPlanVec &plan);
+
+    /**
+     * @return A mutable reference to the ensemble configuration struct
+     * @see CUDAEnsemble::applyConfig() Should be called afterwards to apply changes
+     */
+    EnsembleConfig &Config() { return config; }
+    /**
+     * @return An immutable reference to the ensemble configuration struct
+     */
+    const EnsembleConfig &getConfig() const { return config; }
+    /*
+     * Override current config with args passed via CLI
+     * @note Config values not passed via CLI will remain as their current values (and not be reset to default)
+     */
+    void initialise(int argc, const char** argv);
+    /**
+     * Configure which step data should be logged
+     * @param stepConfig The step logging config for the CUDAEnsemble
+     * @note This must be for the same model description hierarchy as the CUDAEnsemble
+     */
+    void setStepLog(const StepLoggingConfig &stepConfig);
+    /**
+     * Configure which exit data should be logged
+     * @param exitConfig The logging config for the CUDAEnsemble
+     * @note This must be for the same model description hierarchy as the CUDAEnsemble
+     */
+    void setExitLog(const LoggingConfig &exitConfig);
+    /**
+     * Get the duration of the last call to simulate() in milliseconds. 
+     * With a resolution of around 0.5 microseconds (cudaEventElapsedtime)
+     */
+    int64_t getEnsembleElapsedTime() const { return ensemble_elapsed_time; }
+    /**
+     * Return the list of logs collected from the last call to simulate()
+     */
+    const std::vector<RunLog> &getLogs();
+
+ private:
+    /**
+     * Print command line interface help
+     */
+    void printHelp(const char *executable);
+    /**
+     * Parse CLI into config
+     */
+    int checkArgs(int argc, const char** argv);
+    /**
+     * Config options for the ensemble
+     */
+    EnsembleConfig config;
+    /**
+     * Step logging config
+     */
+    std::shared_ptr<const StepLoggingConfig> step_log_config;
+    /**
+     * Exit logging config
+     */
+    std::shared_ptr<const LoggingConfig> exit_log_config;
+    /**
+     * Logs collected by simulate()
+     */
+    std::vector<RunLog> run_logs;
+    /**
+     * Model description hierarchy for the ensemble, a copy of this will be passed to every CUDASimulation
+     */
+    const std::shared_ptr<const ModelData> model;
+    /**
+     * Runtime of previous call to simulate() in milliseconds, initially 0
+     */
+    int64_t ensemble_elapsed_time = 0;
+};
+
+#endif  // INCLUDE_FLAMEGPU_GPU_CUDAENSEMBLE_H_

--- a/include/flamegpu/gpu/CUDAScanCompaction.h
+++ b/include/flamegpu/gpu/CUDAScanCompaction.h
@@ -1,11 +1,6 @@
 #ifndef INCLUDE_FLAMEGPU_GPU_CUDASCANCOMPACTION_H_
 #define INCLUDE_FLAMEGPU_GPU_CUDASCANCOMPACTION_H_
 
-/**
- * PLEASE NOTE: This implementation currently assumes there is only one instance of CUDASimulation executing at once
- * PLEASE NOTE: There is not currently a mechanism to release these (could trigger something via CUDASimulation destructor)
- */
-
 // forward declare classes from other modules
 class CUDASimulation;
 

--- a/include/flamegpu/io/Logger.h
+++ b/include/flamegpu/io/Logger.h
@@ -1,0 +1,22 @@
+#ifndef INCLUDE_FLAMEGPU_IO_LOGGER_H_
+#define INCLUDE_FLAMEGPU_IO_LOGGER_H_
+
+struct RunLog;
+class RunPlan;
+
+class Logger {
+ public:
+    virtual ~Logger() = default;
+    /**
+     * Log a runlog to file, using a RunPlan in place of config
+     * @throws May throw exceptions if logging to file failed for any reason
+     */
+    virtual void log(const RunLog &log, const RunPlan &plan, bool logSteps = true, bool logExit = true) const = 0;
+    /**
+     * Log a runlog to file, uses config data (random seed) from the RunLog
+     * @throws May throw exceptions if logging to file failed for any reason
+     */
+    virtual void log(const RunLog &log, bool logConfig = true, bool logSteps = true, bool logExit = true) const = 0;
+};
+
+#endif  // INCLUDE_FLAMEGPU_IO_LOGGER_H_

--- a/include/flamegpu/io/jsonLogger.h
+++ b/include/flamegpu/io/jsonLogger.h
@@ -1,0 +1,100 @@
+#ifndef INCLUDE_FLAMEGPU_IO_JSONLOGGER_H_
+#define INCLUDE_FLAMEGPU_IO_JSONLOGGER_H_
+
+#include <string>
+#include <typeindex>
+
+#include "flamegpu/io/Logger.h"
+#include "flamegpu/util/Any.h"
+
+struct RunLog;
+struct LogFrame;
+class RunPlan;
+
+class jsonLogger : public Logger{
+ public:
+    jsonLogger(const std::string &outPath, bool prettyPrint, bool truncateFile);
+    /**
+     * Log a runlog to file, using a RunPlan in place of config
+     * @throws May throw exceptions if logging to file failed for any reason
+     */
+    void log(const RunLog &log, const RunPlan &plan, bool logSteps = true, bool logExit = true) const override;
+    /**
+     * Log a runlog to file, uses config data (random seed) from the RunLog
+     * @throws May throw exceptions if logging to file failed for any reason
+     */
+    void log(const RunLog &log, bool logConfig = true, bool logSteps = true, bool logExit = true) const override;
+
+ private:
+    /**
+     * Internal logging method, allows Plan to be passed as null
+     */
+    void logCommon(const RunLog &log, const RunPlan *plan, bool logConfig, bool logSteps, bool logExit) const;
+    /**
+     * rapidjson::Writer doesn't have virtual methods, so can't pass rapidjson::PrettyWriter around as ptr to rapidjson::writer
+     * Instead we call a templated version of all the methods
+     */
+    template<typename T>
+    void logCommon(T &writer, const RunLog &log, const RunPlan *plan, bool logConfig, bool logSteps, bool logExit) const;
+    /**
+     * Writes out the run config via a JSON object
+     * @param writer Rapidjson writer instance
+     * @param log RunLog containing the config items to be written
+     * @tparam T Instance of rapidjson::Writer or subclass (e.g. rapidjson::PrettyWriter)
+     * @note Templated as can't forward declare rapidjson::Writer<rapidjson::StringBuffer>
+     */
+    template<typename T>
+    void logConfig(T &writer, const RunLog &log) const;
+    /**
+     * Writes out step logs as a JSON array via the provided writer
+     * @param writer Rapidjson writer instance
+     * @param plan RunPlan containing the config items to be written
+     * @tparam T Instance of rapidjson::Writer or subclass (e.g. rapidjson::PrettyWriter)
+     * @note Templated as can't forward declare rapidjson::Writer<rapidjson::StringBuffer>
+     */
+    template<typename T>
+    void logConfig(T &writer, const RunPlan &plan) const;
+    /**
+     * Writes out step logs as a JSON array via the provided writer
+     * @param writer Rapidjson writer instance
+     * @param log RunLog containing the step logs to be written
+     * @tparam T Instance of rapidjson::Writer or subclass (e.g. rapidjson::PrettyWriter)
+     * @note Templated as can't forward declare rapidjson::Writer<rapidjson::StringBuffer>
+     */
+    template<typename T>
+    void logSteps(T &writer, const RunLog &log) const;
+    /**
+     * Writes out an exit log as a JSON object via the provided writer
+     * @param writer Rapidjson writer instance
+     * @param log RunLog containing the exit log to be written
+     * @tparam T Instance of rapidjson::Writer or subclass (e.g. rapidjson::PrettyWriter)
+     * @note Templated as can't forward declare rapidjson::Writer<rapidjson::StringBuffer>
+     */
+    template<typename T>
+    void logExit(T &writer, const RunLog &log) const;
+    /**
+     * Writes out a LogFrame instance as a JSON object via the provided writer
+     * @param writer Rapidjson writer instance
+     * @param log LogFrame to be written
+     * @tparam T Instance of rapidjson::Writer or subclass (e.g. rapidjson::PrettyWriter)
+     * @note Templated as can't forward declare rapidjson::Writer<rapidjson::StringBuffer>
+     */
+    template<typename T>
+    void writeLogFrame(T &writer, const LogFrame &log) const;
+    /**
+     * Writes out the value of an Any via the provided writer
+     * @param writer Rapidjson writer instance
+     * @param value The Any to be written
+     * @param elements The number of individual elements stored in the Any (1 if not an array)
+     * @tparam T Instance of rapidjson::Writer or subclass (e.g. rapidjson::PrettyWriter)
+     * @note Templated as can't forward declare rapidjson::Writer<rapidjson::StringBuffer>
+     */
+    template<typename T>
+    void writeAny(T &writer, const Any &value, const unsigned int &elements = 1) const;
+
+    std::string out_path;
+    bool prettyPrint;
+    bool truncateFile;
+};
+
+#endif  // INCLUDE_FLAMEGPU_IO_JSONLOGGER_H_

--- a/include/flamegpu/io/jsonReader.h
+++ b/include/flamegpu/io/jsonReader.h
@@ -26,7 +26,7 @@ class jsonReader : public StateReader {
     jsonReader(
         const std::string &model_name,
         const std::unordered_map<std::string, EnvironmentDescription::PropData> &env_desc,
-        std::unordered_map<std::pair<std::string, unsigned int>, EnvironmentDescription::Any> &env_init,
+        std::unordered_map<std::pair<std::string, unsigned int>, Any> &env_init,
         const std::unordered_map<std::string,
         std::shared_ptr<AgentPopulation>> &model_state,
         const std::string &input_file,

--- a/include/flamegpu/io/statereader.h
+++ b/include/flamegpu/io/statereader.h
@@ -33,7 +33,7 @@ class StateReader {
     StateReader(
         const std::string &_model_name,
         const std::unordered_map<std::string, EnvironmentDescription::PropData> &_env_desc,
-        std::unordered_map<std::pair<std::string, unsigned int>, EnvironmentDescription::Any> &_env_init,
+        std::unordered_map<std::pair<std::string, unsigned int>, Any> &_env_init,
         const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &_model_state,
         const std::string &input,
         Simulation *_sim_instance)
@@ -79,7 +79,7 @@ class StateReader {
     std::string inputFile;
     const std::string model_name;
     const std::unordered_map<std::string, EnvironmentDescription::PropData> &env_desc;
-    std::unordered_map<std::pair<std::string, unsigned int>, EnvironmentDescription::Any> &env_init;
+    std::unordered_map<std::pair<std::string, unsigned int>, Any> &env_init;
     Simulation *sim_instance;
 };
 

--- a/include/flamegpu/io/xmlLogger.h
+++ b/include/flamegpu/io/xmlLogger.h
@@ -1,0 +1,89 @@
+#ifndef INCLUDE_FLAMEGPU_IO_XMLLOGGER_H_
+#define INCLUDE_FLAMEGPU_IO_XMLLOGGER_H_
+
+#include <string>
+#include <typeindex>
+
+#include "flamegpu/io/Logger.h"
+#include "flamegpu/util/Any.h"
+
+struct Any;
+struct RunLog;
+struct LogFrame;
+class RunPlan;
+namespace tinyxml2 {
+class XMLNode;
+class XMLDocument;
+class XMLElement;
+}  // namespace tinyxml2
+
+class xmlLogger : public Logger{
+ public:
+    xmlLogger(const std::string &outPath, bool prettyPrint, bool truncateFile);
+    /**
+     * Log a runlog to file, using a RunPlan in place of config
+     * @throws May throw exceptions if logging to file failed for any reason
+     */
+    void log(const RunLog &log, const RunPlan &plan, bool logSteps = true, bool logExit = true) const override;
+    /**
+     * Log a runlog to file, uses config data (random seed) from the RunLog
+     * @throws May throw exceptions if logging to file failed for any reason
+     */
+    void log(const RunLog &log, bool logConfig = true, bool logSteps = true, bool logExit = true) const override;
+
+ private:
+    /**
+     * Internal logging method, allows Plan to be passed as null
+     */
+    void logCommon(const RunLog &log, const RunPlan *plan, bool logConfig, bool logSteps, bool logExit) const;
+    /**
+     * Writes out the run config via a JSON object to the provided node
+     * @param doc tinyxml2 document used for allocating the new element
+     * @param log RunLog containing the config items to be written
+     * @return The created XMLNode, the calling method will then add it to the main XML hierarchy
+     */
+    tinyxml2::XMLNode *logConfig(tinyxml2::XMLDocument &doc, const RunLog &log) const;
+    /**
+     * Writes out step logs as a JSON array to the provided node
+     * @param doc tinyxml2 document used for allocating the new element
+     * @param plan RunPlan containing the config items to be written
+     * @return The created XMLNode, the calling method will then add it to the main XML hierarchy
+     */
+    tinyxml2::XMLNode *logConfig(tinyxml2::XMLDocument &doc, const RunPlan &plan) const;
+    /**
+     * Writes out step logs as a JSON array to the provided node
+     * @param doc tinyxml2 document used for allocating the new element
+     * @param log RunLog containing the step logs to be written
+     * @return The created XMLNode, the calling method will then add it to the main XML hierarchy
+     */
+    tinyxml2::XMLNode *logSteps(tinyxml2::XMLDocument &doc, const RunLog &log) const;
+    /**
+     * Writes out an exit log as a JSON object to the provided node
+     * @param doc tinyxml2 document used for allocating the new element
+     * @param log RunLog containing the exit log to be written
+     * @return The created XMLNode, the calling method will then add it to the main XML hierarchy
+     */
+    tinyxml2::XMLNode *logExit(tinyxml2::XMLDocument &doc, const RunLog &log) const;
+    /**
+     * Writes out a LogFrame instance as a JSON object to the provided node
+     * @param node tinyxml node to act as parent
+     * @param log LogFrame to be written
+     * @return The created XMLNode, the calling method will then add it to the main XML hierarchy
+     */
+    tinyxml2::XMLNode *writeLogFrame(tinyxml2::XMLDocument &doc, const LogFrame &log) const;
+    /**
+     * Writes out the value of an Any to the provided node
+     * @param element The element to set the value of
+     * @param value The Any to be written
+     * @param elements The number of individual elements stored in the Any (1 if not an array)
+     * @tparam T Instance of rapidjson::Writer or subclass (e.g. rapidjson::PrettyWriter)
+     * @note Templated as can't forward declare rapidjson::Writer<rapidjson::StringBuffer>
+     */
+    void writeAny(tinyxml2::XMLElement *element, const Any &value, const unsigned int &elements = 1) const;
+
+    std::string out_path;
+    bool prettyPrint;
+    bool truncateFile;
+};
+
+#endif  // INCLUDE_FLAMEGPU_IO_XMLLOGGER_H_

--- a/include/flamegpu/io/xmlReader.h
+++ b/include/flamegpu/io/xmlReader.h
@@ -34,7 +34,7 @@ class xmlReader : public StateReader {
     xmlReader(
         const std::string &model_name,
         const std::unordered_map<std::string, EnvironmentDescription::PropData> &env_desc,
-        std::unordered_map<std::pair<std::string, unsigned int>, EnvironmentDescription::Any> &env_init,
+        std::unordered_map<std::pair<std::string, unsigned int>, Any> &env_init,
         const std::unordered_map<std::string,
         std::shared_ptr<AgentPopulation>> &model_state,
         const std::string &input_file,

--- a/include/flamegpu/model/ModelDescription.h
+++ b/include/flamegpu/model/ModelDescription.h
@@ -6,8 +6,10 @@
 #include <set>
 #include <string>
 
+
+#include "flamegpu/gpu/CUDAEnsemble.h"
 #include "flamegpu/model/ModelData.h"
-#include "flamegpu/sim/Simulation.h"
+#include "flamegpu/gpu/CUDASimulation.h"
 #include "flamegpu/runtime/messaging/BruteForce/BruteForceHost.h"
 
 class AgentDescription;
@@ -24,8 +26,11 @@ class ModelDescription {
     /**
      * Simulation accesses the classes internals to convert it to a constant ModelData
      */
-    friend Simulation::Simulation(const ModelDescription& model);
-
+    friend CUDASimulation::CUDASimulation(const ModelDescription& _model, int argc, const char** argv);
+    friend CUDAEnsemble::CUDAEnsemble(const ModelDescription& model, int argc, const char** argv);
+    friend class RunPlanVec;
+    friend class RunPlan;
+    friend class LoggingConfig;
  public:
     /**
      * Constructor

--- a/include/flamegpu/model/SubModelData.h
+++ b/include/flamegpu/model/SubModelData.h
@@ -48,6 +48,11 @@ struct SubModelData : std::enable_shared_from_this<SubModelData> {
      */
     std::shared_ptr<SubEnvironmentData> subenvironment;
     /**
+     * Max number of steps per submodel execution
+     * 0 is unlimited, but requires the submodel to have an exit condition
+     */
+    unsigned int max_steps;
+    /**
      * Name assigned to the submodel at creation
      */
     std::string name;

--- a/include/flamegpu/model/SubModelDescription.h
+++ b/include/flamegpu/model/SubModelDescription.h
@@ -81,6 +81,17 @@ class SubModelDescription {
     const SubAgentDescription &getSubAgent(const std::string &sub_agent_name) const;
     SubEnvironmentDescription &SubEnvironment(bool auto_map_props = false);
     const SubEnvironmentDescription &getSubEnvironment(bool auto_map_props = false) const;
+    /**
+     * Set the maximum number of steps per execution of the submodel
+     * If 0 (default), unlimited however an exit condition is required
+     */
+    void setMaxSteps(const unsigned int &max_steps);
+    /**
+     * Return the current value of max steps, defaults to 0
+     * This is the maximum number of steps per call of the submodel
+     * 0 is unlimited, however requires the model to have an exit condition
+     */
+    unsigned int getMaxSteps() const;
 
  private:
     /**

--- a/include/flamegpu/runtime/flamegpu_host_agent_api.h
+++ b/include/flamegpu/runtime/flamegpu_host_agent_api.h
@@ -27,6 +27,7 @@
 #include "flamegpu/model/AgentDescription.h"
 #include "flamegpu/runtime/flamegpu_host_api.h"
 #include "flamegpu/gpu/CUDASimulation.h"
+#include "flamegpu/gpu/CUDAAgent.h"
 
 #define FLAMEGPU_CUSTOM_REDUCTION(funcName, a, b)\
 struct funcName ## _impl {\
@@ -55,7 +56,7 @@ __device__ __forceinline__ OutT funcName ## _impl::unary_function<InT, OutT>::op
 class HostAgentInstance {
  public:
     HostAgentInstance(FLAMEGPU_HOST_API &_api, AgentInterface &_agent, const std::string &_stateName = "default")
-        :api(_api),
+        : api(_api),
         agent(_agent),
         hasState(true),
         stateName(_stateName) {

--- a/include/flamegpu/runtime/flamegpu_host_api.h
+++ b/include/flamegpu/runtime/flamegpu_host_api.h
@@ -2,7 +2,6 @@
 #define INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_HOST_API_H_
 
 #include <cuda_runtime_api.h>
-#include <cassert>
 #include <string>
 #include <utility>
 #include <functional>

--- a/include/flamegpu/runtime/utility/EnvironmentManager.cuh
+++ b/include/flamegpu/runtime/utility/EnvironmentManager.cuh
@@ -22,6 +22,7 @@
 #include "flamegpu/exception/FGPUException.h"
 #include "flamegpu/gpu/CUDAErrorChecking.h"
 #include "flamegpu/runtime/cuRVE/curve.h"
+#include "flamegpu/util/Any.h"
 
 struct SubEnvironmentData;
 class EnvironmentDescription;
@@ -444,6 +445,14 @@ class EnvironmentManager {
     template<typename T>
     T getProperty(const unsigned int &instance_id, const std::string &var_name, const size_type &index);
     /**
+     * Returns the current value of an environment property as an Any object
+     * This method should not be exposed to users
+     * @param instance_id instance_id of the CUDASimulation instance the property is attached to
+     * @param var_name name used for accessing the property
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     */
+    Any getPropertyAny(const unsigned int &instance_id, const std::string &var_name) const;
+    /**
      * Removes an environment property
      * @param name name used for accessing the property
      * @throws InvalidEnvProperty If a property of the name does not exist
@@ -526,7 +535,7 @@ class EnvironmentManager {
             if (a != properties.end())
                 return a->second.elements;
             THROW InvalidEnvProperty("Mapped environmental property with name '%u:%s' maps to missing property with name '%u:%s', "
-                "in EnvironmentManager::type().",
+                "in EnvironmentManager::length().",
                 name.first, name.second.c_str(), b->second.masterProp.first, b->second.masterProp.second.c_str());
         }
         THROW InvalidEnvProperty("Environmental property with name '%u:%s' does not exist, "

--- a/include/flamegpu/runtime/utility/HostRandom.cuh
+++ b/include/flamegpu/runtime/utility/HostRandom.cuh
@@ -44,6 +44,15 @@ class HostRandom {
     */
     template<typename T>
     inline T uniform(const T& min, const T& max) const;
+    /**
+     * Change the seed used for random generation
+     * @param seed New random seed
+     */
+    void setSeed(const unsigned int &seed);
+    /**
+     * Returns the last value used to seed random generation
+     */
+    unsigned int getSeed() const;
 
  private:
     explicit HostRandom(RandomManager &_rng) : rng(_rng) { }
@@ -93,6 +102,12 @@ template<>
 inline unsigned char HostRandom::uniform(const unsigned char& min, const unsigned char& max) const {
     std::uniform_int_distribution<uint16_t> dist(min, max);
     return static_cast<unsigned char>(rng.getDistribution<uint16_t>(dist));
+}
+
+template<>
+inline signed char HostRandom::uniform(const signed char& min, const signed char& max) const {
+    std::uniform_int_distribution<int16_t> dist(min, max);
+    return static_cast<signed char>(rng.getDistribution<int16_t>(dist));
 }
 
 

--- a/include/flamegpu/sim/AgentLoggingConfig.h
+++ b/include/flamegpu/sim/AgentLoggingConfig.h
@@ -1,0 +1,191 @@
+#ifndef INCLUDE_FLAMEGPU_SIM_AGENTLOGGINGCONFIG_H_
+#define INCLUDE_FLAMEGPU_SIM_AGENTLOGGINGCONFIG_H_
+
+#include <string>
+#include <memory>
+#include <set>
+#include <mutex>
+#include <utility>
+
+#include "flamegpu/sim/LoggingConfig.h"
+#include "flamegpu/sim/AgentLoggingConfig_Reductions.cuh"
+#include "flamegpu/runtime/flamegpu_host_agent_api.h"
+
+struct ModelData;
+
+/**
+ * Interface to the data structure for controlling how a specific agent-state's data is logged
+ */
+class AgentLoggingConfig {
+     /**
+      * Requires access for calling constructor
+      */
+    friend AgentLoggingConfig LoggingConfig::agent(const std::string &, const std::string &);
+    /**
+     * Private constructor, directly initialises the two member variables
+     * Used by LoggingConfig::agent(const std::string &, const std::string &)
+     */
+    AgentLoggingConfig(std::shared_ptr<const AgentData> agent,
+                       std::pair<std::shared_ptr<std::set<LoggingConfig::NameReductionFn>>, bool> &agent_set);
+
+ public:
+    /**
+     * Log the number of agents in this specific agent state
+     */
+    void logCount() { log_count = true; }
+    /**
+     * Mark the mean of the named agent variable to be logged
+     * @param variable_name Name of the agent variable to have it's mean logged
+     * @tparam T The type of the named variable
+     * @throws InvalidAgentVar If the agent var was not found inside the specified agent
+     * @throws InvalidArgument If the agent var's mean has already been marked for logging
+     */
+    template<typename T>
+    void logMean(const std::string &variable_name);
+    /**
+     * Mark the standard deviation of the named agent variable to be logged
+     * @param variable_name Name of the agent variable to have it's standard deviation logged
+     * @tparam T The type of the named variable
+     * @throws InvalidAgentVar If the agent var was not found inside the specified agent
+     * @throws InvalidArgument If the agent var's standard deviation has already been marked for logging
+     */
+    template<typename T>
+    void logStandardDev(const std::string &variable_name);
+    /**
+     * Mark the min of the named agent variable to be logged
+     * @param variable_name Name of the agent variable to have it's min logged
+     * @tparam T The type of the named variable
+     * @throws InvalidAgentVar If the agent var was not found inside the specified agent
+     * @throws InvalidArgument If the agent var's min has already been marked for logging
+     */
+    template<typename T>
+    void logMin(const std::string &variable_name);
+    /**
+     * Mark the max of the named agent variable to be logged
+     * @param variable_name Name of the agent variable to have it's max logged
+     * @tparam T The type of the named variable
+     * @throws InvalidAgentVar If the agent var was not found inside the specified agent
+     * @throws InvalidArgument If the agent var's max has already been marked for logging
+     */
+    template<typename T>
+    void logMax(const std::string &variable_name);
+    /**
+     * Mark the sum of the named agent variable to be logged
+     * @param variable_name Name of the agent variable to have it's sum logged
+     * @tparam T The type of the named variable
+     * @throws InvalidAgentVar If the agent var was not found inside the specified agent
+     * @throws InvalidArgument If the agent var's sum has already been marked for logging
+     */
+    template<typename T>
+    void logSum(const std::string &variable_name);
+
+ private:
+    /**
+     * Generic logging method
+     * Returns false if that property combo already exists
+     * @throws InvalidAgentVar If the agent var was not found inside the specified agent
+     */
+    void log(const LoggingConfig::NameReductionFn &name, const std::type_index &variable_type, const std::string &method_name);
+    /**
+     * Reference to the agent data structure, for validation agent variable names
+     */
+    const std::shared_ptr<const AgentData> agent;
+    /**
+     * Reference to the set for storing this agent-states logging choices
+     */
+    const std::shared_ptr<std::set<LoggingConfig::NameReductionFn>> agent_set;
+    /**
+     * Bool flag tracking whether the count of agents in the targeted state will be logged
+     */
+    bool &log_count;
+};
+
+
+// Template hackery to for type conversion between input type and result type
+template <typename T> struct sum_input_t;
+template <> struct sum_input_t<float> { typedef double result_t; };
+template <> struct sum_input_t<double> { typedef double result_t; };
+template <> struct sum_input_t<char> { typedef uint64_t result_t; };
+template <> struct sum_input_t<uint8_t> { typedef uint64_t result_t; };
+template <> struct sum_input_t<uint16_t> { typedef uint64_t result_t; };
+template <> struct sum_input_t<uint32_t> { typedef uint64_t result_t; };
+template <> struct sum_input_t<uint64_t> { typedef uint64_t result_t; };
+template <> struct sum_input_t<int8_t> { typedef int64_t result_t; };
+template <> struct sum_input_t<int16_t> { typedef int64_t result_t; };
+template <> struct sum_input_t<int32_t> { typedef int64_t result_t; };
+template <> struct sum_input_t<int64_t> { typedef int64_t result_t; };
+template <typename T> struct sum_input_t { typedef T result_t; };
+
+/**
+ * @brief FLAMEGPU log reduction function pointer definition
+ *  this runs on the host as an init/step/exit or host layer function
+ */
+template<typename T>
+Any getAgentVariableMeanFunc(HostAgentInstance &ai, const std::string &variable_name) {
+    return Any(ai.sum<T, typename sum_input_t<T>::result_t>(variable_name) / static_cast<double>(ai.count()));
+}
+template<typename T>
+Any getAgentVariableSumFunc(HostAgentInstance &ai, const std::string &variable_name) {
+    return Any(ai.sum<T, typename sum_input_t<T>::result_t>(variable_name));
+}
+template<typename T>
+Any getAgentVariableMinFunc(HostAgentInstance &ai, const std::string &variable_name) {
+    return Any(ai.min<T>(variable_name));
+}
+template<typename T>
+Any getAgentVariableMaxFunc(HostAgentInstance &ai, const std::string &variable_name) {
+    return Any(ai.max<T>(variable_name));
+}
+
+template<typename T>
+Any getAgentVariableStandardDevFunc(HostAgentInstance &ai, const std::string &variable_name) {
+    // Todo, workout how to make this more multi-thread/deviceable.
+    // Todo, streams for the memcpy?
+    // Work out the Mean
+    const double mean = ai.sum<T, typename sum_input_t<T>::result_t>(variable_name) / static_cast<double>(ai.count());
+    // Then for each number: subtract the Mean and square the result
+    // Then work out the mean of those squared differences.
+    auto lock = std::unique_lock<std::mutex>(flamegpu_internal::STANDARD_DEVIATION_MEAN_mutex);
+    gpuErrchk(cudaMemcpyToSymbol(flamegpu_internal::STANDARD_DEVIATION_MEAN, &mean, sizeof(double)));
+    const double variance = ai.transformReduce<T, double>(variable_name, flamegpu_internal::standard_deviation_subtract_mean, flamegpu_internal::standard_deviation_add, 0) / static_cast<double>(ai.count());
+    lock.unlock();
+    // Take the square root of that and we are done!
+    return Any(sqrt(variance));
+}
+
+template<typename T>
+void AgentLoggingConfig::logMean(const std::string &variable_name) {
+    // Instantiate the template function for calculating the mean
+    LoggingConfig::ReductionFn *fn = getAgentVariableMeanFunc<T>;
+    // Log the property (validation occurs in this common log method)
+    log({variable_name, LoggingConfig::Mean, fn}, std::type_index(typeid(T)), "Mean");
+}
+template<typename T>
+void AgentLoggingConfig::logStandardDev(const std::string &variable_name) {
+    // Instantiate the template function for calculating the mean
+    LoggingConfig::ReductionFn *fn = getAgentVariableStandardDevFunc<T>;
+    // Log the property (validation occurs in this common log method)
+    log({variable_name, LoggingConfig::StandardDev, fn}, std::type_index(typeid(T)), "StandardDev");
+}
+template<typename T>
+void AgentLoggingConfig::logMin(const std::string &variable_name) {
+    // Instantiate the template function for calculating the mean
+    LoggingConfig::ReductionFn *fn = getAgentVariableMinFunc<T>;
+    // Log the property (validation occurs in this common log method)
+    log({variable_name, LoggingConfig::Min, fn}, std::type_index(typeid(T)), "Min");
+}
+template<typename T>
+void AgentLoggingConfig::logMax(const std::string &variable_name) {
+    // Instantiate the template function for calculating the mean
+    LoggingConfig::ReductionFn *fn = getAgentVariableMaxFunc<T>;
+    // Log the property (validation occurs in this common log method)
+    log({variable_name, LoggingConfig::Max, fn}, std::type_index(typeid(T)), "Max");
+}
+template<typename T>
+void AgentLoggingConfig::logSum(const std::string &variable_name) {
+    // Instantiate the template function for calculating the mean
+    LoggingConfig::ReductionFn *fn = getAgentVariableSumFunc<T>;
+    // Log the property (validation occurs in this common log method)
+    log({variable_name, LoggingConfig::Sum, fn}, std::type_index(typeid(T)), "Sum");
+}
+#endif  // INCLUDE_FLAMEGPU_SIM_AGENTLOGGINGCONFIG_H_

--- a/include/flamegpu/sim/AgentLoggingConfig_Reductions.cuh
+++ b/include/flamegpu/sim/AgentLoggingConfig_Reductions.cuh
@@ -1,0 +1,39 @@
+#ifndef INCLUDE_FLAMEGPU_SIM_AGENTLOGGINGCONFIG_REDUCTIONS_CUH_
+#define INCLUDE_FLAMEGPU_SIM_AGENTLOGGINGCONFIG_REDUCTIONS_CUH_
+
+#include <functional>
+
+namespace flamegpu_internal {
+// standard_deviation_add_impl is a manual expansion of FLAMEGPU_CUSTOM_REDUCTION()
+// This is required, so that the instance definition can be extern'd, as it is placed in a header
+struct standard_deviation_add_impl {
+ public:
+    template <typename OutT>
+    struct binary_function : public std::binary_function<OutT, OutT, OutT> {
+        __device__ __forceinline__ OutT operator()(const OutT &a, const OutT &b) const;
+    };
+};
+// standard_deviation_subtract_mean_impl is a manual expansion of FLAMEGPU_CUSTOM_TRANSFORM()
+// This is required, so that the instance definition can be extern'd, as it is placed in a header
+struct standard_deviation_subtract_mean_impl {
+ public:
+    template<typename InT, typename OutT>
+    struct unary_function : public std::unary_function<InT, OutT> {
+        __host__ __device__ OutT operator()(const InT &a) const;
+    };
+};
+extern __constant__ double STANDARD_DEVIATION_MEAN;
+extern std::mutex STANDARD_DEVIATION_MEAN_mutex;
+extern standard_deviation_add_impl standard_deviation_add;
+extern standard_deviation_subtract_mean_impl standard_deviation_subtract_mean;
+template <typename OutT>
+__device__ __forceinline__ OutT standard_deviation_add_impl::binary_function<OutT>::operator()(const OutT & a, const OutT & b) const {
+    return a + b;
+}
+template<typename InT, typename OutT>
+__device__ __forceinline__ OutT standard_deviation_subtract_mean_impl::unary_function<InT, OutT>::operator()(const InT &a) const {
+    return pow(a - flamegpu_internal::STANDARD_DEVIATION_MEAN, 2.0);
+}
+}  // namespace flamegpu_internal
+
+#endif  // INCLUDE_FLAMEGPU_SIM_AGENTLOGGINGCONFIG_REDUCTIONS_CUH_

--- a/include/flamegpu/sim/LogFrame.h
+++ b/include/flamegpu/sim/LogFrame.h
@@ -1,0 +1,221 @@
+#ifndef INCLUDE_FLAMEGPU_SIM_LOGFRAME_H_
+#define INCLUDE_FLAMEGPU_SIM_LOGFRAME_H_
+
+#include "AgentLoggingConfig.h"
+
+#include <map>
+#include <list>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "flamegpu/sim/LoggingConfig.h"
+#include "flamegpu/util/Any.h"
+#include "flamegpu/exception/FGPUException.h"
+
+struct AgentLogFrame;
+
+/**
+ * Perhaps separate the data and interface in these classes?
+ */
+struct LogFrame {
+    friend class CUDASimulation;
+    /**
+     * Default constructor, creates an empty log
+     */
+    LogFrame();
+    /**
+     * Creates a log with pre-populated data
+     */
+    LogFrame(const std::map<std::string, Any> &&_environment,
+    const std::map<LoggingConfig::NameStatePair, std::pair<std::map<LoggingConfig::NameReductionFn, Any>, unsigned int>> &&_agents,
+    const unsigned int &_step_count);
+    /**
+     * Returns the step count of the log
+     * 0 is the state prior to the first step
+     */
+    unsigned int getStepCount() const { return step_count; }
+    /**
+     * Environment log accessors
+     */
+    bool hasEnvironmentProperty(const std::string &property_name) const;
+    template<typename T>
+    T getEnvironmentProperty(const std::string &property_name) const;
+    template<typename T, unsigned int N>
+    std::array<T, N> getEnvironmentProperty(const std::string &property_name) const;
+#ifdef SWIG
+    /**
+     * Gets an environment property array
+     * @param name name used for accessing the property
+     * @tparam T Type of the elements of the environment property array
+     * @throws InvalidEnvProperty If a property array of the name does not exist
+     */
+    template<typename T>
+    std::vector<T> getEnvironmentPropertyArray(const std::string &property_name) const;
+#endif
+    /**
+     * Agent log accessor
+     */
+    AgentLogFrame getAgent(const std::string &agent_name, const std::string &state_name = ModelData::DEFAULT_STATE) const;
+    /**
+     * Raw access to environment log map
+     */
+    const std::map<std::string, Any> &getEnvironment() const { return environment; }
+    /**
+     * Raw access to agent log map
+     */
+    const std::map<LoggingConfig::NameStatePair, std::pair<std::map<LoggingConfig::NameReductionFn, Any>, unsigned int>> &getAgents() const { return agents; }
+
+ private:
+    std::map<std::string, Any> environment;
+    std::map<LoggingConfig::NameStatePair, std::pair<std::map<LoggingConfig::NameReductionFn, Any>, unsigned int>> agents;
+    unsigned int step_count;
+};
+
+struct RunLog {
+    friend class CUDASimulation;
+    /**
+     * Constructs an empty RunLog
+     */
+    RunLog() { }
+    RunLog(const LogFrame &_exit, const std::list<LogFrame> &_step)
+        : exit(_exit)
+        , step(_step) { }
+
+    const LogFrame &getExitLog() const { return exit; }
+    const std::list<LogFrame> &getStepLog() const {return step; }
+    unsigned int getRandomSeed() const { return random_seed; }
+
+ private:
+    LogFrame exit;
+    std::list<LogFrame> step;
+    unsigned int random_seed = 0;
+    unsigned int step_log_frequency = 0;
+};
+struct AgentLogFrame {
+    explicit AgentLogFrame(const std::map<LoggingConfig::NameReductionFn, Any> &data, const unsigned int &count);
+    unsigned int getCount() const;
+    template<typename T>
+    T getMin(const std::string &variable_name) const;
+    template<typename T>
+    T getMax(const std::string &variable_name) const;
+    template<typename T>
+    typename sum_input_t<T>::result_t getSum(const std::string &variable_name) const;
+    double getMean(const std::string &variable_name) const;
+    double getStandardDev(const std::string &variable_name) const;
+
+ private:
+    const std::map<LoggingConfig::NameReductionFn, Any> &data;
+    const unsigned int &count;
+};
+
+template<typename T>
+T LogFrame::getEnvironmentProperty(const std::string &property_name) const {
+    const auto &it = environment.find(property_name);
+    if (it == environment.end()) {
+      THROW InvalidEnvProperty("Environment property '%s' was not found in the log, "
+          "in LogFrame::getEnvironmentProperty()\n",
+          property_name.c_str());
+    }
+    if (it->second.type != std::type_index(typeid(T))) {
+      THROW InvalidEnvPropertyType("Environment property '%s' has type %s, but requested type %s, "
+          "in LogFrame::getEnvironmentProperty()\n",
+          property_name.c_str(), it->second.type.name(), std::type_index(typeid(T)).name());
+    }
+    if (it->second.elements != 1) {
+      THROW InvalidEnvPropertyType("Environment property '%s' is an array, use alternate function with array interface, "
+          "in LogFrame::getEnvironmentProperty()\n",
+          property_name.c_str(), it->second.type.name(), std::type_index(typeid(T)).name());
+    }
+    return *static_cast<T*>(it->second.ptr);
+}
+template<typename T, unsigned int N>
+std::array<T, N> LogFrame::getEnvironmentProperty(const std::string &property_name) const {
+    const auto &it = environment.find(property_name);
+    if (it == environment.end()) {
+      THROW InvalidEnvProperty("Environment property '%s' was not found in the log, "
+          "in LogFrame::getEnvironmentProperty()\n",
+          property_name.c_str());
+    }
+    if (it->second.type != std::type_index(typeid(T))) {
+      THROW InvalidEnvPropertyType("Environment property '%s' has type %s, but requested type %s, "
+          "in LogFrame::getEnvironmentProperty()\n",
+          property_name.c_str(), it->second.type.name(), std::type_index(typeid(T)).name());
+    }
+    if (it->second.elements != N) {
+      THROW InvalidEnvPropertyType("Environment property array '%s' has %u elements, but requested array with %u, "
+          "in LogFrame::getEnvironmentProperty()\n",
+          property_name.c_str(), it->second.elements, N);
+    }
+    std::array<T, N> rtn;
+    memcpy(rtn.data(), it->second.ptr, it->second.length);
+    return rtn;
+}
+#ifdef SWIG
+template<typename T>
+std::vector<T> LogFrame::getEnvironmentPropertyArray(const std::string& property_name) const {
+    const auto &it = environment.find(property_name);
+    if (it == environment.end()) {
+      THROW InvalidEnvProperty("Environment property '%s' was not found in the log, "
+          "in LogFrame::getEnvironmentPropertyArray()\n",
+          property_name.c_str());
+    }
+    if (it->second.type != std::type_index(typeid(T))) {
+      THROW InvalidEnvPropertyType("Environment property '%s' has type %s, but requested type %s, "
+          "in LogFrame::getEnvironmentPropertyArray()\n",
+          property_name.c_str(), it->second.type.name(), std::type_index(typeid(T)).name());
+    }
+    // Copy old data to return
+    std::vector<T> rtn(static_cast<size_t>(it->second.elements));
+    memcpy(rtn.data(), it->second.ptr, it->second.length);
+    return rtn;
+}
+#endif
+
+template<typename T>
+T AgentLogFrame::getMin(const std::string &variable_name) const {
+    const auto &it = data.find({variable_name, LoggingConfig::Min});
+    if (it == data.end()) {
+        THROW InvalidAgentVar("Min of agent variable '%s' was not found in the log, "
+            "in AgentLogFrame::getMin()\n",
+            variable_name.c_str());
+    }
+    if (it->second.type != std::type_index(typeid(T))) {
+      THROW InvalidVarType("Agent variable '%s' has type %s, but requested type %s, "
+          "in AgentLogFrame::getMin()\n",
+          variable_name.c_str(), it->second.type.name(), std::type_index(typeid(T)).name());
+    }
+    return *static_cast<T *>(it->second.ptr);
+}
+template<typename T>
+T AgentLogFrame::getMax(const std::string &variable_name) const {
+    const auto &it = data.find({variable_name, LoggingConfig::Max});
+    if (it == data.end()) {
+        THROW InvalidAgentVar("Max of agent variable '%s' was not found in the log, "
+            "in AgentLogFrame::getMax()\n",
+            variable_name.c_str());
+    }
+    if (it->second.type != std::type_index(typeid(T))) {
+      THROW InvalidVarType("Agent variable '%s' has type %s, but requested type %s, "
+          "in AgentLogFrame::getMax()\n",
+          variable_name.c_str(), it->second.type.name(), std::type_index(typeid(T)).name());
+    }
+    return *static_cast<T *>(it->second.ptr);
+}
+template<typename T>
+typename sum_input_t<T>::result_t AgentLogFrame::getSum(const std::string &variable_name) const {
+    const auto &it = data.find({variable_name, LoggingConfig::Sum});
+    if (it == data.end()) {
+        THROW InvalidAgentVar("Sum of agent variable '%s' was not found in the log, "
+            "in AgentLogFrame::getSum()\n",
+            variable_name.c_str());
+    }
+    if (it->second.type != std::type_index(typeid(typename sum_input_t<T>::result_t))) {
+      THROW InvalidVarType("Agent variable is not of type '%s', but requested type %s, "
+          "in AgentLogFrame::getSum()\n",
+          variable_name.c_str(), std::type_index(typeid(T)).name());
+    }
+    return *static_cast<typename sum_input_t<T>::result_t *>(it->second.ptr);
+}
+
+#endif  // INCLUDE_FLAMEGPU_SIM_LOGFRAME_H_

--- a/include/flamegpu/sim/LoggingConfig.h
+++ b/include/flamegpu/sim/LoggingConfig.h
@@ -1,0 +1,122 @@
+#ifndef INCLUDE_FLAMEGPU_SIM_LOGGINGCONFIG_H_
+#define INCLUDE_FLAMEGPU_SIM_LOGGINGCONFIG_H_
+
+#include <string>
+#include <map>
+#include <set>
+#include <utility>
+#include <memory>
+
+#include "flamegpu/runtime/flamegpu_host_agent_api.h"
+#include "flamegpu/model/ModelData.h"
+#include "flamegpu/gpu/CUDAEnsemble.h"
+
+class AgentLoggingConfig;
+
+/**
+ * Interface to the data structure for controlling how model data is logged
+ */
+class LoggingConfig {
+    /**
+     * Requires access to typedefs and enums
+     */
+    friend class AgentLoggingConfig;
+    /**
+     * Requires access to model for validating model description hierarchy match
+     */
+    // friend void CUDASimulation::setStepLog(const StepLoggingConfig &);
+    // friend void CUDASimulation::setExitLog(const LoggingConfig &);
+    friend void CUDAEnsemble::setStepLog(const StepLoggingConfig &);
+    friend void CUDAEnsemble::setExitLog(const LoggingConfig &);
+    /**
+     * CUDASimulation::processStepLog() Requires access for reading the config
+     */
+    friend class CUDASimulation;
+
+ public:
+    /**
+     * Enum representing the available reduction types for agent variables
+     */
+    enum Reduction{ Mean, StandardDev, Min, Max, Sum };
+    static constexpr const char *toString(const Reduction &r) {
+        switch (r) {
+        case Mean: return "mean";
+        case StandardDev:  return "standard_deviation";;
+        case Min: return "min";
+        case Max: return "max";
+        case Sum: return "sum";
+        default: return "unknown";
+        }
+    }
+    typedef std::pair<std::string, std::string> NameStatePair;
+    typedef Any (ReductionFn)(HostAgentInstance &ai, const std::string &variable_name);
+    struct NameReductionFn {
+        std::string name;
+        Reduction reduction;
+        ReductionFn *function;
+        bool operator<(const NameReductionFn &other) const {
+            if (name == other.name) {
+                return reduction < other.reduction;
+            }
+            return name < other.name;
+        }
+    };
+    /**
+     * Constructor
+     * @param model The ModelDescriptionHierarchy to produce a logging config for
+     */
+    explicit LoggingConfig(const ModelDescription &model);
+    explicit LoggingConfig(const ModelData &model);
+    /**
+     * Copy Constructor
+     */
+    explicit LoggingConfig(const LoggingConfig &other);
+    /**
+     * Returns an interface to the logging config for the named agent state
+     */
+    AgentLoggingConfig agent(const std::string &agent_name, const std::string &agent_state = ModelData::DEFAULT_STATE);
+    /**
+     * Mark a named environment property to be logged
+     * @param property_name Name of the environment property to be logged
+     * @throws InvalidEnvironment
+     */
+    void logEnvironment(const std::string &property_name);
+
+ private:
+    std::shared_ptr<const ModelData> model;
+    std::set<std::string> environment;
+    /**
+     * map<<agent_name:agent_state, variable_reductions:log_count>
+     */
+    std::map<NameStatePair, std::pair<std::shared_ptr<std::set<NameReductionFn>>, bool>> agents;
+};
+
+class StepLoggingConfig : public LoggingConfig {
+    /**
+     * CUDASimulation::processStepLog() requires access for reading the config
+     */
+    friend class CUDASimulation;
+ public:
+    /**
+     * Constructor
+     * @param model The ModelDescriptionHierarchy to produce a logging config for
+     */
+    explicit StepLoggingConfig(const ModelDescription &model);
+    explicit StepLoggingConfig(const ModelData &model);
+    /**
+     * Copy Constructor
+     */
+    explicit StepLoggingConfig(const StepLoggingConfig &model);
+    explicit StepLoggingConfig(const LoggingConfig &model);
+    /**
+     * Set the frequency of step log collection
+     * How many steps between each log collection, defaults to 1, so a log is collected every step
+     * A value of 0 disables step log collection
+     */
+    void setFrequency(const unsigned int &steps);
+
+ private:
+    unsigned int frequency;
+};
+
+#endif  // INCLUDE_FLAMEGPU_SIM_LOGGINGCONFIG_H_

--- a/include/flamegpu/sim/RunPlan.h
+++ b/include/flamegpu/sim/RunPlan.h
@@ -1,0 +1,395 @@
+#ifndef INCLUDE_FLAMEGPU_SIM_RUNPLAN_H_
+#define INCLUDE_FLAMEGPU_SIM_RUNPLAN_H_
+
+#include <unordered_map>
+#include <string>
+#include <typeinfo>
+#include <vector>
+#include <memory>
+
+#include "flamegpu/model/EnvironmentDescription.h"
+#include "flamegpu/util/Any.h"
+#include "flamegpu/gpu/CUDAEnsemble.h"
+
+
+class ModelDescription;
+class RunPlanVec;
+/**
+ * Individual run config
+ */
+class RunPlan {
+    friend class RunPlanVec;
+    friend class SimRunner;
+    friend class jsonLogger;
+    friend class xmlLogger;
+
+ public:
+    /**
+     * Constructor this will need to set the random seed to a default value, +1 of previous EnsembleRun would make sense
+     * @param environment EnvironmentDescription to limit properties by
+     * @todo Where will default steps and random seed come from?
+     */
+    explicit RunPlan(const ModelDescription &environment);
+    RunPlan& operator=(const RunPlan& other);
+
+    /**
+     * Set the random seed passed to this run of the simulation
+     * @param random_seed Seed for random generation during execution
+     */
+    void setRandomSimulationSeed(const unsigned int &random_seed);
+    /**
+     * Set the number of steps for this instance of the simulation
+     * A steps value of 0 requires the ModelDescription to have atleast 1 exit condition
+     * @param steps The number of steps to execute, 0 is unlimited but requires an exit condition
+     */
+    void setSteps(const unsigned int &steps);
+    /**
+     * Set the sub directory within the output directory for outputs of this run
+     * If left empty, output will not goto subdirectories
+     * @param steps The number of steps to execute, 0 is unlimited but requires an exit condition
+     */
+    void setOutputSubdirectory(const std::string &subdir);
+    /**
+     * Set the environment property override for this run of the model
+     * @param name Environment property name
+     * @param value Environment property value (override)
+     * @tparam T Type of the environment property
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T
+     */
+    template<typename T>
+    void setProperty(const std::string &name, const T&value);
+    /**
+     * Set the environment property override for this run of the model
+     * This version should be used for array properties
+     * @param name Environment property name
+     * @param value Environment property value (override)
+     * @tparam T Type of the environment property
+     * @tparam N Length of the array to be returned
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T, or length to N
+     */
+    template<typename T, EnvironmentManager::size_type N>
+    void setProperty(const std::string &name, const std::array<T, N> &value);
+    /**
+     * Set the environment property override for this run of the model
+     * This version should be used for setting individual elements of array properties
+     * @param name Environment property name
+     * @param index Length of the array to be returned
+     * @param value Environment property value (override)
+     * @tparam T Type of the environment property
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T
+     * @throws std::out_of_range If index is not in range of the length of the property array
+     */
+    template<typename T>
+    void setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value);
+#ifdef SWIG
+    /**
+     * Set the environment property override for this run of the model
+     * This version should be used for array properties
+     * @param name Environment property name
+     * @param length Length of the environmental property array to be created
+     * @param value Environment property value (override)
+     * @tparam T Type of the environment property
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvProperty If value.size() != length
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T, or length to N
+     */
+    template<typename T>
+    void setPropertyArray(const std::string &name, const EnvironmentManager::size_type &length, const std::vector<T> &value);
+#endif
+    /**
+     * Returns the random seed used for this simulation run
+     */
+    unsigned int getRandomSimulationSeed() const;
+    /**
+     * Returns the number of steps to be executed for this simulation run
+     * 0 means unlimited, and is only available if the model description has an exit condition
+     */
+    unsigned int getSteps() const;
+    /**
+     * Returns the currently configured output subdirectory directory
+     * Empty string means output for this run will not be placed into a subdirectory
+     */
+    std::string getOutputSubdirectory() const;
+
+    /**
+     * Gets the currently configured environment property value
+     * @param name name used for accessing the property
+     * @tparam T Type of the value to be returned
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T
+     */
+    template<typename T>
+    T getProperty(const std::string &name) const;
+    /**
+     * Gets the currently configured environment property array value
+     * @param name name used for accessing the property
+     * @tparam T Type of the value to be returned
+     * @tparam N Length of the array to be returned
+     * @throws InvalidEnvProperty If a property array of the name does not exist
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T
+     */
+    template<typename T, EnvironmentManager::size_type N>
+    std::array<T, N> getProperty(const std::string &name) const;
+    /**
+     * Gets an element of the currently configured environment property array
+     * @param name name used for accessing the property
+     * @param index element from the environment property array to return
+     * @tparam T Type of the value to be returned
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T
+     * @throws std::out_of_range If index is not in range of the length of the property array
+     */
+    template<typename T>
+    T getProperty(const std::string &name, const EnvironmentManager::size_type &index) const;
+#ifdef SWIG
+    /**
+     * Gets the currently configured environment property array value
+     * @param name Environment property name
+     * @tparam T Type of the environment property
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T
+     */
+    template<typename T>
+    std::vector<T> getPropertyArray(const std::string &name);
+#endif
+
+    /**
+     * Operator methods for combining vectors
+     */
+    RunPlanVec operator+(const RunPlan& rhs) const;
+    RunPlanVec operator+(const RunPlanVec& rhs) const;
+    RunPlanVec operator*(const unsigned int& rhs) const;
+
+ private:
+    explicit RunPlan(const std::shared_ptr<const std::unordered_map<std::string, EnvironmentDescription::PropData>> &environment, const bool &allow_0);
+    unsigned int random_seed;
+    unsigned int steps;
+    std::string output_subdirectory;
+    std::unordered_map<std::string, Any> property_overrides;
+    /**
+     * Reference to model environment data, for validation
+     */
+    // This needs to be shared_ptr, reference goes out of scope, otherwise have a copy of the map per RunPlan
+    std::shared_ptr<const std::unordered_map<std::string, EnvironmentDescription::PropData>> environment;
+    /**
+     * This flag denotes whether 0 steps are permitted
+     */
+    bool allow_0_steps;
+};
+
+template<typename T>
+void RunPlan::setProperty(const std::string &name, const T&value) {
+    // Validation
+    const auto it = environment->find(name);
+    if (it == environment->end()) {
+        THROW InvalidEnvProperty("Environment description does not contain property '%s', "
+            "in RunPlan::setProperty()\n",
+            name.c_str());
+    }
+    if (it->second.data.type != std::type_index(typeid(T))) {
+        THROW InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
+            "in RunPlan::setProperty()\n",
+            name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
+    }
+    if (it->second.data.elements != 1) {
+        THROW InvalidEnvPropertyType("Environment property '%s' is an array with %u elements, array method should be used, "
+            "in RunPlan::setProperty()\n",
+            name.c_str(), it->second.data.elements);
+    }
+    // Store property
+    property_overrides.emplace(name, Any(&value, sizeof(T), typeid(T), 1));
+}
+template<typename T, EnvironmentManager::size_type N>
+void RunPlan::setProperty(const std::string &name, const std::array<T, N> &value) {
+    // Validation
+    const auto it = environment->find(name);
+    if (it == environment->end()) {
+        THROW InvalidEnvProperty("Environment description does not contain property '%s', "
+            "in RunPlan::setProperty()\n",
+            name.c_str());
+    }
+    if (it->second.data.type != std::type_index(typeid(T))) {
+        THROW InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
+            "in RunPlan::setProperty()\n",
+            name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
+    }
+    if (it->second.data.elements != N) {
+        THROW InvalidEnvPropertyType("Environment property array '%s' length mismatch %u != %u "
+            "in RunPlan::setProperty()\n",
+            name.c_str(), it->second.data.elements, N);
+    }
+    // Store property
+    property_overrides.emplace(name, Any(value.data(), sizeof(T) * N, typeid(T), N));
+}
+template<typename T>
+void RunPlan::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value) {
+    // Validation
+    const auto it = environment->find(name);
+    if (it == environment->end()) {
+        THROW InvalidEnvProperty("Environment description does not contain property '%s', "
+            "in RunPlan::setProperty()\n",
+            name.c_str());
+    }
+    if (it->second.data.type != std::type_index(typeid(T))) {
+        THROW InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
+            "in RunPlan::setProperty()\n",
+            name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
+    }
+    if (it->second.data.elements >= index) {
+        throw std::out_of_range("Environment property array index out of bounds "
+            "in RunPlan::setProperty()\n");
+    }
+    // Check whether array already exists in property overrides
+    auto it2 = property_overrides.find(name);
+    if (it2 == property_overrides.end()) {
+        // Clone default property first
+        it2 = property_overrides.emplace(name, it->second.data).first;
+    }
+    // Store property
+    memcpy(static_cast<T*>(it2->second.ptr) + index, &value, sizeof(T));
+}
+#ifdef SWIG
+template<typename T>
+void RunPlan::setPropertyArray(const std::string &name, const EnvironmentManager::size_type &N, const std::vector<T> &value) {
+    // Validation
+    const auto it = environment->find(name);
+    if (it == environment->end()) {
+        THROW InvalidEnvProperty("Environment description does not contain property '%s', "
+            "in RunPlan::setProperty()\n",
+            name.c_str());
+    }
+    if (it->second.data.type != std::type_index(typeid(T))) {
+        THROW InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
+            "in RunPlan::setProperty()\n",
+            name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
+    }
+    if (it->second.data.elements != N) {
+        THROW InvalidEnvProperty("Environment property array '%s' length mismatch %u != %u, "
+            "in RunPlan::setProperty()\n",
+            name.c_str(), it->second.data.elements, N);
+    }
+    if (value.size() != N) {
+        THROW InvalidEnvProperty("Environment property array length does not match the value provided, %u != %llu,"
+            "in RunPlan::setProperty()\n",
+            name.c_str(), value.size(), N);
+    }
+    // Store property
+    property_overrides.emplace(name, Any(value.data(), sizeof(T) * N, typeid(T), N));
+}
+#endif
+
+template<typename T>
+T RunPlan::getProperty(const std::string &name) const {
+    // Validation
+    const auto it = environment->find(name);
+    if (it == environment->end()) {
+        THROW InvalidEnvProperty("Environment description does not contain property '%s', "
+            "in RunPlan::getProperty()\n",
+            name.c_str());
+    }
+    if (it->second.data.type != std::type_index(typeid(T))) {
+        THROW InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
+            "in RunPlan::getProperty()\n",
+            name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
+    }
+    if (it->second.data.elements != 1) {
+        THROW InvalidEnvPropertyType("Environment property '%s' is an array with %u elements, array method should be used, "
+            "in RunPlan::getProperty()\n",
+            name.c_str(), it->second.data.elements);
+    }
+    // Check whether property already exists in property overrides
+    const auto it2 = property_overrides.find(name);
+    if (it2 == property_overrides.end())
+      return *static_cast<T *>(it2->second.ptr);
+    return *static_cast<T *>(it->second.data.ptr);
+}
+template<typename T, EnvironmentManager::size_type N>
+std::array<T, N> RunPlan::getProperty(const std::string &name) const {
+    // Validation
+    const auto it = environment->find(name);
+    if (it == environment->end()) {
+        THROW InvalidEnvProperty("Environment description does not contain property '%s', "
+            "in RunPlan::getProperty()\n",
+            name.c_str());
+    }
+    if (it->second.data.type != std::type_index(typeid(T))) {
+        THROW InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
+            "in RunPlan::getProperty()\n",
+            name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
+    }
+    if (it->second.data.elements != N) {
+        THROW InvalidEnvPropertyType("Environment property array '%s' length mismatch %u != %u "
+            "in RunPlan::getProperty()\n",
+            name.c_str(), it->second.data.elements, N);
+    }
+    // Check whether array already exists in property overrides
+    const auto it2 = property_overrides.find(name);
+    std::array<T, N> rtn;
+    if (it2 == property_overrides.end()) {
+        memcpy(rtn.data(), it2->second.ptr, it2->second.length);
+    } else {
+        memcpy(rtn.data(), it->second.data.ptr, it->second.data.length);
+    }
+    return rtn;
+}
+template<typename T>
+T RunPlan::getProperty(const std::string &name, const EnvironmentManager::size_type &index) const {
+    // Validation
+    const auto it = environment->find(name);
+    if (it == environment->end()) {
+        THROW InvalidEnvProperty("Environment description does not contain property '%s', "
+            "in RunPlan::getProperty()\n",
+            name.c_str());
+    }
+    if (it->second.data.type != std::type_index(typeid(T))) {
+        THROW InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
+            "in RunPlan::getProperty()\n",
+            name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
+    }
+    if (it->second.data.elements >= index) {
+        throw std::out_of_range("Environment property array index out of bounds "
+            "in RunPlan::getProperty()\n");
+    }
+    // Check whether property already exists in property overrides
+    const auto it2 = property_overrides.find(name);
+    if (it2 == property_overrides.end())
+      return static_cast<T *>(it2->second.ptr)[index];
+    return static_cast<T *>(it->second.data.ptr)[index];
+}
+#ifdef SWIG
+/**
+ * Gets the currently configured environment property array value
+ * @param name Environment property name
+ * @tparam T Type of the environment property
+ * @throws InvalidEnvProperty If a property of the name does not exist
+ */
+template<typename T>
+std::vector<T> RunPlan::getPropertyArray(const std::string &name) {
+    // Validation
+    const auto it = environment->find(name);
+    if (it == environment->end()) {
+        THROW InvalidEnvProperty("Environment description does not contain property '%s', "
+            "in RunPlan::getProperty()\n",
+            name.c_str());
+    }
+    if (it->second.data.type != std::type_index(typeid(T))) {
+        THROW InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
+            "in RunPlan::getProperty()\n",
+            name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
+    }
+    // Check whether array already exists in property overrides
+    const auto it2 = property_overrides.find(name);
+    std::vector<T> rtn(it->second.data.elements);
+    if (it2 == property_overrides.end()) {
+        memcpy(rtn.data(), it2->second.ptr, it2->second.length);
+    } else {
+        memcpy(rtn.data(), it->second.data.ptr, it->second.data.length);
+    }
+    return rtn;
+}
+#endif
+
+#endif  // INCLUDE_FLAMEGPU_SIM_RUNPLAN_H_

--- a/include/flamegpu/sim/RunPlanVec.h
+++ b/include/flamegpu/sim/RunPlanVec.h
@@ -1,0 +1,595 @@
+#ifndef INCLUDE_FLAMEGPU_SIM_RUNPLANVEC_H_
+#define INCLUDE_FLAMEGPU_SIM_RUNPLANVEC_H_
+
+#include <random>
+#include <vector>
+#include <unordered_map>
+#include <string>
+#include <memory>
+
+#include "flamegpu/sim/RunPlan.h"
+#include "flamegpu/exception/FGPUStaticAssert.h"
+
+class ModelDescription;
+class EnvironmentDescription;
+
+/**
+ * Vector of RunPlan
+ * Contains additional methods for generating collections of RunPlans and combining RunPlanVecs
+ */
+class RunPlanVec : private std::vector<RunPlan>  {
+    friend class RunPlan;
+    friend class SimRunner;
+    friend void CUDAEnsemble::simulate(const RunPlanVec &plans);
+
+ public:
+    /**
+     * Constructor, requires the model description to validate environment properties match up
+     * @todo Unsure if this will require additional info, e.g. steps?
+     */
+    explicit RunPlanVec(const ModelDescription &model, unsigned int initial_length);
+    /**
+     * Set the random simulation seed of each RunPlan currently within this vector
+     * @param initial_seed The random seed applied to the first item
+     * @param step The value added to the previous seed to calculate the next seed
+     * @note A step of 0, will give the exact same seed to all RunPlans
+     */
+    void setRandomSimulationSeed(const unsigned int &initial_seed, const unsigned int &step = 0);
+    /**
+     * Set the steps of each RunPlan currently within this vector
+     * @param steps The number of steps to be executed
+     * @note If 0 is provided, the model must have an exit condition
+     */
+    void setSteps(const unsigned int &steps);
+    /**
+     * Set the the sub directory within the output directory for outputs of runplans in this vector
+     * @param subdir The name of the subdirectory
+     * @note Defaults to empty string, where no subdirectory is used
+     */
+    void setOutputSubdirectory(const std::string &subdir);
+    /**
+     * Set named environment property to a specific value
+     * @param name The name of the environment property to set
+     * @param value The value of the environment property to set
+     * @tparam T The type of the environment property, this must match the ModelDescription
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T, or length > 1
+     */
+    template<typename T>
+    void setProperty(const std::string &name, const T &value);
+    /**
+     * Set named environment property array to a specific value
+     * This version should be used for array properties
+     * @param name Environment property name
+     * @param value Environment property value (override)
+     * @tparam T Type of the environment property
+     * @tparam N Length of the array to be returned
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T, or length to N
+     */
+    template<typename T, EnvironmentManager::size_type N>
+    void setProperty(const std::string &name, const std::array<T, N> &value);
+    /**
+     * Array property element equivalent of setProperty()
+     * @param name The name of the environment property array to affect
+     * @param index The index of the environment property array to set
+     * @param value The value of the environment property array to set
+     * @tparam T The type of the environment property, this must match the ModelDescription
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T
+     * @throws std::out_of_range If index is not in range of the length of the property array
+     * @see setProperty(const std::string &name, const T &value)
+     */
+    template<typename T>
+    void setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value);
+#ifdef SWIG
+    /**
+     * Set named environment property array to a specific value
+     * This version should be used for array properties
+     * @param name Environment property name
+     * @param length Length of the environmental property array to be created
+     * @param value Environment property value (override)
+     * @tparam T Type of the environment property
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvProperty If value.size() != length
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T, or length to N
+     */
+    template<typename T>
+    void setPropertyArray(const std::string &name, const EnvironmentManager::size_type &length, const std::vector<T> &value);
+#endif
+    /**
+     * Sweep named environment property over an inclusive uniform distribution
+     * value = min * (1.0 - a) + max * a, where a = index/(size()-1)
+     * @param name The name of the environment property to set
+     * @param min The value to set the first environment property
+     * @param max The value to set the last environment property
+     * @tparam T The type of the environment property, this must match the ModelDescription
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T, or length > 1
+     * @throws std::out_of_range If this vector has a length less than 2
+     */
+    template<typename T>
+    void setPropertyUniformDistribution(const std::string &name, const T &min, const T &max);
+    /**
+     * Array property element equivalent of setPropertyUniformDistribution()
+     * Sweep element of named environment property array over an inclusive uniform distribution
+     * value = min * (1.0 - a) + max * a, where a = index/(size()-1)
+     * @param name The name of the environment property to set
+     * @param index The index of the element within the environment property array to set
+     * @param min The value to set the first environment property array element
+     * @param max The value to set the last environment property array element
+     * @tparam T The type of the environment property, this must match the ModelDescription
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T
+     * @throws std::out_of_range If index is greater than or equal to the length of the environment property array
+     * @throws std::out_of_range If this vector has a length less than 2
+     * @see setPropertyUniformDistribution(const std::string &name, const T &min, const T &max)
+     */
+    template<typename T>
+    void setPropertyUniformDistribution(const std::string &name, const EnvironmentManager::size_type &index, const T &min, const T &max);
+    /**
+     * Seed the internal random generator used for random property distributions
+     * This will only affect subsequent calls to setPropertyRandom()
+     * @param seed The random seed to be used
+     */
+    void setRandomPropertySeed(const unsigned int &seed);
+    /**
+     * Sweep named environment property over a uniform random distribution
+     * Integer types have a range [min, max]
+     * Floating point types have a range [min, max)
+     * @param name The name of the environment property to set
+     * @param min The value of the range to set the first environment property
+     * @param max The value of the range to set the last environment property
+     * @tparam T The type of the environment property, this must match the ModelDescription
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T, or length > 1
+     * @throws std::out_of_range If this vector has a length less than 2
+     */
+    template<typename T>
+    void setPropertyUniformRandom(const std::string &name, const T &min, const T &max);
+    /**
+     * Array property element equivalent of setPropertyUniformRandom()
+     * Sweep named environment property over a uniform random distribution
+     * Integer types have a range [min, max]
+     * Floating point types have a range [min, max)
+     * @param name The name of the environment property to set
+     * @param min The value of the range to set the first environment property
+     * @param max The value of the range to set the last environment property
+     * @tparam T The type of the environment property, this must match the ModelDescription
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T
+     * @throws std::out_of_range If index is greater than or equal to the length of the environment property array
+     * @throws std::out_of_range If this vector has a length less than 2
+     * @see setPropertyUniformRandom(const std::string &name, const T &min, const T &max)
+     */
+    template<typename T>
+    void setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &min, const T &max);
+    /**
+     * Sweep named environment property over a normal random distribution
+     * Only floating point types are supported
+     * @param name The name of the environment property to set
+     * @param mean Mean of the distribution (its expected value). Which coincides with the location of its peak.
+     * @param stddev Standard deviation: The square root of variance, representing the dispersion of values from the distribution mean.
+     * @tparam T The type of the environment property, this must match the ModelDescription
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T, or length > 1
+     * @throws std::out_of_range If this vector has a length less than 2
+     */
+    template<typename T>
+    void setPropertyNormalRandom(const std::string &name, const T &mean, const T &stddev);
+    /**
+     * Array property element equivalent of setPropertyNormalRandom()
+     * Sweep named environment property over a normal random distribution
+     * Only floating point types are supported
+     * @param name The name of the environment property to set
+     * @param mean Mean of the distribution (its expected value). Which coincides with the location of its peak.
+     * @param stddev Standard deviation: The square root of variance, representing the dispersion of values from the distribution mean.
+     * @tparam T The type of the environment property, this must match the ModelDescription
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T
+     * @throws std::out_of_range If index is greater than or equal to the length of the environment property array
+     * @throws std::out_of_range If this vector has a length less than 2
+     * @see setPropertyNormalRandom(const std::string &name, const T &mean, const T &stddev)
+     */
+    template<typename T>
+    void setPropertyNormalRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &mean, const T &stddev);
+    /**
+     * Sweep named environment property over a log normal random distribution
+     * Only floating point types are supported
+     * @param name The name of the environment property to set
+     * @param mean Mean of the underlying normal distribution formed by the logarithm transformations of the possible values in this distribution.
+     * @param stddev Standard deviation of the underlying normal distribution formed by the logarithm transformations of the possible values in this distribution.
+     * @tparam T The type of the environment property, this must match the ModelDescription
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T, or length > 1
+     * @throws std::out_of_range If this vector has a length less than 2
+     */
+    template<typename T>
+    void setPropertyLogNormalRandom(const std::string &name, const T &mean, const T &stddev);
+    /**
+     * Array property element equivalent of setPropertyLogNormalRandom()
+     * Sweep named environment property over a log normal random distribution
+     * Only floating point types are supported
+     * @param name The name of the environment property to set
+     * @param mean Mean of the underlying normal distribution formed by the logarithm transformations of the possible values in this distribution.
+     * @param stddev Standard deviation of the underlying normal distribution formed by the logarithm transformations of the possible values in this distribution.
+     * @tparam T The type of the environment property, this must match the ModelDescription
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T
+     * @throws std::out_of_range If index is greater than or equal to the length of the environment property array
+     * @throws std::out_of_range If this vector has a length less than 2
+     * @see setPropertyNormalRandom(const std::string &name, const T &mean, const T &stddev)
+     */
+    template<typename T>
+    void setPropertyLogNormalRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &mean, const T &stddev);
+    /**
+     * Use a random distribution to generate parameters for the named environment property
+     * @param name The name of the environment property to set
+     * @param distribution The random distribution to use for generating random property values
+     * @tparam T The type of the environment property, this must match the ModelDescription
+     * @tparam rand_dist An object satisfying the requirements of RandomNumberDistribution e.g. std::uniform_real_distribution
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T, or length to N
+     * @throws std::out_of_range If this vector has a length less than 2
+     */
+    template<typename T, typename rand_dist>
+    void setPropertyRandom(const std::string &name, rand_dist &distribution);
+    /**
+     * Array property element equivalent of setPropertyRandom()
+     * Use a random distribution to generate parameters for the specified element of the named environment property array
+     * @param name The name of the environment property to set
+     * @param index The index of the element within the environment property array to set
+     * @param distribution The random distribution to use for generating random property values
+     * @tparam T The type of the environment property array, this must match the ModelDescription
+     * @tparam rand_dist An object satisfying the requirements of RandomNumberDistribution e.g. std::uniform_real_distribution
+     * @throws InvalidEnvProperty If a property of the name does not exist
+     * @throws InvalidEnvPropertyType If a property with the name has a type different to T, or length to N
+     * @throws std::out_of_range If index is greater than or equal to the length of the environment property array
+     * @throws std::out_of_range If this vector has a length less than 2
+     */
+    template<typename T, typename rand_dist>
+    void setPropertyRandom(const std::string &name, const EnvironmentManager::size_type &index, rand_dist &distribution);
+
+    /**
+     * Expose inherited std::vector methods/classes
+     */     
+#ifndef SWIG
+    using std::vector<RunPlan>::begin;
+    using std::vector<RunPlan>::end;
+    using std::vector<RunPlan>::size;
+    using std::vector<RunPlan>::operator[];
+    using std::vector<RunPlan>::insert;
+#else
+    // Can't get SWIG %import to use std::vector<RunPlan> so manually implement the required items
+    size_t size() const { return std::vector<RunPlan>::size(); }
+    RunPlan& operator[] (const size_t _Pos) { return std::vector<RunPlan>::operator[](_Pos); }
+#endif
+
+    /**
+     * Operator methods for combining vectors
+     */
+    RunPlanVec operator+(const RunPlan& rhs) const;
+    RunPlanVec operator+(const RunPlanVec& rhs) const;
+    RunPlanVec& operator+=(const RunPlan& rhs);
+    RunPlanVec& operator+=(const RunPlanVec& rhs);
+    RunPlanVec& operator*=(const unsigned int& rhs);
+    RunPlanVec operator*(const unsigned int& rhs) const;
+
+ private:
+    RunPlanVec(const std::shared_ptr<const std::unordered_map<std::string, EnvironmentDescription::PropData>> &environment, const bool &allow_0_steps);
+    /**
+     * Random distribution used by setPropertyRandom()
+     * Initially set to a random seed with std::random_device (which is a platform specific source of random integers)
+     */
+    std::mt19937 rand;
+    std::shared_ptr<const std::unordered_map<std::string, EnvironmentDescription::PropData>> environment;
+    const bool allow_0_steps;
+};
+
+template<typename T>
+void RunPlanVec::setProperty(const std::string &name, const T &value) {
+    // Validation
+    const auto it = environment->find(name);
+    if (it == environment->end()) {
+        THROW InvalidEnvProperty("Environment description does not contain property '%s', "
+            "in RunPlanVec::setProperty()\n",
+            name.c_str());
+    }
+    if (it->second.data.type != std::type_index(typeid(T))) {
+        THROW InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
+            "in RunPlanVec::setProperty()\n",
+            name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
+    }
+    if (it->second.data.elements == 1) {
+        THROW InvalidEnvPropertyType("Environment property '%s' is an array with %u elements, array method should be used, "
+            "in RunPlanVec::setProperty()\n",
+            name.c_str(), it->second.data.elements);
+    }
+    for (auto &i : *this) {
+        i.setProperty<T>(name, value);
+    }
+}
+template<typename T, EnvironmentManager::size_type N>
+void RunPlanVec::setProperty(const std::string &name, const std::array<T, N> &value) {
+    // Validation
+    const auto it = environment->find(name);
+    if (it == environment->end()) {
+        THROW InvalidEnvProperty("Environment description does not contain property '%s', "
+            "in RunPlanVec::setProperty()\n",
+            name.c_str());
+    }
+    if (it->second.data.type != std::type_index(typeid(T))) {
+        THROW InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
+            "in RunPlanVec::setProperty()\n",
+            name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
+    }
+    if (it->second.data.elements != N) {
+        THROW InvalidEnvPropertyType("Environment property array '%s' length mismatch %u != %u "
+            "in RunPlan::setProperty()\n",
+            name.c_str(), it->second.data.elements, N);
+    }
+    for (auto &i : *this) {
+        i.setProperty<T, N>(name, value);
+    }
+}
+template<typename T>
+void RunPlanVec::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value) {
+    // Validation
+    const auto it = environment->find(name);
+    if (it == environment->end()) {
+        THROW InvalidEnvProperty("Environment description does not contain property '%s', "
+            "in RunPlanVec::setProperty()\n",
+            name.c_str());
+    }
+    if (it->second.data.type != std::type_index(typeid(T))) {
+        THROW InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
+            "in RunPlanVec::setProperty()\n",
+            name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
+    }
+    if (it->second.data.elements >= index) {
+        throw std::out_of_range("Environment property array index out of bounds "
+            "in RunPlan::setProperty()\n");
+    }
+    for (auto &i : *this) {
+        i.setProperty<T>(name, index, value);
+    }
+}
+#ifdef SWIG
+template<typename T>
+void RunPlanVec::setPropertyArray(const std::string &name, const EnvironmentManager::size_type &N, const std::vector<T> &value) {
+    // Validation
+    const auto it = environment->find(name);
+    if (it == environment->end()) {
+        THROW InvalidEnvProperty("Environment description does not contain property '%s', "
+            "in RunPlanVec::setProperty()\n",
+            name.c_str());
+    }
+    if (it->second.data.type != std::type_index(typeid(T))) {
+        THROW InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
+            "in RunPlanVec::setProperty()\n",
+            name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
+    }
+    if (it->second.data.elements != N) {
+        THROW InvalidEnvPropertyType("Environment property array '%s' length mismatch %u != %u "
+            "in RunPlanVec::setProperty()\n",
+            name.c_str(), it->second.data.elements, N);
+    }
+    if (value.size() != N) {
+        THROW InvalidEnvProperty("Environment property array length does not match the value provided, %u != %llu,"
+            "in RunPlanVec::setProperty()\n",
+            name.c_str(), value.size(), N);
+    }
+    for (auto &i : *this) {
+        i.setPropertyArray<T>(name, N, value);
+    }
+}
+#endif
+
+template<typename T>
+void RunPlanVec::setPropertyUniformDistribution(const std::string &name, const T &min, const T &max) {
+    // Validation
+    if (this->size() < 2) {
+        THROW std::out_of_range("Unable to apply a property distribution a vector with less than 2 elements, "
+            "in RunPlanVec::setPropertyUniformDistribution()\n");
+    }
+    const auto it = environment->find(name);
+    if (it == environment->end()) {
+        THROW InvalidEnvProperty("Environment description does not contain property '%s', "
+            "in RunPlanVec::setPropertyUniformDistribution()\n",
+            name.c_str());
+    }
+    if (it->second.data.type != std::type_index(typeid(T))) {
+        THROW InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
+            "in RunPlanVec::setPropertyUniformDistribution()\n",
+            name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
+    }
+    if (it->second.data.elements != 1) {
+        THROW InvalidEnvPropertyType("Environment property '%s' is an array with %u elements, array method should be used, "
+            "in RunPlanVec::setPropertyUniformDistribution()\n",
+            name.c_str(), it->second.data.elements);
+    }
+    unsigned int ct = 0;
+    for (auto &i : *this) {
+        const double a = static_cast<double>(ct++) / (this->size() - 1);
+        const T lerp = static_cast<T>(round(min * (1.0 - a) + max * a));
+        i.setProperty<T>(name, lerp);
+    }
+}
+template<typename T>
+void RunPlanVec::setPropertyUniformDistribution(const std::string &name, const EnvironmentManager::size_type &index, const T &min, const T &max) {
+    // Validation
+    if (this->size() < 2) {
+        THROW std::out_of_range("Unable to apply a property distribution a vector with less than 2 elements, "
+            "in RunPlanVec::setPropertyUniformDistribution()\n");
+    }
+    const auto it = environment->find(name);
+    if (it == environment->end()) {
+        THROW InvalidEnvProperty("Environment description does not contain property '%s', "
+            "in RunPlanVec::setPropertyUniformDistribution()\n",
+            name.c_str());
+    }
+    if (it->second.data.type != std::type_index(typeid(T))) {
+        THROW InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
+            "in RunPlanVec::setPropertyUniformDistribution()\n",
+            name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
+    }
+    if (it->second.data.elements >= index) {
+        throw std::out_of_range("Environment property array index out of bounds "
+            "in RunPlan::setPropertyUniformDistribution()\n");
+    }
+    unsigned int ct = 0;
+    for (auto &i : *this) {
+        const double a = static_cast<double>(ct++) / (this->size() - 1);
+        const T lerp = static_cast<T>(round(min * (1.0 - a) + max * a));
+        i.setProperty<T>(name, index, lerp);
+    }
+}
+
+template<typename T, typename rand_dist>
+void RunPlanVec::setPropertyRandom(const std::string &name, rand_dist &distribution) {
+    // Validation
+    if (this->size() < 2) {
+        THROW std::out_of_range("Unable to apply a property distribution a vector with less than 2 elements, "
+            "in RunPlanVec::setPropertyUniformDistribution()\n");
+    }
+    const auto it = environment->find(name);
+    if (it == environment->end()) {
+        THROW InvalidEnvProperty("Environment description does not contain property '%s', "
+            "in RunPlanVec::setPropertyUniformDistribution()\n",
+            name.c_str());
+    }
+    if (it->second.data.type != std::type_index(typeid(T))) {
+        THROW InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
+            "in RunPlanVec::setPropertyUniformDistribution()\n",
+            name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
+    }
+    if (it->second.data.elements != 1) {
+        THROW InvalidEnvPropertyType("Environment property '%s' is an array with %u elements, array method should be used, "
+            "in RunPlanVec::setPropertyUniformDistribution()\n",
+            name.c_str(), it->second.data.elements);
+    }
+    for (auto &i : *this) {
+        i.setProperty<T>(name, static_cast<T>(distribution(this->rand)));
+    }
+}
+template<typename T, typename rand_dist>
+void RunPlanVec::setPropertyRandom(const std::string &name, const EnvironmentManager::size_type &index, rand_dist &distribution) {
+    // Validation
+    if (this->size() < 2) {
+        THROW std::out_of_range("Unable to apply a property distribution a vector with less than 2 elements, "
+            "in RunPlanVec::setPropertyUniformDistribution()\n");
+    }
+    const auto it = environment->find(name);
+    if (it == environment->end()) {
+        THROW InvalidEnvProperty("Environment description does not contain property '%s', "
+            "in RunPlanVec::setPropertyUniformDistribution()\n",
+            name.c_str());
+    }
+    if (it->second.data.type != std::type_index(typeid(T))) {
+        THROW InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
+            "in RunPlanVec::setPropertyUniformDistribution()\n",
+            name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
+    }
+    if (it->second.data.elements >= index) {
+        throw std::out_of_range("Environment property array index out of bounds "
+            "in RunPlan::setPropertyUniformDistribution()\n");
+    }
+    for (auto &i : *this) {
+        i.setProperty<T>(name, index, static_cast<T>(distribution(this->rand)));
+    }
+}
+/**
+ * Convenience random implementations
+ */
+template<typename T>
+void RunPlanVec::setPropertyUniformRandom(const std::string &name, const T &min, const T &max) {
+    static_assert(FGPU_SA::_Is_IntType<T>::value, "Invalid template argument for RunPlanVec::setPropertyUniformRandom(const std::string &name, const T &min, const T&max)");
+    std::uniform_int_distribution<T> dist(min, max);
+    setPropertyRandom<T>(name, dist);
+}
+template<typename T>
+void RunPlanVec::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &min, const T &max) {
+    static_assert(FGPU_SA::_Is_IntType<T>::value, "Invalid template argument for RunPlanVec::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &min, const T&max)");
+    std::uniform_int_distribution<T> dist(min, max);
+    setPropertyRandom<T>(name, index, dist);
+}
+template<typename T>
+void RunPlanVec::setPropertyNormalRandom(const std::string &name, const T &mean, const T &stddev) {
+    static_assert(FGPU_SA::_Is_RealType<T>::value, "Invalid template argument for RunPlanVec::setPropertyNormalRandom(const std::string &name, const T &mean, const T &stddev)");
+    std::normal_distribution<T> dist(mean, stddev);
+    setPropertyRandom<T>(name, dist);
+}
+template<typename T>
+void RunPlanVec::setPropertyNormalRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &mean, const T &stddev) {
+    static_assert(FGPU_SA::_Is_RealType<T>::value, "Invalid template argument for RunPlanVec::setPropertyNormalRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &mean, const T &stddev)");
+    std::normal_distribution<T> dist(mean, stddev);
+    setPropertyRandom<T>(name, index, dist);
+}
+template<typename T>
+void RunPlanVec::setPropertyLogNormalRandom(const std::string &name, const T &mean, const T &stddev) {
+    static_assert(FGPU_SA::_Is_RealType<T>::value, "Invalid template argument for RunPlanVec::setPropertyLogNormalRandom(const std::string &name, const T &mean, const T &stddev)");
+    std::lognormal_distribution<T> dist(mean, stddev);
+    setPropertyRandom<T>(name, dist);
+}
+template<typename T>
+void RunPlanVec::setPropertyLogNormalRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &mean, const T &stddev) {
+    static_assert(FGPU_SA::_Is_RealType<T>::value, "Invalid template argument for RunPlanVec::setPropertyLogNormalRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &mean, const T &stddev)");
+    std::lognormal_distribution<T> dist(mean, stddev);
+    setPropertyRandom<T>(name, index, dist);
+}
+/**
+ * Special cases
+ * std::random doesn't support char, emulate behaviour
+ * char != signed char (or unsigned char)
+ */
+template<>
+inline void RunPlanVec::setPropertyUniformRandom(const std::string &name, const float &min, const float &max) {
+    std::uniform_real_distribution<float> dist(min, max);
+    setPropertyRandom<float>(name, dist);
+}
+template<>
+inline void RunPlanVec::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const float &min, const float &max) {
+    std::uniform_real_distribution<float> dist(min, max);
+    setPropertyRandom<float>(name, index, dist);
+}
+template<>
+inline void RunPlanVec::setPropertyUniformRandom(const std::string &name, const double &min, const double &max) {
+    std::uniform_real_distribution<double> dist(min, max);
+    setPropertyRandom<double>(name, dist);
+}
+template<>
+inline void RunPlanVec::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const double &min, const double &max) {
+    std::uniform_real_distribution<double> dist(min, max);
+    setPropertyRandom<double>(name, index, dist);
+}
+template<>
+inline void RunPlanVec::setPropertyUniformRandom(const std::string &name, const char &min, const char &max) {
+    std::uniform_int_distribution<int16_t> dist(min, max);
+    setPropertyRandom<char>(name, dist);
+}
+template<>
+inline void RunPlanVec::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const char &min, const char &max) {
+    std::uniform_int_distribution<int16_t> dist(min, max);
+    setPropertyRandom<char>(name, index, dist);
+}
+template<>
+inline void RunPlanVec::setPropertyUniformRandom(const std::string &name, const unsigned char &min, const unsigned char &max) {
+    std::uniform_int_distribution<uint16_t> dist(min, max);
+    setPropertyRandom<unsigned char>(name, dist);
+}
+template<>
+inline void RunPlanVec::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const unsigned char &min, const unsigned char &max) {
+    std::uniform_int_distribution<uint16_t> dist(min, max);
+    setPropertyRandom<unsigned char>(name, index, dist);
+}
+template<>
+inline void RunPlanVec::setPropertyUniformRandom(const std::string &name, const signed char &min, const signed char &max) {
+    std::uniform_int_distribution<int16_t> dist(min, max);
+    setPropertyRandom<signed char>(name, dist);
+}
+template<>
+inline void RunPlanVec::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const signed char &min, const signed char &max) {
+    std::uniform_int_distribution<int16_t> dist(min, max);
+    setPropertyRandom<signed char>(name, index, dist);
+}
+#endif  // INCLUDE_FLAMEGPU_SIM_RUNPLANVEC_H_

--- a/include/flamegpu/sim/SimLogger.h
+++ b/include/flamegpu/sim/SimLogger.h
@@ -1,0 +1,37 @@
+#ifndef INCLUDE_FLAMEGPU_SIM_SIMLOGGER_H_
+#define INCLUDE_FLAMEGPU_SIM_SIMLOGGER_H_
+
+#include <vector>
+#include <thread>
+#include <mutex>
+#include <queue>
+#include <string>
+#include <condition_variable>
+
+#include "flamegpu/sim/LogFrame.h"
+
+class RunPlanVec;
+
+class SimLogger {
+    friend class CUDAEnsemble;
+    SimLogger(const std::vector<RunLog> &run_logs,
+        const RunPlanVec &run_plans,
+        const std::string &out_directory,
+        const std::string &out_format,
+        std::queue<unsigned int> &log_export_queue,
+        std::mutex &log_export_queue_mutex,
+        std::condition_variable &log_export_queue_cdn);
+
+    std::thread thread;
+    void start();
+    // External references
+    const std::vector<RunLog> &run_logs;
+    const RunPlanVec &run_plans;
+    const std::string &out_directory;
+    const std::string &out_format;
+    std::queue<unsigned int> &log_export_queue;
+    std::mutex &log_export_queue_mutex;
+    std::condition_variable &log_export_queue_cdn;
+};
+
+#endif  // INCLUDE_FLAMEGPU_SIM_SIMLOGGER_H_

--- a/include/flamegpu/sim/SimRunner.h
+++ b/include/flamegpu/sim/SimRunner.h
@@ -1,0 +1,57 @@
+#ifndef INCLUDE_FLAMEGPU_SIM_SIMRUNNER_H_
+#define INCLUDE_FLAMEGPU_SIM_SIMRUNNER_H_
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <condition_variable>
+#include <thread>
+#include <vector>
+#include "flamegpu/sim/LogFrame.h"
+
+struct ModelData;
+class LoggingConfig;
+class StepLoggingConfig;
+class RunPlanVec;
+
+class SimRunner {
+    friend class CUDAEnsemble;
+    SimRunner(const std::shared_ptr<const ModelData> _model,
+        std::atomic<unsigned int> &_err_ct,
+        std::atomic<unsigned int> &_next_run,
+        const RunPlanVec &_plans,
+        std::shared_ptr<const StepLoggingConfig> _step_log_config,
+        std::shared_ptr<const LoggingConfig> _exit_log_config,
+        int _device_id,
+        unsigned int _runner_id,
+        bool _verbose,
+        std::vector<RunLog> &run_logs,
+        std::queue<unsigned int> &log_export_queue,
+        std::mutex &log_export_queue_mutex,
+        std::condition_variable &log_export_queue_cdn);
+    // Each sim runner takes it's own clone of model description hierarchy, so it can manipulate environment without conflict
+    const std::shared_ptr<const ModelData> model;
+    // Index of current/last run in RunPlanVec
+    unsigned int run_id;
+    // CUDA Device index of runner
+    const int device_id;
+    // Per device unique runner id
+    const unsigned int runner_id;
+    // Flag for whether to print progress
+    const bool verbose;
+    std::thread thread;
+    void start();
+    // External references
+    std::atomic<unsigned int> &err_ct;
+    std::atomic<unsigned int> &next_run;
+    const RunPlanVec &plans;
+    const std::shared_ptr<const StepLoggingConfig> step_log_config;
+    const std::shared_ptr<const LoggingConfig> exit_log_config;
+    std::vector<RunLog> &run_logs;
+    std::queue<unsigned int> &log_export_queue;
+    std::mutex &log_export_queue_mutex;
+    std::condition_variable &log_export_queue_cdn;
+};
+
+#endif  // INCLUDE_FLAMEGPU_SIM_SIMRUNNER_H_

--- a/include/flamegpu/sim/Simulation.h
+++ b/include/flamegpu/sim/Simulation.h
@@ -13,6 +13,7 @@ class FLAMEGPU_HOST_API;
 class ModelDescription;
 class AgentPopulation;
 struct ModelData;
+struct RunLog;
 
 
 namespace std {
@@ -50,6 +51,10 @@ class Simulation {
 #endif
         }
         std::string input_file;
+        std::string step_log_file;
+        std::string exit_log_file;
+        std::string common_log_file;
+        bool truncate_log_files = true;
         unsigned int random_seed;
         unsigned int steps = 0;
         bool verbose = false;
@@ -64,7 +69,7 @@ class Simulation {
     /**
      * This constructor takes a clone of the ModelData hierarchy
      */
-    explicit Simulation(const ModelDescription& model);
+    explicit Simulation(const std::shared_ptr<const ModelData> &model);
 
  protected:
     /**
@@ -98,10 +103,20 @@ class Simulation {
      * @note XML export does not currently includes config structures, only the same data present in FLAMEGPU1
      */
     void exportData(const std::string &path, bool prettyPrint = true);
+    /**
+     * Export the data logged by the last call to simulate() (and/or step) to the given path
+     * @param path The file to output (must end '.json' or '.xml')
+     * @param steps Whether the step log should be included in the log file
+     * @param exit Whether the exit log should be included in the log file
+     * @param prettyPrint Whether the log file should be minified or not
+     * @note The config (possibly just random seed) is always output
+     */
+    void exportLog(const std::string &path, bool steps, bool exit, bool prettyPrint = true);
 
     virtual void setPopulationData(AgentPopulation& population) = 0;
     virtual void getPopulationData(AgentPopulation& population) = 0;
 
+    virtual const RunLog &getRunLog() const = 0;
     virtual AgentInterface &getAgent(const std::string &name) = 0;
 
     Config &SimulationConfig();
@@ -152,7 +167,7 @@ class Simulation {
     /**
      * Initial environment items if they have been loaded from file, prior to device selection
      */
-    std::unordered_map<std::pair<std::string, unsigned int>, EnvironmentDescription::Any> env_init;
+    std::unordered_map<std::pair<std::string, unsigned int>, Any> env_init;
 
  private:
     /**

--- a/include/flamegpu/util/Any.h
+++ b/include/flamegpu/util/Any.h
@@ -1,0 +1,70 @@
+#ifndef INCLUDE_FLAMEGPU_UTIL_ANY_H_
+#define INCLUDE_FLAMEGPU_UTIL_ANY_H_
+
+/**
+ * Minimal std::any replacement, works pre c++17
+ */
+struct Any {
+    /**
+     * Constructor
+     * @param _ptr Pointer to data to represent
+     * @param _length Length of pointed to data
+     * @param _type Identifier of type
+     * @param _elements How many elements does the property have (1 if it's not an array)
+     * @note Copies the data
+     */
+    Any(const void *_ptr, const size_t &_length, const std::type_index &_type, const unsigned int &_elements)
+        : ptr(malloc(_length))
+        , length(_length)
+        , type(_type)
+        , elements(_elements) {
+        memcpy(ptr, _ptr, length);
+    }
+    template<typename T>
+    explicit Any(const T&other)
+        : ptr(malloc(sizeof(T)))
+        , length(sizeof(T))
+        , type(typeid(T))
+        , elements(1) {
+        memcpy(ptr, &other, sizeof(T));
+    }
+    /**
+     * Copy constructor
+     * @param _other Other Any to be cloned, makes a copy of the pointed to data
+     */
+    Any(const Any &_other)
+        : ptr(malloc(_other.length))
+        , length(_other.length)
+        , type(_other.type)
+        , elements(_other.elements) {
+        memcpy(ptr, _other.ptr, length);
+    }
+    /*
+     * Releases the allocated memory
+     */
+    ~Any() {
+        free(ptr);
+    }
+    /**
+     * Can't assign, members are const at creation
+     */
+    void operator=(const Any &_other) = delete;
+    /**
+     * Data represented by this object
+     */
+    void *const ptr;
+    /**
+     * Length of memory allocation pointed to by ptr
+     */
+    const size_t length;
+    /**
+     * Type index to unwrap the value
+     */
+    const std::type_index type;
+    /**
+     * Number of elements (1 if not array)
+     */
+    const unsigned int elements;
+};
+
+#endif  // INCLUDE_FLAMEGPU_UTIL_ANY_H_

--- a/include/flamegpu/util/file_system.h
+++ b/include/flamegpu/util/file_system.h
@@ -1,0 +1,40 @@
+#ifndef INCLUDE_FLAMEGPU_UTIL_FILESYSTEM_H_
+#define INCLUDE_FLAMEGPU_UTIL_FILESYSTEM_H_
+
+// If earlier than VS 2019
+#if defined(_MSC_VER) && _MSC_VER < 1920
+#include <filesystem>
+using std::tr2::sys::exists;
+using std::tr2::sys::path;
+using std::tr2::sys::create_directory;
+#else
+// VS2019 requires this macro, as building pre c++17 cant use std::filesystem
+#define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
+#include <experimental/filesystem>
+using std::experimental::filesystem::v1::exists;
+using std::experimental::filesystem::v1::path;
+using std::experimental::filesystem::v1::create_directory;
+#endif
+
+namespace util {
+namespace filesystem {
+/**
+ * Creates the directory pointed to by path
+ * Regular directory creation fails to create directories when multiple layers are missing, this is why we recurse
+ * @throw May throw implementation specific exceptions, e.g. if the path is invalid
+ */
+inline void recursive_create_dir(const path &dir) {
+    if (::exists(dir)) {
+        return;
+    }
+    const path parent_dir = dir.parent_path();
+    if (!::exists(parent_dir)) {
+        recursive_create_dir(parent_dir);
+    }
+    create_directory(dir);
+}
+
+}  // namespace file_system
+}  // namespace util
+
+#endif  // INCLUDE_FLAMEGPU_UTIL_FILESYSTEM_H_

--- a/include/flamegpu/util/filesystem.h
+++ b/include/flamegpu/util/filesystem.h
@@ -1,0 +1,40 @@
+#ifndef INCLUDE_FLAMEGPU_UTIL_FILESYSTEM_H_
+#define INCLUDE_FLAMEGPU_UTIL_FILESYSTEM_H_
+
+// If earlier than VS 2019
+#if defined(_MSC_VER) && _MSC_VER < 1920
+#include <filesystem>
+using std::tr2::sys::exists;
+using std::tr2::sys::path;
+using std::tr2::sys::create_directory;
+#else
+// VS2019 requires this macro, as building pre c++17 cant use std::filesystem
+#define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
+#include <experimental/filesystem>
+using std::experimental::filesystem::v1::exists;
+using std::experimental::filesystem::v1::path;
+using std::experimental::filesystem::v1::create_directory;
+#endif
+
+namespace util {
+namespace filesystem {
+/**
+ * Creates the directory pointed to by path
+ * Regular directory creation fails to create directories when multiple layers are missing, this is why we recurse
+ * @throw May throw implementation specific exceptions, e.g. if the path is invalid
+ */
+inline void recursive_create_dir(const path &dir) {
+    if (::exists(dir)) {
+        return;
+    }
+    path parent_dir = absolute(dir).parent_path();
+    if (!::exists(parent_dir)) {
+        recursive_create_dir(parent_dir);
+    }
+    create_directory(dir);
+}
+
+}  // namespace filesystem
+}  // namespace util
+
+#endif  // INCLUDE_FLAMEGPU_UTIL_FILESYSTEM_H_

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,9 @@ SET(SRC_INCLUDE
     ${FLAMEGPU_ROOT}/include/flamegpu/io/xmlReader.h
     ${FLAMEGPU_ROOT}/include/flamegpu/io/xmlWriter.h
     ${FLAMEGPU_ROOT}/include/flamegpu/io/factory.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/io/Logger.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/io/xmlLogger.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/io/jsonLogger.h
     ${FLAMEGPU_ROOT}/include/flamegpu/exception/FGPUException.h
     ${FLAMEGPU_ROOT}/include/flamegpu/exception/FGPUDeviceException.h
     ${FLAMEGPU_ROOT}/include/flamegpu/exception/FGPUDeviceException_device.h
@@ -99,6 +102,7 @@ SET(SRC_INCLUDE
     ${FLAMEGPU_ROOT}/include/flamegpu/gpu/CUDAErrorChecking.h
     ${FLAMEGPU_ROOT}/include/flamegpu/gpu/CUDAMessageList.h
     ${FLAMEGPU_ROOT}/include/flamegpu/gpu/CUDASimulation.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/gpu/CUDAEnsemble.h
     ${FLAMEGPU_ROOT}/include/flamegpu/gpu/CUDAMessage.h
     ${FLAMEGPU_ROOT}/include/flamegpu/gpu/CUDAAgent.h
     ${FLAMEGPU_ROOT}/include/flamegpu/gpu/CUDAAgentStateList.h
@@ -106,6 +110,14 @@ SET(SRC_INCLUDE
     ${FLAMEGPU_ROOT}/include/flamegpu/gpu/CUDAFatAgentStateList.h
     ${FLAMEGPU_ROOT}/include/flamegpu/gpu/CUDAScatter.h
     ${FLAMEGPU_ROOT}/include/flamegpu/sim/AgentInterface.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/sim/AgentLoggingConfig.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/sim/AgentLoggingConfig_Reductions.cuh
+    ${FLAMEGPU_ROOT}/include/flamegpu/sim/LoggingConfig.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/sim/LogFrame.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/sim/RunPlan.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/sim/RunPlanVec.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/sim/SimRunner.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/sim/SimLogger.h
     ${FLAMEGPU_ROOT}/include/flamegpu/sim/Simulation.h
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/AgentFunction.h
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/AgentFunction_shim.h
@@ -152,9 +164,11 @@ SET(SRC_INCLUDE
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/utility/HostEnvironment.cuh
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/utility/HostRandom.cuh
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/utility/RandomManager.cuh    
+    ${FLAMEGPU_ROOT}/include/flamegpu/util/Any.h
     ${FLAMEGPU_ROOT}/include/flamegpu/util/nvtx.h
     ${FLAMEGPU_ROOT}/include/flamegpu/util/SignalHandlers.h
     ${FLAMEGPU_ROOT}/include/flamegpu/util/compute_capability.cuh
+    ${FLAMEGPU_ROOT}/include/flamegpu/util/filesystem.h
     ${FLAMEGPU_ROOT}/include/flamegpu/model/SubModelData.h
     ${FLAMEGPU_ROOT}/include/flamegpu/model/SubAgentData.h
     ${FLAMEGPU_ROOT}/include/flamegpu/model/SubEnvironmentData.h
@@ -185,8 +199,16 @@ SET(SRC_FLAMEGPU2
     ${FLAMEGPU_ROOT}/src/flamegpu/gpu/CUDAFatAgentStateList.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/gpu/CUDAMessage.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/gpu/CUDAScatter.cu
-    ${FLAMEGPU_ROOT}/src/flamegpu/sim/Simulation.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/gpu/CUDASimulation.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/gpu/CUDAEnsemble.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/sim/AgentLoggingConfig.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/sim/LoggingConfig.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/sim/LogFrame.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/sim/RunPlan.cpp
+    ${FLAMEGPU_ROOT}/src/flamegpu/sim/RunPlanVec.cpp
+    ${FLAMEGPU_ROOT}/src/flamegpu/sim/SimRunner.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/sim/SimLogger.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/sim/Simulation.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/cuRVE/curve.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/cuRVE/curve_rtc.cpp
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/flamegpu_host_api.cu
@@ -202,10 +224,13 @@ SET(SRC_FLAMEGPU2
     ${FLAMEGPU_ROOT}/src/flamegpu/io/jsonWriter.cpp
     ${FLAMEGPU_ROOT}/src/flamegpu/io/xmlReader.cpp
     ${FLAMEGPU_ROOT}/src/flamegpu/io/xmlWriter.cpp
+    ${FLAMEGPU_ROOT}/src/flamegpu/io/xmlLogger.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/io/jsonLogger.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/utility/HostEnvironment.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/utility/EnvironmentManager.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/utility/RandomManager.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/util/compute_capability.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/runtime/utility/HostRandom.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/model/SubModelData.cpp
     ${FLAMEGPU_ROOT}/src/flamegpu/model/SubAgentData.cpp
     ${FLAMEGPU_ROOT}/src/flamegpu/model/SubEnvironmentData.cpp

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -1,0 +1,288 @@
+#include "flamegpu/gpu/CUDAEnsemble.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <memory>
+#include <thread>
+#include <set>
+#include <chrono>
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+
+#include "flamegpu/model/ModelDescription.h"
+#include "flamegpu/sim/RunPlanVec.h"
+#include "flamegpu/util/compute_capability.cuh"
+#include "flamegpu/gpu/CUDASimulation.h"
+#include "flamegpu/io/factory.h"
+#include "flamegpu/util/filesystem.h"
+#include "flamegpu/sim/LoggingConfig.h"
+#include "flamegpu/sim/SimRunner.h"
+#include "flamegpu/sim/LogFrame.h"
+#include "flamegpu/sim/SimLogger.h"
+
+
+CUDAEnsemble::CUDAEnsemble(const ModelDescription& _model, int argc, const char** argv)
+    : model(_model.model->clone()) {
+    initialise(argc, argv);
+}
+CUDAEnsemble::~CUDAEnsemble() {
+    // Nothing to do
+}
+
+
+
+void CUDAEnsemble::simulate(const RunPlanVec &plans) {
+    // Validate that RunPlan model matches CUDAEnsemble model
+    if (*plans.environment != this->model->environment->properties) {
+        THROW InvalidArgument("RunPlan is for a different ModelDescription, in CUDAEnsemble::simulate()");
+    }
+    // Validate/init output directories
+    if (!config.out_directory.empty()) {
+        // Validate out format is right
+        config.out_format = WriterFactory::detectSupportedFileExt(config.out_format);
+        if (config.out_format.empty()) {
+            THROW InvalidArgument("The out_directory config option also requires the out_format options to be set to a suitable type (e.g. 'json', 'xml'), in CUDAEnsemble::simulate()");
+        }
+        // Create any missing directories
+        try {
+            util::filesystem::recursive_create_dir(config.out_directory);
+        } catch (const std::exception &e) {
+            THROW InvalidArgument("Unable to use output directory '%s', in CUDAEnsemble::simulate(): %s", config.out_directory.c_str(), e.what());
+        }
+        for (const auto &p : plans) {
+            const auto subdir = p.getOutputSubdirectory();
+            if (!subdir.empty()) {
+                path sub_path = config.out_directory;
+                try {
+                    sub_path.append(subdir);
+                    util::filesystem::recursive_create_dir(sub_path);
+                } catch (const std::exception &e) {
+                    THROW InvalidArgument("Unable to use output subdirectory '%s', in CUDAEnsemble::simulate(): %s", sub_path.generic_string().c_str(), e.what());
+                }
+            }
+        }
+    }
+    // Purge run logs, and resize ready for new runs
+    // Resize means we can setup logs during execution out of order, without risk of list being reallocated
+    run_logs.clear();
+    run_logs.resize(plans.size());
+    // Workout how many devices and runner we will be executing
+    int ct = -1;
+    gpuErrchk(cudaGetDeviceCount(&ct));
+    std::set<int> devices;
+    if (config.devices.size()) {
+        devices = config.devices;
+    } else {
+        for (int i = 0; i < ct; ++i) {
+        devices.emplace(i);
+        }
+    }
+    // Check that each device is capable, and init cuda context
+    for (auto d = devices.begin(); d != devices.end(); ++d) {
+        if (!util::compute_capability::checkComputeCapability(*d)) {
+            fprintf(stderr, "FLAMEGPU2 has not been built with an appropriate compute capability for device %d, this device will not be used.\n", *d);
+            d = devices.erase(d);
+            --d;
+        } else {
+            gpuErrchk(cudaSetDevice(*d));
+            gpuErrchk(cudaFree(nullptr));
+        }
+    }
+    // Return to device 0 (or check original device first?)
+    gpuErrchk(cudaSetDevice(0));
+
+    // Init runners, devices * concurrent runs
+    std::atomic<unsigned int> err_ct;
+    std::atomic<unsigned int> next_run;
+    const size_t TOTAL_RUNNERS = devices.size() * config.concurrent_runs;
+    SimRunner *runners = static_cast<SimRunner *>(malloc(sizeof(SimRunner) * TOTAL_RUNNERS));
+
+    // Log Time (We can't use CUDA events here, due to device resets)
+    const auto start_time = std::chrono::high_resolution_clock::now();
+    // Reset the elapsed time.
+    ensemble_elapsed_time = 0;
+
+    // Logging thread-safety items
+    std::queue<unsigned int> log_export_queue;
+    std::mutex log_export_queue_mutex;
+    std::condition_variable log_export_queue_cdn;
+
+    // Init with placement new
+    {
+        if (!config.silent)
+            printf("\rCUDAEnsemble progress: %u/%u", 0, static_cast<unsigned int>(plans.size()));
+        unsigned int i = 0;
+        for (auto &d : devices) {
+            for (unsigned int j = 0; j < config.concurrent_runs; ++j) {
+                new (&runners[i++]) SimRunner(model, err_ct, next_run, plans, step_log_config, exit_log_config, d, j, !config.silent, run_logs, log_export_queue, log_export_queue_mutex, log_export_queue_cdn);
+            }
+        }
+    }
+
+    // Init log worker
+    SimLogger *log_worker = nullptr;
+    if (!config.out_directory.empty() && !config.out_format.empty()) {
+        log_worker = new SimLogger(run_logs, plans, config.out_directory, config.out_format, log_export_queue, log_export_queue_mutex, log_export_queue_cdn);
+    } else if (!config.out_directory.empty() ^ !config.out_format.empty())  {
+        fprintf(stderr, "Warning: Only 1 of out_directory and out_format is set, both must be set for logging to commence to file.\n");
+    }
+
+    // Wait for all runners to exit
+    for (unsigned int i = 0; i < TOTAL_RUNNERS; ++i) {
+        runners[i].thread.join();
+        runners[i].~SimRunner();
+    }
+    // Notify logger to exit
+    if (log_worker) {
+        {
+            std::lock_guard<std::mutex> lck(log_export_queue_mutex);
+            log_export_queue.push(UINT_MAX);
+        }
+        log_export_queue_cdn.notify_one();
+        log_worker->thread.join();
+        delete log_worker;
+        log_worker = nullptr;
+    }
+
+    // Record and store the elapsed time
+    const auto end_time = std::chrono::high_resolution_clock::now();
+    ensemble_elapsed_time = static_cast<int64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count());
+
+    // Ensemble has finished, print summary
+    if (!config.silent) {
+        printf("\rCUDAEnsemble completed %u runs successfully!\n", static_cast<unsigned int>(plans.size() - err_ct));
+        if (err_ct)
+            printf("There were a total of %u errors.\n", err_ct.load());
+    }
+    if (config.timing) {
+        printf("Ensemble time elapsed: %zums\n", ensemble_elapsed_time);
+    }
+
+    // Free memory
+    free(runners);
+}
+
+void CUDAEnsemble::initialise(int argc, const char** argv) {
+    if (!checkArgs(argc, argv)) {
+        exit(EXIT_FAILURE);
+    }
+}
+int CUDAEnsemble::checkArgs(int argc, const char** argv) {
+    // Parse optional args
+    int i = 1;
+    for (; i < argc; i++) {
+        // Get arg as lowercase
+        std::string arg(argv[i]);
+        std::transform(arg.begin(), arg.end(), arg.begin(), [](unsigned char c) { return std::use_facet< std::ctype<char>>(std::locale()).tolower(c); });
+        // --concurrent <runs>, Number of concurrent simulations to run per device
+        if (arg.compare("--concurrent") == 0 || arg.compare("-c") == 0) {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "%s requires a trailing argument\n", arg.c_str());
+                return false;
+            }
+            config.concurrent_runs = static_cast<unsigned int>(strtoul(argv[++i], nullptr, 0));
+            continue;
+        }
+        // --devices <string>, comma separated list of uints
+        if (arg.compare("--devices") == 0 || arg.compare("-d") == 0) {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "%s requires a trailing argument\n", arg.c_str());
+                return false;
+            }
+            // Split and parse string
+            std::string device_string = argv[++i];
+            device_string += ",";  // Append comma, to catch final item
+            int max_id = 0;  // Catch max device so we can validate it exists
+            size_t pos;
+            while ((pos = device_string.find(",")) != std::string::npos) {
+                const unsigned int id = static_cast<unsigned int>(strtoul(device_string.substr(0, pos).c_str(), nullptr, 0));
+                if (id == 0 && (device_string.length() < 2 || (device_string[0] != '0' || device_string[1] != ','))) {
+                    fprintf(stderr, "'%s' is not a valid device index.\n", device_string.substr(0, pos).c_str());
+                    printHelp(argv[0]);
+                    return false;
+                }
+                max_id = static_cast<int>(id) > max_id ? id : max_id;
+                config.devices.emplace(id);
+                device_string.erase(0, pos + 1);
+            }
+            int ct = -1;
+            gpuErrchk(cudaGetDeviceCount(&ct));
+            if (max_id >= ct) {
+                fprintf(stderr, "Device id %u exceeds available CUDA devices %d\n", max_id, ct);
+                printHelp(argv[0]);
+                return false;
+            }
+            continue;
+        }
+        // -o/--out <directory> <filetype>, Quiet FLAME GPU output.
+        if (arg.compare("--out") == 0 || arg.compare("-o") == 0) {
+            if (i + 2 >= argc) {
+                fprintf(stderr, "%s requires two trailing arguments\n", arg.c_str());
+                return false;
+            }
+            // Validate output directory is valid (and recursively create it if necessary)
+            try {
+                path out_directory = argv[++i];
+                util::filesystem::recursive_create_dir(out_directory);
+                config.out_directory = out_directory.generic_string();
+            } catch (const std::exception &e) {
+                // Catch any exceptions, probably std::filesystem::filesystem_error, but other implementation defined errors also possible
+                fprintf(stderr, "Unable to use '%s' as output directory:\n%s\n", argv[i], e.what());
+                return false;
+            }
+            // Validate output format is available in io module
+            config.out_format = WriterFactory::detectSupportedFileExt(argv[++i]);
+            if (config.out_format.empty()) {
+                fprintf(stderr, "'%s' is not a supported output file type.\n", argv[i]);
+                return false;
+            }
+            continue;
+        }
+        // -s/--silent, Don't report progress to console.
+        if (arg.compare("--silent") == 0 || arg.compare("-s") == 0) {
+            config.silent = true;
+            continue;
+        }
+        // -t/--timing, Output timing information to stdout
+        if (arg.compare("--timing") == 0 || arg.compare("-t") == 0) {
+            config.timing = true;
+            continue;
+        }
+        fprintf(stderr, "Unexpected argument: %s\n", arg.c_str());
+        printHelp(argv[0]);
+        return false;
+    }
+    return true;
+}
+void CUDAEnsemble::printHelp(const char *executable) {
+    printf("Usage: %s [optional arguments]\n", executable);
+    printf("Optional Arguments:\n");
+    const char *line_fmt = "%-18s %s\n";
+    printf(line_fmt, "-d, --devices <device ids>", "Comma separated list of device ids to be used");
+    printf(line_fmt, "", "By default, all available devices will be used.");
+    printf(line_fmt, "-c, --concurrent <runs>", "Number of concurrent simulations to run per device");
+    printf(line_fmt, "", "By default, 4 will be used.");
+    printf(line_fmt, "-o, --out <directory> <filetype>", "Directory and filetype for ensemble outputs");
+    printf(line_fmt, "-s, --silent", "Don't print progress information to console");
+    printf(line_fmt, "-t, --timing", "Output timing information to stdout");
+}
+void CUDAEnsemble::setStepLog(const StepLoggingConfig &stepConfig) {
+    // Validate ModelDescription matches
+    if (*stepConfig.model != *model) {
+      THROW InvalidArgument("Model descriptions attached to LoggingConfig and CUDAEnsemble do not match, in CUDAEnsemble::setStepLog()\n");
+    }
+    // Set internal config
+    step_log_config = std::make_shared<StepLoggingConfig>(stepConfig);
+}
+void CUDAEnsemble::setExitLog(const LoggingConfig &exitConfig) {
+    // Validate ModelDescription matches
+    if (*exitConfig.model != *model) {
+      THROW InvalidArgument("Model descriptions attached to LoggingConfig and CUDAEnsemble do not match, in CUDAEnsemble::setExitLog()\n");
+    }
+    // Set internal config
+    exit_log_config = std::make_shared<LoggingConfig>(exitConfig);
+}
+const std::vector<RunLog> &CUDAEnsemble::getLogs() {
+    return run_logs;
+}

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -18,6 +18,10 @@
 #include "flamegpu/util/SignalHandlers.h"
 #include "flamegpu/runtime/cuRVE/curve_rtc.h"
 #include "flamegpu/runtime/HostFunctionCallback.h"
+#include "flamegpu/gpu/CUDAAgent.h"
+#include "flamegpu/gpu/CUDAMessage.h"
+#include "flamegpu/sim/LoggingConfig.h"
+#include "flamegpu/sim/LogFrame.h"
 
 std::map<int, std::atomic<int>> CUDASimulation::active_device_instances;
 std::map<int, std::shared_timed_mutex> CUDASimulation::active_device_mutex;
@@ -26,9 +30,16 @@ std::atomic<int> CUDASimulation::active_instances;  // This value should default
 bool CUDASimulation::AUTO_CUDA_DEVICE_RESET = true;
 
 CUDASimulation::CUDASimulation(const ModelDescription& _model, int argc, const char** argv)
+    : CUDASimulation(_model.model) {
+    if (argc && argv) {
+        initialise(argc, argv);
+    }
+}
+CUDASimulation::CUDASimulation(const std::shared_ptr<const ModelData> &_model)
     : Simulation(_model)
     , step_count(0)
     , simulation_elapsed_time(0.f)
+    , run_log(std::make_unique<RunLog>())
     , streams(std::vector<cudaStream_t>())
     , singletons(nullptr)
     , singletonsInitialised(false)
@@ -36,10 +47,6 @@ CUDASimulation::CUDASimulation(const ModelDescription& _model, int argc, const c
     , rtc_kernel_cache(nullptr) {
     ++active_instances;
     initOffsetsAndMap();
-    // Add CUDASimulation specific environment members
-    unsigned int zero = 0;
-    model->environment->newProperty("_stepCount", reinterpret_cast<const char*>(&zero), sizeof(unsigned int), false, 1, typeid(unsigned int));
-
     // Register the signal handler.
     SignalHandlers::registerSignalHandlers();
 
@@ -64,24 +71,24 @@ CUDASimulation::CUDASimulation(const ModelDescription& _model, int argc, const c
     for (auto it_sm = smm.cbegin(); it_sm != smm.cend(); ++it_sm) {
         submodel_map.emplace(it_sm->first, std::unique_ptr<CUDASimulation>(new CUDASimulation(it_sm->second, this)));
     }
-
-    if (argc && argv) {
-        initialise(argc, argv);
-    }
 }
 CUDASimulation::CUDASimulation(const std::shared_ptr<SubModelData> &submodel_desc, CUDASimulation *master_model)
     : Simulation(submodel_desc, master_model)
     , step_count(0)
+    , run_log(std::make_unique<RunLog>())
     , streams(std::vector<cudaStream_t>())
     , singletons(nullptr)
     , singletonsInitialised(false)
     , rtcInitialised(false)
-    , rtc_kernel_cache(nullptr)  {
+    , rtc_kernel_cache(nullptr) {
     ++active_instances;
     initOffsetsAndMap();
-    // Add CUDASimulation specific environment members
-    unsigned int zero = 0;
-    model->environment->newProperty("_stepCount", reinterpret_cast<const char*>(&zero), sizeof(unsigned int), false, 1, typeid(unsigned int));
+    // Ensure submodel is valid
+    if (submodel_desc->submodel->exitConditions.empty() && submodel_desc->submodel->exitConditionCallbacks.empty() && submodel_desc->max_steps == 0) {
+        THROW InvalidSubModel("Model '%s' does not contain any exit conditions or exit condition callbacks and submodel '%s' max steps is set to 0, SubModels must exit of their own accord, "
+            "in CUDASimulation::CUDASimulation().",
+            submodel_desc->submodel->name.c_str(), submodel_desc->name.c_str());
+    }
 
     // populate the CUDA agent map (With SubAgents!)
     const auto &am = model->agents;
@@ -120,6 +127,7 @@ CUDASimulation::CUDASimulation(const std::shared_ptr<SubModelData> &submodel_des
     }
     // Submodels all run silent by default
     SimulationConfig().verbose = false;
+    SimulationConfig().steps = submodel_desc->max_steps;
 }
 
 CUDASimulation::~CUDASimulation() {
@@ -739,8 +747,11 @@ bool CUDASimulation::step() {
             visualisation->updateBuffers(step_count+1);
         }
 #endif
+
     // Update step count at the end of the step - when it has completed.
     incrementStepCounter();
+
+    processStepLog();
     return true;
 }
 
@@ -792,6 +803,10 @@ void CUDASimulation::simulate() {
         processHostAgentCreation(0);
     NVTX_POP();
 
+    // Reset and log initial state to step log 0
+    resetLog();
+    processStepLog();
+
 #ifdef VISUALISATION
     if (visualisation) {
         visualisation->updateBuffers();
@@ -800,8 +815,10 @@ void CUDASimulation::simulate() {
 
     for (unsigned int i = 0; getSimulationConfig().steps == 0 ? true : i < getSimulationConfig().steps; i++) {
         // std::cout <<"step: " << i << std::endl;
-        if (!step())
+        if (!step()) {
+            processStepLog();
             break;
+        }
 #ifdef VISUALISATION
         // Special case, if steps == 0 and visualisation has been closed
         if (getSimulationConfig().steps == 0 &&
@@ -817,6 +834,8 @@ void CUDASimulation::simulate() {
         exitFn(this->host_api.get());
     for (auto &exitFn : model->exitFunctionCallbacks)
         exitFn->run(this->host_api.get());
+
+    processExitLog();
 
 #ifdef VISUALISATION
     if (visualisation) {
@@ -847,6 +866,14 @@ void CUDASimulation::simulate() {
         gpuErrchk(cudaStreamDestroy(stream));
     }
     streams.clear();
+
+    // Export logs
+    if (!SimulationConfig().step_log_file.empty())
+        exportLog(SimulationConfig().step_log_file, true, false);
+    if (!SimulationConfig().exit_log_file.empty())
+        exportLog(SimulationConfig().exit_log_file, false, true);
+    if (!SimulationConfig().common_log_file.empty())
+        exportLog(SimulationConfig().common_log_file, true, true);
 }
 
 void CUDASimulation::reset(bool submodelReset) {
@@ -971,6 +998,23 @@ CUDAMessage& CUDASimulation::getCUDAMessage(const std::string& message_name) con
     }
 
     return *(it->second);
+}
+
+void CUDASimulation::setStepLog(const StepLoggingConfig &stepConfig) {
+    // Validate ModelDescription matches
+    if (*stepConfig.model != *model) {
+        THROW InvalidArgument("Model descriptions attached to LoggingConfig and CUDASimulation do not match, in CUDASimulation::setStepLog()\n");
+    }
+    // Set internal config
+    step_log_config = std::make_shared<StepLoggingConfig>(stepConfig);
+}
+void CUDASimulation::setExitLog(const LoggingConfig &exitConfig) {
+    // Validate ModelDescription matches
+    if (*exitConfig.model != *model) {
+        THROW InvalidArgument("Model descriptions attached to LoggingConfig and CUDASimulation do not match, in CUDASimulation::setExitLog()\n");
+    }
+    // Set internal config
+    exit_log_config = std::make_shared<LoggingConfig>(exitConfig);
 }
 
 bool CUDASimulation::checkArgs_derived(int argc, const char** argv, int &i) {
@@ -1372,4 +1416,80 @@ void CUDASimulation::initEnvironmentMgr() {
     }
     // Clear init
     env_init.clear();
+}
+void CUDASimulation::resetLog() {
+    run_log->step.clear();
+    run_log->exit = LogFrame();
+    run_log->random_seed = SimulationConfig().random_seed;
+    run_log->step_log_frequency = step_log_config ? step_log_config->frequency : 0;
+}
+void CUDASimulation::processStepLog() {
+    if (!step_log_config)
+        return;
+    if (step_count % step_log_config->frequency != 0)
+        return;
+    // Iterate members of step log to build the step log frame
+    std::map<std::string, Any> environment_log;
+    for (const auto &prop_name : step_log_config->environment) {
+        // Fetch the named environment prop
+        environment_log.emplace(prop_name, singletons->environment.getPropertyAny(instance_id, prop_name));
+    }
+    std::map<LoggingConfig::NameStatePair, std::pair<std::map<LoggingConfig::NameReductionFn, Any>, unsigned int>> agents_log;
+    for (const auto &name_state : step_log_config->agents) {
+        // Create the named sub map
+        const std::string &agent_name = name_state.first.first;
+        const std::string &agent_state = name_state.first.second;
+        HostAgentInstance host_agent = host_api->agent(agent_name, agent_state);
+        auto &agent_state_log = agents_log.emplace(name_state.first, std::make_pair(std::map<LoggingConfig::NameReductionFn, Any>(), UINT_MAX)).first->second;
+        // Log individual variable reductions
+        for (const auto &name_reduction : *name_state.second.first) {
+            // Perform the corresponding reduction
+            auto result = name_reduction.function(host_agent, name_reduction.name);
+            // Store the result
+            agent_state_log.first.emplace(name_reduction, std::move(result));
+        }
+        // Log count of agents in state
+        if (name_state.second.second) {
+            agent_state_log.second = host_api->agent(agent_name, agent_state).count();
+        }
+    }
+
+    // Append to step log
+    run_log->step.push_back(LogFrame(std::move(environment_log), std::move(agents_log), step_count));
+}
+
+void CUDASimulation::processExitLog() {
+    if (!exit_log_config)
+        return;
+    // Iterate members of step log to build the step log frame
+    std::map<std::string, Any> environment_log;
+    for (const auto &prop_name : step_log_config->environment) {
+        // Fetch the named environment prop
+        environment_log.emplace(prop_name, singletons->environment.getPropertyAny(instance_id, prop_name));
+    }
+    std::map<LoggingConfig::NameStatePair, std::pair<std::map<LoggingConfig::NameReductionFn, Any>, unsigned int>> agents_log;
+    for (const auto &name_state : step_log_config->agents) {
+        // Create the named sub map
+        const std::string &agent_name = name_state.first.first;
+        const std::string &agent_state = name_state.first.second;
+        HostAgentInstance host_agent = host_api->agent(agent_name, agent_state);
+        auto &agent_state_log = agents_log.emplace(name_state.first, std::make_pair(std::map<LoggingConfig::NameReductionFn, Any>(), UINT_MAX)).first->second;
+        // Log individual variable reductions
+        for (const auto &name_reduction : *name_state.second.first) {
+            // Perform the corresponding reduction
+            auto result = name_reduction.function(host_agent, name_reduction.name);
+            // Store the result
+            agent_state_log.first.emplace(name_reduction, std::move(result));
+        }
+        // Log count of agents in state
+        if (name_state.second.second) {
+            agent_state_log.second = host_api->agent(agent_name, agent_state).count();
+        }
+    }
+
+    // Set Log
+    run_log->exit = LogFrame(std::move(environment_log), std::move(agents_log), step_count);
+}
+const RunLog &CUDASimulation::getRunLog() const {
+    return *run_log;
 }

--- a/src/flamegpu/io/jsonLogger.cu
+++ b/src/flamegpu/io/jsonLogger.cu
@@ -1,0 +1,245 @@
+#include "flamegpu/io/jsonLogger.h"
+
+#include <rapidjson/writer.h>
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/stringbuffer.h>
+#include <iostream>
+#include <fstream>
+#include <string>
+
+#include "flamegpu/sim/RunPlan.h"
+#include "flamegpu/sim/LogFrame.h"
+
+jsonLogger::jsonLogger(const std::string &outPath, bool _prettyPrint, bool _truncateFile)
+    : out_path(outPath)
+    , prettyPrint(_prettyPrint)
+    , truncateFile(_truncateFile) { }
+
+void jsonLogger::log(const RunLog &log, const RunPlan &plan, bool logSteps, bool logExit) const {
+  logCommon(log, &plan, false, logSteps, logExit);
+}
+void jsonLogger::log(const RunLog &log, bool logConfig, bool logSteps, bool logExit) const {
+  logCommon(log, nullptr, logConfig, logSteps, logExit);
+}
+
+template<typename T>
+void jsonLogger::writeAny(T &writer, const Any &value, const unsigned int &elements) const {
+    // Output value
+    if (elements > 1) {
+        writer.StartArray();
+    }
+    // Loop through elements, to construct array
+    for (unsigned int el = 0; el < elements; ++el) {
+        if (value.type == std::type_index(typeid(float))) {
+            writer.Double(static_cast<const float*>(value.ptr)[el]);
+        } else if (value.type == std::type_index(typeid(double))) {
+            writer.Double(static_cast<const double*>(value.ptr)[el]);
+        } else if (value.type == std::type_index(typeid(int64_t))) {
+            writer.Int64(static_cast<const int64_t*>(value.ptr)[el]);
+        } else if (value.type == std::type_index(typeid(uint64_t))) {
+            writer.Uint64(static_cast<const uint64_t*>(value.ptr)[el]);
+        } else if (value.type == std::type_index(typeid(int32_t))) {
+            writer.Int(static_cast<const int32_t*>(value.ptr)[el]);
+        } else if (value.type == std::type_index(typeid(uint32_t))) {
+            writer.Uint(static_cast<const uint32_t*>(value.ptr)[el]);
+        } else if (value.type == std::type_index(typeid(int16_t))) {
+            writer.Int(static_cast<const int16_t*>(value.ptr)[el]);
+        } else if (value.type == std::type_index(typeid(uint16_t))) {
+            writer.Uint(static_cast<const uint16_t*>(value.ptr)[el]);
+        } else if (value.type == std::type_index(typeid(int8_t))) {
+            writer.Int(static_cast<int32_t>(static_cast<const int8_t*>(value.ptr)[el]));  // Char outputs weird if being used as an integer
+        } else if (value.type == std::type_index(typeid(uint8_t))) {
+            writer.Uint(static_cast<uint32_t>(static_cast<const uint8_t*>(value.ptr)[el]));  // Char outputs weird if being used as an integer
+        } else if (value.type == std::type_index(typeid(char))) {
+            writer.Int(static_cast<int32_t>(static_cast<const char*>(value.ptr)[el]));  // Char outputs weird if being used as an integer
+        } else {
+            THROW RapidJSONError("Attempting to export value of unsupported type '%s', "
+                "in jsonLogger::writeAny()\n", value.type.name());
+        }
+    }
+    if (elements > 1) {
+        writer.EndArray();
+    }
+}
+template<typename T>
+void jsonLogger::writeLogFrame(T &writer, const LogFrame &frame) const {
+    writer.StartObject();
+    {
+        // Add static items
+        writer.Key("step_index");
+        writer.Uint(frame.getStepCount());
+        if (frame.getEnvironment().size()) {
+            // Add dynamic environment values
+            writer.Key("environment");
+            writer.StartObject();
+            {
+                for (const auto &prop : frame.getEnvironment()) {
+                    writer.Key(prop.first.c_str());
+                    // Log value
+                    writeAny(writer, prop.second, prop.second.elements);
+                }
+            }
+            writer.EndObject();
+        }
+
+        if (frame.getAgents().size()) {
+            // Add dynamic agent values
+            writer.Key("agents");
+            writer.StartObject();
+            {
+                // This assumes that sort order places all agents of same name, different state consecutively
+                std::string current_agent;
+                for (const auto &agent : frame.getAgents()) {
+                    // Start/end new agent
+                    if (current_agent != agent.first.first) {
+                        if (!current_agent.empty())
+                            writer.EndObject();
+                        current_agent = agent.first.first;
+                        writer.Key(current_agent.c_str());
+                        writer.StartObject();
+                    }
+                    // Start new state
+                    writer.Key(agent.first.second.c_str());
+                    writer.StartObject();
+                    {
+                        // Log agent count if provided
+                        if (agent.second.second != UINT_MAX) {
+                            writer.Key("count");
+                            writer.Uint(agent.second.second);
+                        }
+                        if (agent.second.first.size()) {
+                            writer.Key("variables");
+                            writer.StartObject();
+                            // This assumes that sort order places all variables of same name, different reduction consecutively
+                            std::string current_variable;
+                            // Log each reduction
+                            for (auto &var : agent.second.first) {
+                                // Start/end new variable
+                                if (current_variable != var.first.name) {
+                                    if (!current_variable.empty())
+                                        writer.EndObject();
+                                    current_variable = var.first.name;
+                                    writer.Key(current_variable.c_str());
+                                    writer.StartObject();
+                                }
+                                // Build name key for the variable
+                                writer.Key(LoggingConfig::toString(var.first.reduction));
+                                // Log value
+                                writeAny(writer, var.second, 1);
+                            }
+                            if (!current_variable.empty())
+                                writer.EndObject();
+                            writer.EndObject();
+                        }
+                    }
+                    writer.EndObject();
+                }
+                if (!current_agent.empty())
+                    writer.EndObject();
+            }
+            writer.EndObject();
+        }
+    }
+    writer.EndObject();
+}
+
+template<typename T>
+void jsonLogger::logConfig(T &writer, const RunLog &log) const {
+    writer.Key("config");
+    writer.StartObject();
+    {
+        writer.Key("random_seed");
+        writer.Uint(log.getRandomSeed());
+    }
+    writer.EndObject();
+}
+template<typename T>
+void jsonLogger::logConfig(T &writer, const RunPlan &plan) const {
+    writer.Key("config");
+    writer.StartObject();
+    {
+        // Add static items
+        writer.Key("random_seed");
+        writer.Uint(plan.getRandomSimulationSeed());
+        writer.Key("steps");
+        writer.Uint(plan.getSteps());
+        // Add dynamic environment overrides
+        writer.Key("environment");
+        writer.StartObject();
+        {
+            for (const auto &prop : plan.property_overrides) {
+                const EnvironmentDescription::PropData &env_prop = plan.environment->at(prop.first);
+                writer.Key(prop.first.c_str());
+                writeAny(writer, prop.second, env_prop.data.elements);
+            }
+        }
+        writer.EndObject();
+    }
+    writer.EndObject();
+}
+template<typename T>
+void jsonLogger::logSteps(T &writer, const RunLog &log) const {
+    writer.Key("steps");
+    writer.StartArray();
+    {
+        for (const auto &step : log.getStepLog()) {
+            writeLogFrame(writer, step);
+        }
+    }
+    writer.EndArray();
+}
+template<typename T>
+void jsonLogger::logExit(T &writer, const RunLog &log) const {
+    writer.Key("exit");
+    writeLogFrame(writer, log.getExitLog());
+}
+
+template<typename T>
+void jsonLogger::logCommon(T &writer, const RunLog &log, const RunPlan *plan, bool doLogConfig, bool doLogSteps, bool doLogExit) const {
+    // Begin json output object
+    writer->StartObject();
+    {
+        // Log config
+        if (plan) {
+            logConfig(*writer, *plan);
+        } else if (doLogConfig) {
+            logConfig(*writer, log);
+        }
+
+        // Log step log
+        if (doLogSteps) {
+            logSteps(*writer, log);
+        }
+
+        // Log exit log
+        if (doLogExit) {
+            logExit(*writer, log);
+        }
+    }
+    // End Json file
+    writer->EndObject();
+}
+void jsonLogger::logCommon(const RunLog &log, const RunPlan *plan, bool doLogConfig, bool doLogSteps, bool doLogExit) const {
+    // Init writer
+    rapidjson::StringBuffer s;
+    if (prettyPrint) {
+        // rapidjson::Writer doesn't have virtual methods, so can't pass rapidjson::PrettyWriter around as ptr to rapidjson::writer
+        rapidjson::PrettyWriter<rapidjson::StringBuffer>* writer = new rapidjson::PrettyWriter<rapidjson::StringBuffer>(s);
+        writer->SetIndent('\t', 1);
+        logCommon(writer, log, plan, doLogConfig, doLogSteps, doLogExit);
+        delete writer;
+    } else {
+        rapidjson::Writer<rapidjson::StringBuffer> *writer = new rapidjson::Writer<rapidjson::StringBuffer>(s);
+        logCommon(writer, log, plan, doLogConfig, doLogSteps, doLogExit);
+        delete writer;
+    }
+    // Perform output
+    std::ofstream out(out_path, truncateFile ? std::ofstream::trunc : std::ofstream::app);
+    if (!out.is_open()) {
+        THROW RapidJSONError("Unable to open file '%s' for writing\n", out_path.c_str());
+    }
+
+    out << s.GetString();
+    out << "\n";
+    out.close();
+}

--- a/src/flamegpu/io/jsonReader.cpp
+++ b/src/flamegpu/io/jsonReader.cpp
@@ -16,7 +16,7 @@
 jsonReader::jsonReader(
     const std::string &model_name,
     const std::unordered_map<std::string, EnvironmentDescription::PropData> &env_desc,
-    std::unordered_map<std::pair<std::string, unsigned int>, EnvironmentDescription::Any> &env_init,
+    std::unordered_map<std::pair<std::string, unsigned int>, Any> &env_init,
     const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &model_state,
     const std::string &input,
     Simulation *sim_instance)
@@ -31,7 +31,7 @@ class jsonReader_impl : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, j
     std::string lastKey;
     std::string filename;
     const std::unordered_map<std::string, EnvironmentDescription::PropData> env_desc;
-    std::unordered_map<std::pair<std::string, unsigned int>, EnvironmentDescription::Any> &env_init;
+    std::unordered_map<std::pair<std::string, unsigned int>, Any> &env_init;
     /**
      * Used for setting agent values
      */
@@ -56,7 +56,7 @@ class jsonReader_impl : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, j
  public:
     jsonReader_impl(const std::string &_filename,
         const std::unordered_map<std::string, EnvironmentDescription::PropData> &_env_desc,
-        std::unordered_map<std::pair<std::string, unsigned int>, EnvironmentDescription::Any> &_env_init,
+        std::unordered_map<std::pair<std::string, unsigned int>, Any> &_env_init,
         const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &_model_state)
         : filename(_filename)
         , env_desc(_env_desc)
@@ -79,37 +79,37 @@ class jsonReader_impl : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, j
                 THROW RapidJSONError("Input file contains environment property '%s' multiple times, "
                     "in jsonReader::parse()\n", lastKey.c_str());
             }
-            const std::type_index val_type = it->second.type;
+            const std::type_index val_type = it->second.data.type;
             if (val_type == std::type_index(typeid(float))) {
                 const float t = static_cast<float>(val);
-                env_init.emplace(make_pair(lastKey, current_variable_array_index++), EnvironmentDescription::Any(&t, sizeof(float)));
+                env_init.emplace(make_pair(lastKey, current_variable_array_index++), Any(&t, sizeof(float), val_type, 1));
             } else if (val_type == std::type_index(typeid(double))) {
                 const double t = static_cast<double>(val);
-                env_init.emplace(make_pair(lastKey, current_variable_array_index++), EnvironmentDescription::Any(&t, sizeof(double)));
+                env_init.emplace(make_pair(lastKey, current_variable_array_index++), Any(&t, sizeof(double), val_type, 1));
             } else if (val_type == std::type_index(typeid(int64_t))) {
                 const int64_t t = static_cast<int64_t>(val);
-                env_init.emplace(make_pair(lastKey, current_variable_array_index++), EnvironmentDescription::Any(&t, sizeof(int64_t)));
+                env_init.emplace(make_pair(lastKey, current_variable_array_index++), Any(&t, sizeof(int64_t), val_type, 1));
             } else if (val_type == std::type_index(typeid(uint64_t))) {
                 const uint64_t t = static_cast<uint64_t>(val);
-                env_init.emplace(make_pair(lastKey, current_variable_array_index++), EnvironmentDescription::Any(&t, sizeof(uint64_t)));
+                env_init.emplace(make_pair(lastKey, current_variable_array_index++), Any(&t, sizeof(uint64_t), val_type, 1));
             } else if (val_type == std::type_index(typeid(int32_t))) {
                 const int32_t t = static_cast<int32_t>(val);
-                env_init.emplace(make_pair(lastKey, current_variable_array_index++), EnvironmentDescription::Any(&t, sizeof(int32_t)));
+                env_init.emplace(make_pair(lastKey, current_variable_array_index++), Any(&t, sizeof(int32_t), val_type, 1));
             } else if (val_type == std::type_index(typeid(uint32_t))) {
                 const uint32_t t = static_cast<uint32_t>(val);
-                env_init.emplace(make_pair(lastKey, current_variable_array_index++), EnvironmentDescription::Any(&t, sizeof(uint32_t)));
+                env_init.emplace(make_pair(lastKey, current_variable_array_index++), Any(&t, sizeof(uint32_t), val_type, 1));
             } else if (val_type == std::type_index(typeid(int16_t))) {
                 const int16_t t = static_cast<int16_t>(val);
-                env_init.emplace(make_pair(lastKey, current_variable_array_index++), EnvironmentDescription::Any(&t, sizeof(int16_t)));
+                env_init.emplace(make_pair(lastKey, current_variable_array_index++), Any(&t, sizeof(int16_t), val_type, 1));
             } else if (val_type == std::type_index(typeid(uint16_t))) {
                 const uint16_t t = static_cast<uint16_t>(val);
-                env_init.emplace(make_pair(lastKey, current_variable_array_index++), EnvironmentDescription::Any(&t, sizeof(uint16_t)));
+                env_init.emplace(make_pair(lastKey, current_variable_array_index++), Any(&t, sizeof(uint16_t), val_type, 1));
             } else if (val_type == std::type_index(typeid(int8_t))) {
                 const int8_t t = static_cast<int8_t>(val);
-                env_init.emplace(make_pair(lastKey, current_variable_array_index++), EnvironmentDescription::Any(&t, sizeof(int8_t)));
+                env_init.emplace(make_pair(lastKey, current_variable_array_index++), Any(&t, sizeof(int8_t), val_type, 1));
             } else if (val_type == std::type_index(typeid(uint8_t))) {
                 const uint8_t t = static_cast<uint8_t>(val);
-                env_init.emplace(make_pair(lastKey, current_variable_array_index++), EnvironmentDescription::Any(&t, sizeof(uint8_t)));
+                env_init.emplace(make_pair(lastKey, current_variable_array_index++), Any(&t, sizeof(uint8_t), val_type, 1));
             } else {
                 THROW RapidJSONError("Model contains environment property '%s' of unsupported type '%s', "
                     "in jsonReader::parse()\n", lastKey.c_str(), val_type.name());

--- a/src/flamegpu/io/jsonWriter.cpp
+++ b/src/flamegpu/io/jsonWriter.cpp
@@ -11,7 +11,6 @@
 #include "flamegpu/model/AgentDescription.h"
 #include "flamegpu/pop/AgentPopulation.h"
 #include "flamegpu/gpu/CUDASimulation.h"
-#include "tinyxml2/tinyxml2.h"
 
 jsonWriter::jsonWriter(
     const std::string &model_name,

--- a/src/flamegpu/io/xmlLogger.cu
+++ b/src/flamegpu/io/xmlLogger.cu
@@ -1,0 +1,257 @@
+#include "flamegpu/io/xmlLogger.h"
+
+#include <sstream>
+
+#include "tinyxml2/tinyxml2.h"              // downloaded from https:// github.com/leethomason/tinyxml2, the list of xml parsers : http:// lars.ruoff.free.fr/xmlcpp/
+
+#include "flamegpu/sim/RunPlan.h"
+#include "flamegpu/sim/LogFrame.h"
+
+#ifndef XMLCheckResult
+#define XMLCheckResult(a_eResult) if (a_eResult != tinyxml2::XML_SUCCESS) { FGPUException::setLocation(__FILE__, __LINE__);\
+    switch (a_eResult) { \
+    case tinyxml2::XML_ERROR_FILE_NOT_FOUND : \
+    case tinyxml2::XML_ERROR_FILE_COULD_NOT_BE_OPENED : \
+        throw InvalidInputFile("TinyXML error: File could not be opened.\n Error code: %d", a_eResult); \
+    case tinyxml2::XML_ERROR_FILE_READ_ERROR : \
+        throw InvalidInputFile("TinyXML error: File could not be read.\n Error code: %d", a_eResult); \
+    case tinyxml2::XML_ERROR_PARSING_ELEMENT : \
+    case tinyxml2::XML_ERROR_PARSING_ATTRIBUTE : \
+    case tinyxml2::XML_ERROR_PARSING_TEXT : \
+    case tinyxml2::XML_ERROR_PARSING_CDATA : \
+    case tinyxml2::XML_ERROR_PARSING_COMMENT : \
+    case tinyxml2::XML_ERROR_PARSING_DECLARATION : \
+    case tinyxml2::XML_ERROR_PARSING_UNKNOWN : \
+    case tinyxml2::XML_ERROR_PARSING : \
+        throw TinyXMLError("TinyXML error: Error parsing file.\n Error code: %d", a_eResult); \
+    case tinyxml2::XML_ERROR_EMPTY_DOCUMENT : \
+        throw TinyXMLError("TinyXML error: XML_ERROR_EMPTY_DOCUMENT\n Error code: %d", a_eResult); \
+    case tinyxml2::XML_ERROR_MISMATCHED_ELEMENT : \
+        throw TinyXMLError("TinyXML error: XML_ERROR_MISMATCHED_ELEMENT\n Error code: %d", a_eResult); \
+    case tinyxml2::XML_CAN_NOT_CONVERT_TEXT : \
+        throw TinyXMLError("TinyXML error: XML_CAN_NOT_CONVERT_TEXT\n Error code: %d", a_eResult); \
+    case tinyxml2::XML_NO_TEXT_NODE : \
+        throw TinyXMLError("TinyXML error: XML_NO_TEXT_NODE\n Error code: %d", a_eResult); \
+    case tinyxml2::XML_ELEMENT_DEPTH_EXCEEDED : \
+        throw TinyXMLError("TinyXML error: XML_ELEMENT_DEPTH_EXCEEDED\n Error code: %d", a_eResult); \
+    case tinyxml2::XML_ERROR_COUNT : \
+        throw TinyXMLError("TinyXML error: XML_ERROR_COUNT\n Error code: %d", a_eResult); \
+    case tinyxml2::XML_NO_ATTRIBUTE: \
+        throw TinyXMLError("TinyXML error: XML_NO_ATTRIBUTE\n Error code: %d", a_eResult); \
+    case tinyxml2::XML_WRONG_ATTRIBUTE_TYPE : \
+        throw TinyXMLError("TinyXML error: XML_WRONG_ATTRIBUTE_TYPE\n Error code: %d", a_eResult); \
+    default: \
+        throw TinyXMLError("TinyXML error: Unrecognised error code\n Error code: %d", a_eResult); \
+    } \
+}
+#endif
+
+xmlLogger::xmlLogger(const std::string &outPath, bool _prettyPrint, bool _truncateFile)
+    : out_path(outPath)
+    , prettyPrint(_prettyPrint)
+    , truncateFile(_truncateFile) { }
+
+void xmlLogger::log(const RunLog &log, const RunPlan &plan, bool logSteps, bool logExit) const {
+  logCommon(log, &plan, false, logSteps, logExit);
+}
+void xmlLogger::log(const RunLog &log, bool logConfig, bool logSteps, bool logExit) const {
+  logCommon(log, nullptr, logConfig, logSteps, logExit);
+}
+
+void xmlLogger::logCommon(const RunLog &log, const RunPlan *plan, bool doLogConfig, bool doLogSteps, bool doLogExit) const {
+    tinyxml2::XMLDocument doc;
+
+    tinyxml2::XMLNode * pRoot = doc.NewElement("log");
+    doc.InsertFirstChild(pRoot);
+
+    // Log config
+    if (plan) {
+        pRoot->InsertEndChild(logConfig(doc, *plan));
+    } else if (doLogConfig) {
+        pRoot->InsertEndChild(logConfig(doc, log));
+    }
+
+    // Log step log
+    if (doLogSteps) {
+        pRoot->InsertEndChild(logSteps(doc, log));
+    }
+
+    // Log exit log
+    if (doLogExit) {
+        pRoot->InsertEndChild(logExit(doc, log));
+    }
+    // export
+    FILE *fptr = fopen(out_path.c_str(), truncateFile ? "w" : "a");
+    if (fptr == nullptr) {
+        THROW TinyXMLError("Unable to open file '%s' for writing\n", out_path.c_str());
+    }
+    XMLCheckResult(doc.SaveFile(fptr, !prettyPrint));
+    fwrite("\n", sizeof(char), 1, fptr);
+    fclose(fptr);
+}
+
+tinyxml2::XMLNode *xmlLogger::logConfig(tinyxml2::XMLDocument &doc, const RunLog &log) const {
+    tinyxml2::XMLElement *pConfigElement = doc.NewElement("config");
+    {
+        tinyxml2::XMLElement *pListElement;
+        pListElement = doc.NewElement("random_seed");
+        pListElement->SetText(log.getRandomSeed());
+        pConfigElement->InsertEndChild(pListElement);
+    }
+    return pConfigElement;
+}
+tinyxml2::XMLNode *xmlLogger::logConfig(tinyxml2::XMLDocument &doc, const RunPlan &plan) const {
+    tinyxml2::XMLElement *pConfigElement = doc.NewElement("config");
+    {
+        tinyxml2::XMLElement *pListElement;
+        // Add static items
+        pListElement = doc.NewElement("random_seed");
+        pListElement->SetText(plan.getRandomSimulationSeed());
+        pConfigElement->InsertEndChild(pListElement);
+        pListElement = doc.NewElement("steps");
+        pListElement->SetText(plan.getSteps());
+        pConfigElement->InsertEndChild(pListElement);
+        // Add dynamic environment overrides
+        tinyxml2::XMLElement *pEnvElement = doc.NewElement("environment");
+        {
+            for (const auto &prop : plan.property_overrides) {
+                const EnvironmentDescription::PropData &env_prop = plan.environment->at(prop.first);
+                pListElement = doc.NewElement(prop.first.c_str());
+                writeAny(pListElement, prop.second, env_prop.data.elements);
+                pEnvElement->InsertEndChild(pListElement);
+            }
+        }
+        pConfigElement->InsertEndChild(pEnvElement);
+    }
+    return pConfigElement;
+}
+tinyxml2::XMLNode *xmlLogger::logSteps(tinyxml2::XMLDocument &doc, const RunLog &log) const {
+    tinyxml2::XMLElement *pStepsElement = doc.NewElement("steps");
+    {
+        for (const auto &step : log.getStepLog()) {
+            pStepsElement->InsertEndChild(writeLogFrame(doc, step));
+        }
+    }
+    return pStepsElement;
+}
+tinyxml2::XMLNode *xmlLogger::logExit(tinyxml2::XMLDocument &doc, const RunLog &log) const {
+    tinyxml2::XMLElement *pExitElement = doc.NewElement("exit");
+    pExitElement->InsertEndChild(writeLogFrame(doc, log.getExitLog()));
+    return pExitElement;
+}
+
+tinyxml2::XMLNode *xmlLogger::writeLogFrame(tinyxml2::XMLDocument &doc, const LogFrame &frame) const {
+    tinyxml2::XMLElement *pFrameElement = doc.NewElement("step");
+    {
+        tinyxml2::XMLElement *pListElement;
+        // Add static items
+        pListElement = doc.NewElement("step_index");
+        pListElement->SetText(frame.getStepCount());
+        pFrameElement->InsertEndChild(pListElement);
+        // Add dynamic environment values
+        if (frame.getEnvironment().size()) {
+            tinyxml2::XMLElement *pEnvElement = doc.NewElement("environment");
+            {
+                for (const auto &prop : frame.getEnvironment()) {
+                    pListElement = doc.NewElement(prop.first.c_str());
+                    writeAny(pListElement, prop.second, prop.second.elements);
+                    pEnvElement->InsertEndChild(pListElement);
+                }
+            }
+            pFrameElement->InsertEndChild(pEnvElement);
+        }
+
+        if (frame.getAgents().size()) {
+            // Add dynamic agent values
+            tinyxml2::XMLElement *pAgentsElement = doc.NewElement("agents");
+            {
+                // This assumes that sort order places all agents of same name, different state consecutively
+                std::string current_agent;
+                tinyxml2::XMLElement *pAgentsItemElement = nullptr;
+                for (const auto &agent : frame.getAgents()) {
+                    // Start/end new agent
+                    if (current_agent != agent.first.first) {
+                        if (!current_agent.empty())
+                            pAgentsElement->InsertEndChild(pAgentsItemElement);
+                        current_agent = agent.first.first;
+                        pAgentsItemElement = doc.NewElement(current_agent.c_str());
+                    }
+                    // Start new state
+                    tinyxml2::XMLElement *pStateElement = doc.NewElement(agent.first.second.c_str());
+                    {
+                        // Log agent count if provided
+                        if (agent.second.second != UINT_MAX) {
+                            tinyxml2::XMLElement *pCountElement = doc.NewElement("count");
+                            pCountElement->SetText(agent.second.second);
+                            pStateElement->InsertEndChild(pCountElement);
+                        }
+                        if (agent.second.first.size()) {
+                            tinyxml2::XMLElement *pVariablesBlock = doc.NewElement("variables");
+                            // This assumes that sort order places all variables of same name, different reduction consecutively
+                            std::string current_variable;
+                            tinyxml2::XMLElement *pVariableElement = nullptr;
+                            // Log each reduction
+                            for (auto &var : agent.second.first) {
+                                // Start/end new variable
+                                if (current_variable != var.first.name) {
+                                    if (!current_variable.empty())
+                                        pVariablesBlock->InsertEndChild(pVariableElement);
+                                    current_variable = var.first.name;
+                                    pVariableElement = doc.NewElement(current_variable.c_str());
+                                }
+                                // Build name key for the variable & log value
+                                tinyxml2::XMLElement *pValueElement = doc.NewElement(LoggingConfig::toString(var.first.reduction));
+                                writeAny(pValueElement, var.second, 1);
+                                pVariableElement->InsertEndChild(pValueElement);
+                            }
+                            if (!current_variable.empty())
+                                pVariablesBlock->InsertEndChild(pVariableElement);
+                            pStateElement->InsertEndChild(pVariablesBlock);
+                        }
+                    }
+                    pAgentsItemElement->InsertEndChild(pStateElement);
+                }
+                if (!current_agent.empty())
+                    pAgentsElement->InsertEndChild(pAgentsItemElement);
+            }
+            pFrameElement->InsertEndChild(pAgentsElement);
+        }
+    }
+    return pFrameElement;
+}
+
+void xmlLogger::writeAny(tinyxml2::XMLElement *pElement, const Any &value, const unsigned int &elements) const {
+    std::stringstream ss;
+    // Loop through elements, to construct csv string
+    for (unsigned int el = 0; el < elements; ++el) {
+        if (value.type == std::type_index(typeid(float))) {
+            ss << static_cast<const float*>(value.ptr)[el];
+        } else if (value.type == std::type_index(typeid(double))) {
+             ss << static_cast<const double*>(value.ptr)[el];
+        } else if (value.type == std::type_index(typeid(int64_t))) {
+            ss << static_cast<const int64_t*>(value.ptr)[el];
+        } else if (value.type == std::type_index(typeid(uint64_t))) {
+             ss << static_cast<const uint64_t*>(value.ptr)[el];
+        } else if (value.type == std::type_index(typeid(int32_t))) {
+            ss << static_cast<const int32_t*>(value.ptr)[el];
+        } else if (value.type == std::type_index(typeid(uint32_t))) {
+             ss << static_cast<const uint32_t*>(value.ptr)[el];
+        } else if (value.type == std::type_index(typeid(int16_t))) {
+             ss << static_cast<const int16_t*>(value.ptr)[el];
+        } else if (value.type == std::type_index(typeid(uint16_t))) {
+             ss << static_cast<const uint16_t*>(value.ptr)[el];
+        } else if (value.type == std::type_index(typeid(int8_t))) {
+            ss << static_cast<int32_t>(static_cast<const int8_t*>(value.ptr)[el]);  // Char outputs weird if being used as an integer
+        } else if (value.type == std::type_index(typeid(uint8_t))) {
+            ss << static_cast<uint32_t>(static_cast<const uint8_t*>(value.ptr)[el]);  // Char outputs weird if being used as an integer
+        } else if (value.type == std::type_index(typeid(char))) {
+            ss << static_cast<int32_t>(static_cast<const char*>(value.ptr)[el]);  // Char outputs weird if being used as an integer
+        } else {
+            THROW TinyXMLError("Attempting to export value of unsupported type '%s', "
+                "in xmlLogger::writeAny()\n", value.type.name());
+       }
+        if (el + 1 != elements)
+            ss << ",";
+    }
+    pElement->SetText(ss.str().c_str());
+}

--- a/src/flamegpu/io/xmlReader.cpp
+++ b/src/flamegpu/io/xmlReader.cpp
@@ -60,7 +60,7 @@
 xmlReader::xmlReader(
     const std::string &model_name,
     const std::unordered_map<std::string, EnvironmentDescription::PropData> &env_desc,
-    std::unordered_map<std::pair<std::string, unsigned int>, EnvironmentDescription::Any> &env_init,
+    std::unordered_map<std::pair<std::string, unsigned int>, Any> &env_init,
     const std::unordered_map<std::string, std::shared_ptr<AgentPopulation>> &model_state,
     const std::string &input,
     Simulation *sim_instance)
@@ -177,8 +177,8 @@ int xmlReader::parse() {
                 THROW TinyXMLError("Input file contains unrecognised environment property '%s',"
                     "in xmlReader::parse()\n", key);
             }
-            const std::type_index val_type = it->second.type;
-            const auto elements = it->second.elements;
+            const std::type_index val_type = it->second.data.type;
+            const auto elements = it->second.data.elements;
             unsigned int el = 0;
             while (getline(ss, token, ',')) {
                 if (env_init.find(make_pair(std::string(key), el)) != env_init.end()) {
@@ -187,34 +187,34 @@ int xmlReader::parse() {
                 }
                 if (val_type == std::type_index(typeid(float))) {
                     const float t = stof(token);
-                    env_init.emplace(make_pair(std::string(key), el++), EnvironmentDescription::Any(&t, sizeof(float)));
+                    env_init.emplace(make_pair(std::string(key), el++), Any(&t, sizeof(float), val_type, 1));
                 } else if (val_type == std::type_index(typeid(double))) {
                     const double t = stod(token);
-                    env_init.emplace(make_pair(std::string(key), el++), EnvironmentDescription::Any(&t, sizeof(double)));
+                    env_init.emplace(make_pair(std::string(key), el++), Any(&t, sizeof(double), val_type, 1));
                 } else if (val_type == std::type_index(typeid(int64_t))) {
                     const int64_t t = stoll(token);
-                    env_init.emplace(make_pair(std::string(key), el++), EnvironmentDescription::Any(&t, sizeof(int64_t)));
+                    env_init.emplace(make_pair(std::string(key), el++), Any(&t, sizeof(int64_t), val_type, 1));
                 } else if (val_type == std::type_index(typeid(uint64_t))) {
                     const uint64_t t = stoull(token);
-                    env_init.emplace(make_pair(std::string(key), el++), EnvironmentDescription::Any(&t, sizeof(uint64_t)));
+                    env_init.emplace(make_pair(std::string(key), el++), Any(&t, sizeof(uint64_t), val_type, 1));
                 } else if (val_type == std::type_index(typeid(int32_t))) {
                     const int32_t t = static_cast<int32_t>(stoll(token));
-                    env_init.emplace(make_pair(std::string(key), el++), EnvironmentDescription::Any(&t, sizeof(int32_t)));
+                    env_init.emplace(make_pair(std::string(key), el++), Any(&t, sizeof(int32_t), val_type, 1));
                 } else if (val_type == std::type_index(typeid(uint32_t))) {
                     const uint32_t t = static_cast<uint32_t>(stoull(token));
-                    env_init.emplace(make_pair(std::string(key), el++), EnvironmentDescription::Any(&t, sizeof(uint32_t)));
+                    env_init.emplace(make_pair(std::string(key), el++), Any(&t, sizeof(uint32_t), val_type, 1));
                 } else if (val_type == std::type_index(typeid(int16_t))) {
                     const int16_t t = static_cast<int16_t>(stoll(token));
-                    env_init.emplace(make_pair(std::string(key), el++), EnvironmentDescription::Any(&t, sizeof(int16_t)));
+                    env_init.emplace(make_pair(std::string(key), el++), Any(&t, sizeof(int16_t), val_type, 1));
                 } else if (val_type == std::type_index(typeid(uint16_t))) {
                     const uint16_t t = static_cast<uint16_t>(stoull(token));
-                    env_init.emplace(make_pair(std::string(key), el++), EnvironmentDescription::Any(&t, sizeof(uint16_t)));
+                    env_init.emplace(make_pair(std::string(key), el++), Any(&t, sizeof(uint16_t), val_type, 1));
                 } else if (val_type == std::type_index(typeid(int8_t))) {
                     const int8_t t = static_cast<int8_t>(stoll(token));
-                    env_init.emplace(make_pair(std::string(key), el++), EnvironmentDescription::Any(&t, sizeof(int8_t)));
+                    env_init.emplace(make_pair(std::string(key), el++), Any(&t, sizeof(int8_t), val_type, 1));
                 } else if (val_type == std::type_index(typeid(uint8_t))) {
                     const uint8_t t = static_cast<uint8_t>(stoull(token));
-                    env_init.emplace(make_pair(std::string(key), el++), EnvironmentDescription::Any(&t, sizeof(uint8_t)));
+                    env_init.emplace(make_pair(std::string(key), el++), Any(&t, sizeof(uint8_t), val_type, 1));
                 } else {
                     THROW TinyXMLError("Model contains environment property '%s' of unsupported type '%s', "
                         "in xmlReader::parse()\n", key, val_type.name());

--- a/src/flamegpu/model/EnvironmentDescription.cu
+++ b/src/flamegpu/model/EnvironmentDescription.cu
@@ -1,5 +1,12 @@
 #include "flamegpu/model/EnvironmentDescription.h"
 
+EnvironmentDescription::EnvironmentDescription() {
+    // Add CUDASimulation specific environment members
+    // We do this here, to not break comparing different model description hierarchies before/after CUDASimulation creation
+    unsigned int zero = 0;
+    newProperty("_stepCount", reinterpret_cast<const char*>(&zero), sizeof(unsigned int), false, 1, typeid(unsigned int));
+}
+
 bool EnvironmentDescription::operator==(const EnvironmentDescription& rhs) const {
     if (this == &rhs)  // They point to same object
         return true;
@@ -9,8 +16,8 @@ bool EnvironmentDescription::operator==(const EnvironmentDescription& rhs) const
             if (_v == rhs.properties.end())
                 return false;
             if (v.second.isConst != _v->second.isConst
-                || v.second.elements != _v->second.elements
-                || v.second.type != _v->second.type)
+                || v.second.data.elements != _v->second.data.elements
+                || v.second.data.type != _v->second.data.type)
                 return false;
             if (v.second.data.ptr == _v->second.data.ptr &&
                 v.second.data.length == _v->second.data.length)
@@ -32,7 +39,7 @@ bool EnvironmentDescription::operator!=(const EnvironmentDescription& rhs) const
 }
 
 void EnvironmentDescription::newProperty(const std::string &name, const char *ptr, const size_t &length, const bool &isConst, const EnvironmentManager::size_type &elements, const std::type_index &type) {
-    properties.emplace(name, PropData(isConst,  elements, Any(ptr, length), type));
+    properties.emplace(name, PropData(isConst,  Any(ptr, length, type, elements)));
 }
 
 bool EnvironmentDescription::getConst(const std::string &name) {

--- a/src/flamegpu/model/LayerData.cpp
+++ b/src/flamegpu/model/LayerData.cpp
@@ -43,8 +43,32 @@ bool LayerData::operator==(const LayerData &rhs) const {
     && agent_functions.size() == rhs.agent_functions.size()
     && host_functions.size() == rhs.host_functions.size()
     && host_functions_callbacks.size() == rhs.host_functions_callbacks.size()
-    && agent_functions == rhs.agent_functions
-    && host_functions == rhs.host_functions) {
+    && host_functions_callbacks == rhs.host_functions_callbacks) {
+        // Compare pointed to values, not pointers
+        for (auto &a : agent_functions) {
+            bool success = false;
+            for (auto &b : rhs.agent_functions) {
+                if (*a == *b) {
+                    success = true;
+                    break;
+                }
+            }
+            if (!success) {
+                return false;
+            }
+        }
+        for (auto &a : host_functions) {
+            bool success = false;
+            for (auto &b : rhs.host_functions) {
+                if (*a == *b) {
+                    success = true;
+                    break;
+                }
+            }
+            if (!success) {
+                return false;
+            }
+        }
         return true;
     }
     return false;

--- a/src/flamegpu/model/ModelData.cpp
+++ b/src/flamegpu/model/ModelData.cpp
@@ -124,7 +124,7 @@ bool ModelData::operator==(const ModelData& rhs) const {
                 auto it1 = layers.begin();
                 auto it2 = rhs.layers.begin();
                 while (it1 != layers.end() && it2 != rhs.layers.end()) {
-                    if (*it1 != *it2)
+                    if (*(*it1) != *(*it2))
                         return false;
                     ++it1;
                     ++it2;

--- a/src/flamegpu/model/ModelDescription.cpp
+++ b/src/flamegpu/model/ModelDescription.cpp
@@ -74,11 +74,6 @@ SubModelDescription& ModelDescription::newSubModel(const std::string &submodel_n
     }
     // Submodel name is not in use
     if (!hasSubModel(submodel_name)) {
-        if (submodel_description.model->exitConditions.empty() && submodel_description.model->exitConditionCallbacks.empty()) {
-            THROW InvalidSubModel("Model '%s' does not contain any exit conditions or exit condition callbacks, SubModels must exit of their own accord, "
-                "in ModelDescription::newSubModel().",
-                submodel_name.c_str());
-        }
         auto rtn = std::shared_ptr<SubModelData>(new SubModelData(model, submodel_name, submodel_description.model));
         // This will actually generate the environment mapping (cant do it in constructor, due to shared_from_this)
         // Not the end of the world if it isn't init (we should be able to catch it down the line), but safer this way

--- a/src/flamegpu/model/SubEnvironmentDescription.cpp
+++ b/src/flamegpu/model/SubEnvironmentDescription.cpp
@@ -46,13 +46,13 @@ void SubEnvironmentDescription::mapProperty(const std::string &sub_property_name
         }
     }
     // Check properties are the same
-    if (subProp->second.type != masterProp->second.type) {
+    if (subProp->second.data.type != masterProp->second.data.type) {
         THROW InvalidEnvProperty("Property types do not match, '%s' != '%s', "
-            "in SubEnvironmentDescription::mapProperty()\n", subProp->second.type.name(), masterProp->second.type.name());
+            "in SubEnvironmentDescription::mapProperty()\n", subProp->second.data.type.name(), masterProp->second.data.type.name());
     }
-    if (subProp->second.elements != masterProp->second.elements) {
+    if (subProp->second.data.elements != masterProp->second.data.elements) {
         THROW InvalidEnvProperty("Property lengths do not match, '%u' != '%u'",
-            "in SubEnvironmentDescription::mapProperty()\n", subProp->second.elements, masterProp->second.elements);
+            "in SubEnvironmentDescription::mapProperty()\n", subProp->second.data.elements, masterProp->second.data.elements);
     }
     if (masterProp->second.isConst && !subProp->second.isConst) {
         THROW InvalidEnvProperty("SubEnvironment property '%s' must be const, if mapped to const MasterEnvironment property '%s', "
@@ -89,8 +89,8 @@ void SubEnvironmentDescription::autoMapProperties() {
         // If there exists variable with same name in both environments
         if (masterProp != masterEnv->properties.end()) {
             // Check properties are the same
-            if ((subProp.second.type == masterProp->second.type) &&
-                (subProp.second.elements == masterProp->second.elements) &&
+            if ((subProp.second.data.type == masterProp->second.data.type) &&
+                (subProp.second.data.elements == masterProp->second.data.elements) &&
                 !(masterProp->second.isConst && !subProp.second.isConst)) {
                 data->properties.emplace(subProp.first, masterProp->first);  // Doesn't actually matter, both strings are equal
             }

--- a/src/flamegpu/model/SubModelData.cpp
+++ b/src/flamegpu/model/SubModelData.cpp
@@ -10,7 +10,8 @@ bool SubModelData::operator==(const SubModelData& rhs) const {
         return true;
     // Compare members
     if (subagents.size() == rhs.subagents.size()
-        && (submodel == rhs.submodel || *submodel == *rhs.submodel)) {
+        && (submodel == rhs.submodel || *submodel == *rhs.submodel)
+        && max_steps == rhs.max_steps) {
         // Compare subagents map
         for (auto &v : subagents) {
             auto _v = rhs.subagents.find(v.first);
@@ -21,6 +22,7 @@ bool SubModelData::operator==(const SubModelData& rhs) const {
             if (*v.second != *_v->second)
                 return false;
         }
+        return true;
     }
     return false;
 }
@@ -29,6 +31,7 @@ bool SubModelData::operator!=(const SubModelData& rhs) const {
 }
 SubModelData::SubModelData(const std::shared_ptr<ModelData> &model, const SubModelData &other)
     : submodel(other.submodel->clone())
+    , max_steps(other.max_steps)
     , name(other.name)
     , description(model ? new SubModelDescription(model, this) : nullptr) {
     // Note, this does not init subagents!
@@ -36,5 +39,6 @@ SubModelData::SubModelData(const std::shared_ptr<ModelData> &model, const SubMod
 }
 SubModelData::SubModelData(const std::shared_ptr<ModelData> &model, const std::string &submodel_name, const std::shared_ptr<ModelData> &_submodel)
     : submodel(_submodel)
+    , max_steps(0)
     , name(submodel_name)
-    , description(new SubModelDescription(model, this)) { }
+    , description(new SubModelDescription(model, this))  { }

--- a/src/flamegpu/model/SubModelDescription.cpp
+++ b/src/flamegpu/model/SubModelDescription.cpp
@@ -119,3 +119,10 @@ const SubEnvironmentDescription &SubModelDescription::getSubEnvironment(bool aut
         data->subenvironment->description->autoMapProperties();
     return *data->subenvironment->description;
 }
+
+void SubModelDescription::setMaxSteps(const unsigned int &max_steps) {
+    data->max_steps = max_steps;
+}
+unsigned int SubModelDescription::getMaxSteps() const {
+    return data->max_steps;
+}

--- a/src/flamegpu/runtime/utility/HostRandom.cu
+++ b/src/flamegpu/runtime/utility/HostRandom.cu
@@ -1,0 +1,8 @@
+#include "flamegpu/runtime/utility/HostRandom.cuh"
+
+void HostRandom::setSeed(const unsigned int &seed) {
+    rng.reseed(seed);
+}
+unsigned int HostRandom::getSeed() const {
+    return static_cast<unsigned int>(rng.seed());
+}

--- a/src/flamegpu/sim/AgentLoggingConfig.cu
+++ b/src/flamegpu/sim/AgentLoggingConfig.cu
@@ -1,0 +1,42 @@
+#include <utility>
+
+#include "flamegpu/sim/AgentLoggingConfig.h"
+#include "flamegpu/model/AgentData.h"
+
+namespace flamegpu_internal {
+    __constant__ double STANDARD_DEVIATION_MEAN;
+    std::mutex STANDARD_DEVIATION_MEAN_mutex;
+    standard_deviation_add_impl standard_deviation_add;
+    standard_deviation_subtract_mean_impl standard_deviation_subtract_mean;
+}
+
+AgentLoggingConfig::AgentLoggingConfig(
+    std::shared_ptr<const AgentData> _agent,
+    std::pair<std::shared_ptr<std::set<LoggingConfig::NameReductionFn>>, bool> &_agent_set)
+    : agent(std::move(_agent))
+    , agent_set(_agent_set.first)
+    , log_count(_agent_set.second) { }
+
+void AgentLoggingConfig::log(const LoggingConfig::NameReductionFn &nrf, const std::type_index &variable_type, const std::string &method_name) {
+    // Validate variable name and type
+    const auto var = agent->variables.find(nrf.name);
+    if (var == agent->variables.end()) {
+        THROW InvalidAgentVar("Agent ('%s') variable '%s' was not found in the model description, "
+            "in AgentLoggingConfig::log%s()\n",
+            agent->name.c_str(), nrf.name.c_str(), method_name.c_str());
+    } else if (var->second.type != variable_type) {
+        THROW InvalidVarType("Agent ('%s') variable '%s' has type '%s', incorrect type '%s' was provided to template, "
+            "in AgentLoggingConfig::log%s()\n",
+            agent->name.c_str(), nrf.name.c_str(), var->second.type.name(), variable_type.name(), method_name.c_str());
+    } else if (var->second.elements != 1) {
+        THROW InvalidVarType("Agent ('%s') variable '%s' is an array variable, this function does not support array variables, "
+            "in AgentLoggingConfig::log%s()\n",
+            agent->name.c_str(), nrf.name.c_str(), method_name.c_str());
+    }
+    // Store it in the map
+    if (!agent_set->emplace(nrf).second) {
+        THROW InvalidArgument("Agent ('%s') variable '%s' %s has already been marked for logging, "
+            "in AgentLoggingConfig::log%s()\n",
+             agent->name.c_str(), nrf.name.c_str(), method_name.c_str(), method_name.c_str());
+    }
+}

--- a/src/flamegpu/sim/LogFrame.cu
+++ b/src/flamegpu/sim/LogFrame.cu
@@ -1,0 +1,58 @@
+#include "flamegpu/sim/LogFrame.h"
+
+LogFrame::LogFrame()
+    : step_count(0) { }
+
+
+LogFrame::LogFrame(const std::map<std::string, Any> &&_environment,
+const std::map<LoggingConfig::NameStatePair,  std::pair<std::map<LoggingConfig::NameReductionFn, Any>, unsigned int>> &&_agents,
+const unsigned int &_step_count)
+    : environment(_environment)
+    , agents(_agents)
+    , step_count(_step_count) { }
+
+
+bool LogFrame::hasEnvironmentProperty(const std::string &property_name) const {
+    const auto &it = environment.find(property_name);
+    return it != environment.end();
+}
+
+AgentLogFrame LogFrame::getAgent(const std::string &agent_name, const std::string &state_name) const {
+    const auto &it = agents.find({agent_name, state_name});
+    if (it == agents.end()) {
+          THROW InvalidAgentState("Log data for agent '%s' state '%s' was not found, "
+              "in LogFrame::getEnvironmentProperty()\n",
+              agent_name.c_str(), state_name.c_str());
+    }
+    return AgentLogFrame(it->second.first, it->second.second);
+}
+
+AgentLogFrame::AgentLogFrame(const std::map<LoggingConfig::NameReductionFn, Any> &_data, const unsigned int &_count)
+    : data(_data)
+    , count(_count) { }
+
+
+unsigned int AgentLogFrame::getCount() const {
+    if (count != UINT_MAX)
+        return count;
+    THROW InvalidOperation("Count of agents in state was not found in the log, "
+        "in AgentLogFrame::getCount()\n");
+}
+double AgentLogFrame::getMean(const std::string &variable_name) const {
+    const auto &it = data.find({variable_name, LoggingConfig::Mean});
+    if (it == data.end()) {
+        THROW InvalidAgentVar("Mean of agent variable '%s' was not found in the log, "
+            "in AgentLogFrame::getMean()\n",
+            variable_name.c_str());
+    }
+    return *static_cast<double *>(it->second.ptr);
+}
+double AgentLogFrame::getStandardDev(const std::string &variable_name) const {
+    const auto &it = data.find({variable_name, LoggingConfig::StandardDev});
+    if (it == data.end()) {
+        THROW InvalidAgentVar("Standard deviation of agent variable '%s' was not found in the log, "
+            "in AgentLogFrame::getStandardDev()\n",
+            variable_name.c_str());
+    }
+    return *static_cast<double *>(it->second.ptr);
+}

--- a/src/flamegpu/sim/LoggingConfig.cu
+++ b/src/flamegpu/sim/LoggingConfig.cu
@@ -1,0 +1,65 @@
+#include "flamegpu/sim/LoggingConfig.h"
+
+#include "flamegpu/sim/AgentLoggingConfig.h"
+#include "flamegpu/model/ModelDescription.h"
+#include "flamegpu/model/ModelData.h"
+#include "flamegpu/model/AgentData.h"
+
+LoggingConfig::LoggingConfig(const ModelDescription &_model)
+    :model(_model.model->clone()) { }
+LoggingConfig::LoggingConfig(const ModelData &_model)
+    :model(_model.clone()) { }
+LoggingConfig::LoggingConfig(const LoggingConfig &other)
+    : model(other.model->clone())
+    , environment(other.environment)
+    , agents(other.agents) { }
+AgentLoggingConfig LoggingConfig::agent(const std::string &agent_name, const std::string &agent_state) {
+    // Validate the agent state combination exists
+    auto model_agent_it = model->agents.find(agent_name);
+    if (model_agent_it == model->agents.end()) {
+        THROW InvalidAgentName("Agent '%s' was not found in the model description, "
+            "in LoggingConfig::agent()\n",
+            agent_name.c_str());
+    }
+    if (model_agent_it->second->states.find(agent_state) == model_agent_it->second->states.end()) {
+        THROW InvalidAgentState("State '%s' was not found within agent '%s' in the model description, "
+            "in LoggingConfig::agent()\n",
+            agent_state.c_str(), agent_name.c_str());
+    }
+    NameStatePair name = std::make_pair(agent_name, agent_state);
+    auto agent_it = agents.find(name);
+    if (agent_it== agents.end())
+        agent_it = agents.emplace(name, std::make_pair(std::make_shared<std::set<NameReductionFn>>(), false)).first;
+    return AgentLoggingConfig(model_agent_it->second, agent_it->second);
+}
+
+void LoggingConfig::logEnvironment(const std::string &property_name) {
+    // Validate the environment property exists
+    auto env_map = model->environment->getPropertiesMap();
+    if (env_map.find(property_name) == env_map.end()) {
+        THROW InvalidEnvProperty("Environment property '%s' was not found in the model description, "
+            "in LoggingConfig::logEnvironment()\n",
+            property_name.c_str());
+    }
+    // Log the property
+    if (!environment.emplace(property_name).second) {
+        THROW InvalidEnvProperty("Environment property '%s' has already been marked for logging, "
+            "in LoggingConfig::logEnvironment()\n",
+            property_name.c_str());
+    }
+}
+StepLoggingConfig::StepLoggingConfig(const ModelDescription &model)
+    : LoggingConfig(model)
+    , frequency(1) { }
+StepLoggingConfig::StepLoggingConfig(const ModelData &model)
+    : LoggingConfig(model)
+    , frequency(1) { }
+StepLoggingConfig::StepLoggingConfig(const StepLoggingConfig &other)
+    : LoggingConfig(other)
+    , frequency(other.frequency) { }
+StepLoggingConfig::StepLoggingConfig(const LoggingConfig &other)
+    : LoggingConfig(other)
+    , frequency(1) { }
+void StepLoggingConfig::setFrequency(const unsigned int &steps) {
+    frequency = steps;
+}

--- a/src/flamegpu/sim/RunPlan.cpp
+++ b/src/flamegpu/sim/RunPlan.cpp
@@ -1,0 +1,79 @@
+#include "flamegpu/sim/RunPlan.h"
+#include "flamegpu/sim/RunPlanVec.h"
+
+#include "flamegpu/model/ModelDescription.h"
+
+RunPlan::RunPlan(const ModelDescription &model)
+    : RunPlan(std::make_shared<std::unordered_map<std::string, EnvironmentDescription::PropData> const>(model.model->environment->getPropertiesMap()),
+      model.model->exitConditions.size() + model.model->exitConditionCallbacks.size() > 0) { }
+RunPlan::RunPlan(const std::shared_ptr<const std::unordered_map<std::string, EnvironmentDescription::PropData>>  &environment, const bool &allow_0)
+    : random_seed(0)
+    , steps(0)
+    , environment(environment)
+    , allow_0_steps(allow_0) { }
+
+RunPlan& RunPlan::operator=(const RunPlan& other) {
+    this->random_seed = other.random_seed;
+    this->steps = other.steps;
+    this->environment = other.environment;
+    this->allow_0_steps = other.allow_0_steps;
+    this->output_subdirectory = other.output_subdirectory;
+    this->allow_0_steps = other.allow_0_steps;
+    for (auto &i : other.property_overrides)
+        this->property_overrides.emplace(i.first, Any(i.second));
+    return *this;
+}
+void RunPlan::setRandomSimulationSeed(const unsigned int &_random_seed) { random_seed = _random_seed; }
+void RunPlan::setSteps(const unsigned int &_steps) {
+    if (_steps == 0 && !allow_0_steps) {
+        throw std::out_of_range("Model description requires atleast 1 exit condition to have unlimited steps, "
+            "in RunPlan::setSteps()");
+    }
+    steps = _steps;
+}
+void RunPlan::setOutputSubdirectory(const std::string &subdir) {
+    output_subdirectory = subdir;
+}
+
+unsigned int RunPlan::getRandomSimulationSeed() const {
+    return random_seed;
+}
+unsigned int RunPlan::getSteps() const {
+    return steps;
+}
+std::string RunPlan::getOutputSubdirectory() const {
+    return output_subdirectory;
+}
+
+RunPlanVec RunPlan::operator+(const RunPlan& rhs) const {
+    // Validation
+    if (*rhs.environment != *this->environment) {
+        THROW InvalidArgument("RunPlan is for a different ModelDescription, "
+            "in ::operator+(RunPlan, RunPlan)");
+    }
+    // Operation
+    RunPlanVec rtn(this->environment, this->allow_0_steps);
+    rtn+=*this;
+    rtn+=rhs;
+    return rtn;
+}
+RunPlanVec RunPlan::operator+(const RunPlanVec& rhs) const {
+    // This function is defined internally inside both RunPlan and RunPlanVec as it's the only way to both pass CI and have SWIG build
+    // Validation
+    if (*rhs.environment != *this->environment) {
+        THROW InvalidArgument("RunPlan is for a different ModelDescription, "
+            "in ::operator+(RunPlan, RunPlanVec)");
+    }
+    // Operation
+    RunPlanVec rtn(rhs);
+    rtn+=*this;
+    return rtn;
+}
+RunPlanVec RunPlan::operator*(const unsigned int& rhs) const {
+    // Operation
+    RunPlanVec rtn(this->environment, this->allow_0_steps);
+    for (unsigned int i = 0; i < rhs; ++i) {
+        rtn+=*this;
+    }
+    return rtn;
+}

--- a/src/flamegpu/sim/RunPlanVec.cpp
+++ b/src/flamegpu/sim/RunPlanVec.cpp
@@ -1,0 +1,120 @@
+#include "flamegpu/sim/RunPlanVec.h"
+#include "flamegpu/model/ModelDescription.h"
+
+RunPlanVec::RunPlanVec(const ModelDescription &model, unsigned int initial_length)
+    : std::vector<RunPlan>(initial_length, RunPlan(model)),
+      rand(std::random_device()())
+    , environment(std::make_shared<std::unordered_map<std::string, EnvironmentDescription::PropData> const>(model.model->environment->getPropertiesMap()))
+    , allow_0_steps(model.model->exitConditions.size() + model.model->exitConditionCallbacks.size() > 0) {
+    this->resize(initial_length, RunPlan(environment, allow_0_steps));
+}
+
+RunPlanVec::RunPlanVec(const std::shared_ptr<const std::unordered_map<std::string, EnvironmentDescription::PropData>> &_environment, const bool &_allow_0_steps)
+    : std::vector<RunPlan>(),
+      rand(std::random_device()())
+    , environment(_environment)
+    , allow_0_steps(_allow_0_steps) { }
+void RunPlanVec::setRandomSimulationSeed(const unsigned int &initial_seed, const unsigned int &step) {
+    unsigned int current_seed = initial_seed;
+    for (auto &i : *this) {
+        i.setRandomSimulationSeed(current_seed);
+        current_seed += step;
+    }
+}
+void RunPlanVec::setSteps(const unsigned int &steps) {
+    if (steps == 0 && !allow_0_steps) {
+        throw std::out_of_range("Model description requires atleast 1 exit condition to have unlimited steps, "
+            "in RunPlanVec::setSteps()");
+    }
+    for (auto &i : *this) {
+        i.setSteps(steps);
+    }
+}
+void RunPlanVec::setOutputSubdirectory(const std::string &subdir) {
+    for (auto &i : *this) {
+        i.setOutputSubdirectory(subdir);
+    }
+}
+void RunPlanVec::setRandomPropertySeed(const unsigned int &seed) {
+    rand.seed(seed);
+}
+
+RunPlanVec RunPlanVec::operator+(const RunPlan& rhs) const {
+    // This function is defined internally inside both RunPlan and RunPlanVec as it's the only way to both pass CI and have SWIG build
+    // Validation
+    if (*rhs.environment != *this->environment) {
+        THROW InvalidArgument("RunPlan is for a different ModelDescription, "
+            "in ::operator+(RunPlanVec, RunPlan)");
+    }
+    // Operation
+    RunPlanVec rtn(*this);
+    rtn+=rhs;
+    return rtn;
+}
+RunPlanVec RunPlanVec::operator+(const RunPlanVec& rhs) const {
+    // Validation
+    if (*rhs.environment != *this->environment) {
+        THROW InvalidArgument("RunPlanVecs are for different ModelDescriptions, "
+            "in ::operator+(RunPlanVec, RunPlanVec)");
+    }
+    // Operation
+    RunPlanVec rtn(*this);
+    rtn+=rhs;
+    return rtn;
+}
+RunPlanVec& RunPlanVec::operator+=(const RunPlan& rhs) {
+    // Validation
+    if (*rhs.environment != *this->environment) {
+        THROW InvalidArgument("RunPlan is for a different ModelDescription, "
+            "in ::operator+=(RunPlanVec, RunPlan)");
+    }
+    // Update shared_ptr to env
+    RunPlan rhs_copy = rhs;
+    rhs_copy.environment = environment;
+    // Operation
+    this->push_back(rhs_copy);
+    return *this;
+}
+RunPlanVec& RunPlanVec::operator+=(const RunPlanVec& rhs) {
+    // Validation
+    if (this == &rhs) {
+        return *this*=2;
+    }
+    if (*rhs.environment != *this->environment) {
+        THROW InvalidArgument("RunPlan is for a different ModelDescription, "
+            "in ::operator+=(RunPlanVec, RunPlan)");
+    }
+    // Operation
+    this->reserve(size() + rhs.size());
+    // Iterate, because insert would require RunPlan::operator==
+    for (const auto &i : rhs) {
+        // Update shared_ptr to env
+        RunPlan i_copy = i;
+        i_copy.environment = environment;
+        this->push_back(i);
+    }
+    return *this;
+}
+RunPlanVec& RunPlanVec::operator*=(const unsigned int& rhs) {
+    RunPlanVec copy(*this);
+    this->clear();
+    this->reserve(copy.size() * rhs);
+    for (unsigned int i = 0; i < rhs; ++i) {
+        // Iterate, because insert would require RunPlan::operator==
+        for (const auto &j : copy) {
+            this->push_back(j);
+        }
+    }
+    return *this;
+}
+RunPlanVec RunPlanVec::operator*(const unsigned int& rhs) const {
+    RunPlanVec rtn(this->environment, this->allow_0_steps);
+    rtn.reserve(size() * rhs);
+    for (unsigned int i = 0; i < rhs; ++i) {
+        // Iterate, because insert would require RunPlan::operator==
+        for (const auto &j : *this) {
+            rtn.push_back(j);
+        }
+    }
+    return *this;
+}

--- a/src/flamegpu/sim/SimLogger.cu
+++ b/src/flamegpu/sim/SimLogger.cu
@@ -1,0 +1,91 @@
+#include "flamegpu/sim/SimLogger.h"
+
+#include "flamegpu/io/factory.h"
+#include "flamegpu/sim/RunPlanVec.h"
+
+// If earlier than VS 2019
+#if defined(_MSC_VER) && _MSC_VER < 1920
+#include <filesystem>
+using std::tr2::sys::exists;
+using std::tr2::sys::path;
+using std::tr2::sys::create_directory;
+#else
+// VS2019 requires this macro, as building pre c++17 cant use std::filesystem
+#define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
+#include <experimental/filesystem>
+using std::experimental::filesystem::v1::exists;
+using std::experimental::filesystem::v1::path;
+using std::experimental::filesystem::v1::create_directory;
+#endif
+
+#ifdef _MSC_VER
+#include <windows.h>
+#else
+#include <pthread.h>
+#endif
+
+SimLogger::SimLogger(const std::vector<RunLog> &_run_logs,
+        const RunPlanVec &_run_plans,
+        const std::string &_out_directory,
+        const std::string &_out_format,
+        std::queue<unsigned int> &_log_export_queue,
+        std::mutex &_log_export_queue_mutex,
+        std::condition_variable &_log_export_queue_cdn)
+    : run_logs(_run_logs)
+    , run_plans(_run_plans)
+    , out_directory(_out_directory)
+    , out_format(_out_format)
+    , log_export_queue(_log_export_queue)
+    , log_export_queue_mutex(_log_export_queue_mutex)
+    , log_export_queue_cdn(_log_export_queue_cdn) {
+    this->thread = std::thread(&SimLogger::start, this);
+    // Attempt to name the thread
+#ifdef _MSC_VER
+    std::wstringstream thread_name;
+    thread_name << L"SimLogger";
+    // HRESULT hr =
+    SetThreadDescription(this->thread.native_handle(), thread_name.str().c_str());
+    // if (FAILED(hr)) {
+    //     fprintf(stderr, "Failed to name thread 'SimLogger'\n");
+    // }
+#else
+    std::stringstream thread_name;
+    thread_name << "SimLogger";
+    // int hr =
+    pthread_setname_np(this->thread.native_handle(), thread_name.str().c_str());
+    // if (hr) {
+    //     fprintf(stderr, "Failed to name thread 'SimLogger'\n");
+    // }
+#endif
+}
+void SimLogger::start() {
+    const path p_out_directory = out_directory;
+    unsigned int logs_processed = 0;
+    while (logs_processed < run_plans.size()) {
+        std::unique_lock<std::mutex> lock(log_export_queue_mutex);
+        log_export_queue_cdn.wait(lock, [this]{ return !log_export_queue.empty(); });
+        do {
+            // Pop item to be logged from queue
+            const unsigned int target_log = log_export_queue.front();
+            log_export_queue.pop();
+            lock.unlock();
+
+            // Check item isn't telling us to exit early
+            if (target_log == UINT_MAX) {
+                logs_processed = UINT_MAX;
+                break;
+            }
+            // Log items
+            const path exit_path = p_out_directory/path(run_plans[target_log].getOutputSubdirectory())/path("exit." + out_format);
+            const auto exit_logger = WriterFactory::createLogger(exit_path.generic_string(), false, false);
+            exit_logger->log(run_logs[target_log], true, false, true);
+            const path step_path = p_out_directory/path(run_plans[target_log].getOutputSubdirectory())/path(std::to_string(target_log)+"."+out_format);
+            const auto step_logger = WriterFactory::createLogger(step_path.generic_string(), false, false);
+            step_logger->log(run_logs[target_log], true, true, false);
+
+            // Continue
+            ++logs_processed;
+            lock.lock();
+        } while (!log_export_queue.empty());
+    }
+}

--- a/src/flamegpu/sim/SimRunner.cu
+++ b/src/flamegpu/sim/SimRunner.cu
@@ -1,0 +1,104 @@
+#include "flamegpu/sim/SimRunner.h"
+
+#include <utility>
+
+#include "flamegpu/model/ModelData.h"
+#include "flamegpu/gpu/CUDASimulation.h"
+#include "flamegpu/sim/RunPlanVec.h"
+
+#ifdef _MSC_VER
+#include <windows.h>
+#else
+#include <pthread.h>
+#endif
+
+SimRunner::SimRunner(const std::shared_ptr<const ModelData> _model,
+    std::atomic<unsigned int> &_err_ct,
+    std::atomic<unsigned int> &_next_run,
+    const RunPlanVec &_plans,
+    std::shared_ptr<const StepLoggingConfig> _step_log_config,
+    std::shared_ptr<const LoggingConfig> _exit_log_config,
+    int _device_id,
+    unsigned int _runner_id,
+    bool _verbose,
+    std::vector<RunLog> &_run_logs,
+    std::queue<unsigned int> &_log_export_queue,
+    std::mutex &_log_export_queue_mutex,
+    std::condition_variable &_log_export_queue_cdn)
+      : model(_model->clone())
+      , run_id(0)
+      , device_id(_device_id)
+      , runner_id(_runner_id)
+      , verbose(_verbose)
+      , err_ct(_err_ct)
+      , next_run(_next_run)
+      , plans(_plans)
+      , step_log_config(std::move(_step_log_config))
+      , exit_log_config(std::move(_exit_log_config))
+      , run_logs(_run_logs)
+      , log_export_queue(_log_export_queue)
+      , log_export_queue_mutex(_log_export_queue_mutex)
+      ,  log_export_queue_cdn(_log_export_queue_cdn) {
+    this->thread = std::thread(&SimRunner::start, this);
+    // Attempt to name the thread
+#ifdef _MSC_VER
+    std::wstringstream thread_name;
+    thread_name << L"CUDASim D" << device_id << L"T" << runner_id;
+    // HRESULT hr =
+    SetThreadDescription(this->thread.native_handle(), thread_name.str().c_str());
+    // if (FAILED(hr)) {
+    //     fprintf(stderr, "Failed to name thread 'CUDASim D%dT%u'\n", device_id, runner_id);
+    // }
+#else
+    std::stringstream thread_name;
+    thread_name << "CUDASim D" << device_id << "T" << runner_id;
+    // int hr =
+    pthread_setname_np(this->thread.native_handle(), thread_name.str().c_str());
+    // if (hr) {
+    //     fprintf(stderr, "Failed to name thread 'CUDASim D%dT%u'\n", device_id, runner_id);
+    // }
+#endif
+}
+
+
+void SimRunner::start() {
+    // While there are still plans to process
+    while ((this->run_id = next_run++) < plans.size()) {
+        try {
+            // Update environment (this might be worth moving into CUDASimulation)
+            auto &prop_map = model->environment->properties;
+            for (auto &ovrd : plans[run_id].property_overrides) {
+                auto &prop = prop_map.at(ovrd.first);
+                memcpy(prop.data.ptr, ovrd.second.ptr, prop.data.length);
+            }
+            // Set simulation device
+            std::unique_ptr<CUDASimulation> simulation = std::unique_ptr<CUDASimulation>(new CUDASimulation(model));
+            // Copy steps and seed from runplan
+            simulation->SimulationConfig().steps = plans[run_id].getSteps();
+            simulation->SimulationConfig().random_seed = plans[run_id].getRandomSimulationSeed();
+            simulation->SimulationConfig().verbose = false;
+            simulation->SimulationConfig().timing = false;
+            simulation->CUDAConfig().device_id = this->device_id;
+            simulation->applyConfig();
+            // Set the step config directly, to bypass validation
+            simulation->step_log_config = step_log_config;
+            simulation->exit_log_config = exit_log_config;
+            // TODO Set population?
+            // Execute simulation
+            simulation->simulate();
+            // Store results in run_log (use placement new because const members)
+            run_logs[this->run_id] = simulation->getRunLog();
+            // Notify logger
+            {
+                std::lock_guard<std::mutex> lck(log_export_queue_mutex);
+                log_export_queue.push(this->run_id);
+            }
+            log_export_queue_cdn.notify_one();
+            // Print progress to console
+            if (verbose)
+                printf("\rCUDAEnsemble progress: %u/%u", run_id + 1, static_cast<unsigned int>(plans.size()));
+        } catch(std::exception &e) {
+            fprintf(stderr, "\nRun %u failed on device %d, thread %u with exception: \n%s\n", run_id, device_id, runner_id, e.what());
+        }
+    }
+}

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -24,6 +24,7 @@ SET(SWIG_INPUT_FILE_NAME flamegpu)
 # setup properties of swig input file
 set_property(SOURCE ${SWIG_INPUT_FILE_NAME}.i PROPERTY CPLUSPLUS ON)
 set_property(SOURCE ${SWIG_INPUT_FILE_NAME}.i PROPERTY SWIG_MODULE_NAME ${PYTHON_MODULE_NAME})
+set_property(SOURCE ${SWIG_INPUT_FILE_NAME}.i PROPERTY SWIG_FLAGS "-threads")
 #set_property(SOURCE ${SWIG_INPUT_FILE_NAME}.i PROPERTY SWIG_FLAGS "-builtin")
 
 # Add swig module

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,6 +57,8 @@ SET(TEST_CASE_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/gpu/test_gpu_validation.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/gpu/test_cuda_subagent.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/io/test_io.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/io/test_logging.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/io/test_logging_exceptions.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/model/test_environment_description.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/model/test_model.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/model/test_agent.cu

--- a/tests/swig/python/io/test_logging.py
+++ b/tests/swig/python/io/test_logging.py
@@ -1,0 +1,509 @@
+import pytest
+from unittest import TestCase
+from pyflamegpu import *
+import os
+
+MODEL_NAME = "Model";
+AGENT_NAME1 = "Agent1";
+FUNCTION_NAME1 = "Func1";
+HOST_FUNCTION_NAME1 = "Func2";
+
+
+class step_fn1(pyflamegpu.HostFunctionCallback):
+    def run(self, FLAMEGPU):
+        # increment all properties
+        FLAMEGPU.environment.setPropertyFloat("float_prop", FLAMEGPU.environment.getPropertyFloat("float_prop") + 1.0);
+        FLAMEGPU.environment.setPropertyInt("int_prop", FLAMEGPU.environment.getPropertyInt("int_prop") + 1);
+        FLAMEGPU.environment.setPropertyUInt("uint_prop", FLAMEGPU.environment.getPropertyUInt("uint_prop") + 1);
+
+        a = FLAMEGPU.environment.getPropertyArrayFloat("float_prop_array");
+        b = FLAMEGPU.environment.getPropertyArrayInt("int_prop_array");
+        c = FLAMEGPU.environment.getPropertyArrayUInt("uint_prop_array");
+        FLAMEGPU.environment.setPropertyArrayFloat("float_prop_array", [a[0] + 1.0, a[1] + 1.0]);
+        FLAMEGPU.environment.setPropertyArrayInt("int_prop_array", [b[0] + 1, b[1] + 1, b[2] + 1]);
+        FLAMEGPU.environment.setPropertyArrayUInt("uint_prop_array", [c[0] + 1, c[1] + 1, c[2] + 1, c[3] + 1]);
+    
+class logging_ensemble_init(pyflamegpu.HostFunctionCallback):
+    def run(self, FLAMEGPU):
+        instance_id  = FLAMEGPU.environment.getPropertyInt("instance_id");
+        for i in range(instance_id, instance_id + 101):
+            instance = FLAMEGPU.newAgent(AGENT_NAME1);
+            instance.setVariableFloat("float_var", i);
+            instance.setVariableInt("int_var", i+1);
+            instance.setVariableUInt("uint_var", i+2);
+
+class LoggingTest(TestCase):
+
+    agent_fn1 = """
+        FLAMEGPU_AGENT_FUNCTION(agent_fn1, MsgNone, MsgNone) {
+            // increment all variables
+            FLAMEGPU->setVariable<float>("float_var", FLAMEGPU->getVariable<float>("float_var") + 1.0f);
+            FLAMEGPU->setVariable<int>("int_var", FLAMEGPU->getVariable<int>("int_var") + 1);
+            FLAMEGPU->setVariable<unsigned int>("uint_var", FLAMEGPU->getVariable<unsigned int>("uint_var") + 1);
+            return ALIVE;
+        }
+        """
+
+    def logAllAgent(self, alcfg, var_name, type):
+        fn = getattr(alcfg, f"logMin{type}");
+        fn(var_name);
+        fn = getattr(alcfg, f"logMax{type}");
+        fn(var_name);
+        fn = getattr(alcfg, f"logMean{type}");
+        fn(var_name);
+        fn = getattr(alcfg, f"logStandardDev{type}");
+        fn(var_name);
+        fn = getattr(alcfg, f"logSum{type}");
+        fn(var_name);
+
+    def test_CUDASimulationStep(self):
+        """
+           Ensure the expected data is logged when CUDASimulation::step() is called
+           Note: does not check files logged to disk
+        """
+        # Define model
+        m = pyflamegpu.ModelDescription(MODEL_NAME)
+        a = m.newAgent(AGENT_NAME1)
+        a.newVariableFloat("float_var");
+        a.newVariableInt("int_var");
+        a.newVariableUInt("uint_var");
+        f1 = a.newRTCFunction(FUNCTION_NAME1, self.agent_fn1);
+        m.newLayer().addAgentFunction(f1);
+        sf1 = step_fn1();
+        m.addStepFunctionCallback(sf1);
+        m.Environment().newPropertyFloat("float_prop", 1.0);
+        m.Environment().newPropertyInt("int_prop", 1);
+        m.Environment().newPropertyUInt("uint_prop", 1);
+        m.Environment().newPropertyArrayFloat("float_prop_array", 2, [1.0, 2.0]);
+        m.Environment().newPropertyArrayInt("int_prop_array", 3, [2, 3, 4]);
+        m.Environment().newPropertyArrayUInt("uint_prop_array", 4, [3, 4, 5, 6]);
+
+        # Define logging configs
+        lcfg = pyflamegpu.LoggingConfig(m);
+        alcfg = lcfg.agent(AGENT_NAME1);
+        alcfg.logCount();
+        self.logAllAgent(alcfg, "float_var", "Float");
+        self.logAllAgent(alcfg, "int_var", "Int");
+        self.logAllAgent(alcfg, "uint_var", "UInt");
+        lcfg.logEnvironment("float_prop");
+        lcfg.logEnvironment("int_prop");
+        lcfg.logEnvironment("uint_prop");
+        lcfg.logEnvironment("float_prop_array");
+        lcfg.logEnvironment("int_prop_array");
+        lcfg.logEnvironment("uint_prop_array");
+
+        slcfg = pyflamegpu.StepLoggingConfig(lcfg);
+        slcfg.setFrequency(2);
+
+        # Create agent population
+        pop = pyflamegpu.AgentPopulation(a, 101);
+        for i in range(101):
+            instance = pop.getNextInstance();
+            instance.setVariableFloat("float_var", i);
+            instance.setVariableInt("int_var", i+1);
+            instance.setVariableUInt("uint_var", i+2);
+
+
+        # Run model
+        sim = pyflamegpu.CUDASimulation(m);
+        sim.SimulationConfig().steps = 10;
+        sim.setStepLog(slcfg);
+        sim.setExitLog(lcfg);
+        sim.setPopulationData(pop);
+
+        # Step log 5 individual times, and check step logs match expectations
+        for i in range(1, 11):
+            sim.step();
+            log = sim.getRunLog();
+            steps = log.getStepLog();
+            # Step log frequency works as intended
+            assert steps.size() == int(i/2)  
+        
+        log = sim.getRunLog();
+        steps = log.getStepLog();
+        step_index = 2;
+        for step in steps:
+            assert step.getStepCount() == step_index
+            # Agent step logging works
+            # assert step.getAgents().size() == 1 # Not supported in Py, getAgents() returns a complex map of custom types
+            agent_log = step.getAgent(AGENT_NAME1);
+            assert 101 == agent_log.getCount()
+
+            assert 100.0 + step_index == agent_log.getMaxFloat("float_var")
+            assert 101 + step_index == agent_log.getMaxInt("int_var")
+            assert 102.0 + step_index == agent_log.getMaxUInt("uint_var")
+
+            assert 0.0 + step_index == agent_log.getMinFloat("float_var")
+            assert 1 + step_index == agent_log.getMinInt("int_var")
+            assert 2.0 + step_index == agent_log.getMinUInt("uint_var")
+
+            assert 50.0 + step_index == agent_log.getMean("float_var")
+            assert 51.0 + step_index == agent_log.getMean("int_var")
+            assert 52.0 + step_index == agent_log.getMean("uint_var")
+
+            # Test value calculated with excel
+            assert pytest.approx(29.15476, 0.0001) == agent_log.getStandardDev("float_var")
+            assert pytest.approx(29.15476, 0.0001) == agent_log.getStandardDev("int_var")
+            assert pytest.approx(29.15476, 0.0001) == agent_log.getStandardDev("uint_var")
+
+            assert (50.0 + step_index) * 101 == agent_log.getSumFloat("float_var")
+            assert (51 + step_index) * 101 == agent_log.getSumInt("int_var")
+            assert (52 + step_index) * 101 == agent_log.getSumUInt("uint_var")
+
+            # Env step logging works
+            assert step.getEnvironmentPropertyFloat("float_prop") == 1.0 + step_index
+            assert step.getEnvironmentPropertyInt("int_prop") == 1 + step_index
+            assert step.getEnvironmentPropertyUInt("uint_prop") == 1 + step_index
+
+            f_a = step.getEnvironmentPropertyArrayFloat("float_prop_array");
+            assert f_a[0] == 1.0 + step_index
+            assert f_a[1] == 2.0 + step_index
+            i_a = step.getEnvironmentPropertyArrayInt("int_prop_array");
+            assert i_a[0] == 2 + step_index
+            assert i_a[1] == 3 + step_index
+            assert i_a[2] == 4 + step_index
+            u_a = step.getEnvironmentPropertyArrayUInt("uint_prop_array");
+            assert u_a[0] == 3 + step_index
+            assert u_a[1] == 4 + step_index
+            assert u_a[2] == 5 + step_index
+            assert u_a[3] == 6 + step_index
+
+            step_index+=2;   
+    
+    def test_CUDASimulationSimulate(self):
+        """
+           Ensure the expected data is logged when CUDASimulation::simulate() is called
+           Note: does not check files logged to disk
+        """
+        # Define model
+        m = pyflamegpu.ModelDescription(MODEL_NAME)
+        a = m.newAgent(AGENT_NAME1)
+        a.newVariableFloat("float_var");
+        a.newVariableInt("int_var");
+        a.newVariableUInt("uint_var");
+        f1 = a.newRTCFunction(FUNCTION_NAME1, self.agent_fn1);
+        m.newLayer().addAgentFunction(f1);
+        sf1 = step_fn1();
+        m.addStepFunctionCallback(sf1);
+        m.Environment().newPropertyFloat("float_prop", 1.0);
+        m.Environment().newPropertyInt("int_prop", 1);
+        m.Environment().newPropertyUInt("uint_prop", 1);
+        m.Environment().newPropertyArrayFloat("float_prop_array", 2, [1.0, 2.0]);
+        m.Environment().newPropertyArrayInt("int_prop_array", 3, [2, 3, 4]);
+        m.Environment().newPropertyArrayUInt("uint_prop_array", 4, [3, 4, 5, 6]);
+
+        # Define logging configs
+        lcfg = pyflamegpu.LoggingConfig(m);
+        alcfg = lcfg.agent(AGENT_NAME1);
+        alcfg.logCount();
+        self.logAllAgent(alcfg, "float_var", "Float");
+        self.logAllAgent(alcfg, "int_var", "Int");
+        self.logAllAgent(alcfg, "uint_var", "UInt");
+        lcfg.logEnvironment("float_prop");
+        lcfg.logEnvironment("int_prop");
+        lcfg.logEnvironment("uint_prop");
+        lcfg.logEnvironment("float_prop_array");
+        lcfg.logEnvironment("int_prop_array");
+        lcfg.logEnvironment("uint_prop_array");
+
+        slcfg = pyflamegpu.StepLoggingConfig(lcfg);
+        slcfg.setFrequency(2);
+
+        # Create agent population
+        pop = pyflamegpu.AgentPopulation(a, 101);
+        for i in range(101):
+            instance = pop.getNextInstance();
+            instance.setVariableFloat("float_var", i);
+            instance.setVariableInt("int_var", i+1);
+            instance.setVariableUInt("uint_var", i+2);
+
+        # Run model
+        sim = pyflamegpu.CUDASimulation(m);
+        # sim.SimulationConfig().common_log_file = "commmon.json";
+        # sim.SimulationConfig().step_log_file = "step.json";
+        # sim.SimulationConfig().exit_log_file = "exit.json";
+        sim.SimulationConfig().steps = 10;
+        sim.setStepLog(slcfg);
+        sim.setExitLog(lcfg);
+        sim.setPopulationData(pop);
+        
+        # Call simulate(), and check step and exit logs match expectations
+        sim.simulate();
+        
+        #Check step log
+        log = sim.getRunLog();
+        steps = log.getStepLog();
+        # init log, + 5 logs from 10 steps
+        assert steps.size() == 6
+        step_index = 0;
+        for step in steps:
+            assert step.getStepCount() == step_index
+            # Agent step logging works
+            # assert step.getAgents().size() == 1 # Not supported in Py, getAgents() returns a complex map of custom types
+            agent_log = step.getAgent(AGENT_NAME1);
+            assert 101 == agent_log.getCount()
+            
+            assert 100.0 + step_index == agent_log.getMaxFloat("float_var")
+            assert 101 + step_index == agent_log.getMaxInt("int_var")
+            assert 102.0 + step_index == agent_log.getMaxUInt("uint_var")
+
+            assert 0.0 + step_index == agent_log.getMinFloat("float_var")
+            assert 1 + step_index == agent_log.getMinInt("int_var")
+            assert 2.0 + step_index == agent_log.getMinUInt("uint_var")
+
+            assert 50.0 + step_index == agent_log.getMean("float_var")
+            assert 51.0 + step_index == agent_log.getMean("int_var")
+            assert 52.0 + step_index == agent_log.getMean("uint_var")
+
+            # Test value calculated with excel
+            assert pytest.approx(29.15476, 0.0001) == agent_log.getStandardDev("float_var")
+            assert pytest.approx(29.15476, 0.0001) == agent_log.getStandardDev("int_var")
+            assert pytest.approx(29.15476, 0.0001) == agent_log.getStandardDev("uint_var")
+
+            assert (50.0 + step_index) * 101 == agent_log.getSumFloat("float_var")
+            assert (51 + step_index) * 101 == agent_log.getSumInt("int_var")
+            assert (52 + step_index) * 101 == agent_log.getSumUInt("uint_var")
+
+            # Env step logging works
+            assert step.getEnvironmentPropertyFloat("float_prop") == 1.0 + step_index
+            assert step.getEnvironmentPropertyInt("int_prop") == 1 + step_index
+            assert step.getEnvironmentPropertyUInt("uint_prop") == 1 + step_index
+
+            f_a = step.getEnvironmentPropertyArrayFloat("float_prop_array");
+            assert f_a[0] == 1.0 + step_index
+            assert f_a[1] == 2.0 + step_index
+            i_a = step.getEnvironmentPropertyArrayInt("int_prop_array");
+            assert i_a[0] == 2 + step_index
+            assert i_a[1] == 3 + step_index
+            assert i_a[2] == 4 + step_index
+            u_a = step.getEnvironmentPropertyArrayUInt("uint_prop_array");
+            assert u_a[0] == 3 + step_index
+            assert u_a[1] == 4 + step_index
+            assert u_a[2] == 5 + step_index
+            assert u_a[3] == 6 + step_index
+
+            step_index+=2;
+
+      
+        # Check exit log, should match final step log
+        step_index = 10;
+        exit = log.getExitLog();
+        assert exit.getStepCount() == step_index
+        # Agent step logging works
+        # assert exit.getAgents().size() == 1 # Not supported in Py, getAgents() returns a complex map of custom types
+        agent_log = exit.getAgent(AGENT_NAME1);
+        assert 101 == agent_log.getCount()
+
+        assert 100.0 + step_index == agent_log.getMaxFloat("float_var")
+        assert 101 + step_index == agent_log.getMaxInt("int_var")
+        assert 102.0 + step_index == agent_log.getMaxUInt("uint_var")
+
+        assert 0.0 + step_index == agent_log.getMinFloat("float_var")
+        assert 1 + step_index == agent_log.getMinInt("int_var")
+        assert 2.0 + step_index == agent_log.getMinUInt("uint_var")
+
+        assert 50.0 + step_index == agent_log.getMean("float_var")
+        assert 51.0 + step_index == agent_log.getMean("int_var")
+        assert 52.0 + step_index == agent_log.getMean("uint_var")
+
+        # Test value calculated with excel
+        assert pytest.approx(29.15476, 0.0001) == agent_log.getStandardDev("float_var")
+        assert pytest.approx(29.15476, 0.0001) == agent_log.getStandardDev("int_var")
+        assert pytest.approx(29.15476, 0.0001) == agent_log.getStandardDev("uint_var")
+
+        assert (50.0 + step_index) * 101 == agent_log.getSumFloat("float_var")
+        assert (51 + step_index) * 101 == agent_log.getSumInt("int_var")
+        assert (52 + step_index) * 101 == agent_log.getSumUInt("uint_var")
+
+        # Env step logging works
+        assert step.getEnvironmentPropertyFloat("float_prop") == 1.0 + step_index
+        assert step.getEnvironmentPropertyInt("int_prop") == 1 + step_index
+        assert step.getEnvironmentPropertyUInt("uint_prop") == 1 + step_index
+
+        f_a = step.getEnvironmentPropertyArrayFloat("float_prop_array");
+        assert f_a[0] == 1.0 + step_index
+        assert f_a[1] == 2.0 + step_index
+        i_a = step.getEnvironmentPropertyArrayInt("int_prop_array");
+        assert i_a[0] == 2 + step_index
+        assert i_a[1] == 3 + step_index
+        assert i_a[2] == 4 + step_index
+        u_a = step.getEnvironmentPropertyArrayUInt("uint_prop_array");
+        assert u_a[0] == 3 + step_index
+        assert u_a[1] == 4 + step_index
+        assert u_a[2] == 5 + step_index
+        assert u_a[3] == 6 + step_index    
+
+    def test_CUDAEnsembleSimulate(self):
+        """
+           Ensure the expected data is logged when CUDAEnsemble::simulate() is called
+           Note: does not check files logged to disk
+        """
+        # Define model
+        m = pyflamegpu.ModelDescription(MODEL_NAME)
+        a = m.newAgent(AGENT_NAME1)
+        a.newVariableFloat("float_var");
+        a.newVariableInt("int_var");
+        a.newVariableUInt("uint_var");
+        f1 = a.newRTCFunction(FUNCTION_NAME1, self.agent_fn1);
+        if1 = logging_ensemble_init();
+        m.addInitFunctionCallback(if1);  # This causes an access violation?
+        m.newLayer().addAgentFunction(f1);
+        sf1 = step_fn1();
+        m.addStepFunctionCallback(sf1);  # This causes an access violation?
+        m.Environment().newPropertyInt("instance_id", 0); # This will act as the modifier for ensemble instances, only impacting the init fn
+        m.Environment().newPropertyFloat("float_prop", 1.0);
+        m.Environment().newPropertyInt("int_prop", 1);
+        m.Environment().newPropertyUInt("uint_prop", 1);
+        m.Environment().newPropertyArrayFloat("float_prop_array", 2, [1.0, 2.0]);
+        m.Environment().newPropertyArrayInt("int_prop_array", 3, [2, 3, 4]);
+        m.Environment().newPropertyArrayUInt("uint_prop_array", 4, [3, 4, 5, 6]);
+
+        # Define logging configs
+        lcfg = pyflamegpu.LoggingConfig(m);
+        alcfg = lcfg.agent(AGENT_NAME1);
+        alcfg.logCount();
+        self.logAllAgent(alcfg, "float_var", "Float");
+        self.logAllAgent(alcfg, "int_var", "Int");
+        self.logAllAgent(alcfg, "uint_var", "UInt");
+        lcfg.logEnvironment("float_prop");
+        lcfg.logEnvironment("instance_id");
+        lcfg.logEnvironment("int_prop");
+        lcfg.logEnvironment("uint_prop");
+        lcfg.logEnvironment("float_prop_array");
+        lcfg.logEnvironment("int_prop_array");
+        lcfg.logEnvironment("uint_prop_array");
+
+        slcfg = pyflamegpu.StepLoggingConfig(lcfg);
+        slcfg.setFrequency(2);
+
+        # Set up the runplan
+        plan = pyflamegpu.RunPlanVec(m, 10);
+        i_id = 0;
+        for p in plan:
+            p.setSteps(10);
+            p.setPropertyInt("instance_id", i_id);
+            i_id += 1
+            # p.setOutputSubdirectory(i_id%2 == 0 ? "a" : "b");
+    
+
+        # Run model
+        sim = pyflamegpu.CUDAEnsemble(m);
+        sim.Config().concurrent_runs = 5;
+        sim.Config().silent = True;
+        sim.Config().timing = False;
+        # sim.Config().out_directory = "ensemble_out";
+        # sim.Config().out_format = "json";
+        sim.setStepLog(slcfg);
+        sim.setExitLog(lcfg);
+        # Call simulate(), and check step and exit logs match expectations
+        sim.simulate(plan);
+    
+        # Check step log
+        run_logs = sim.getLogs();
+        i_id = 0;
+        for log in run_logs:
+            # Check step log
+            steps = log.getStepLog();
+            # init log, + 5 logs from 10 steps
+            assert steps.size() == 6
+            step_index = 0;
+            for step in steps:
+                # Log corresponds to the correct instance
+                assert step.getEnvironmentPropertyInt("instance_id") == i_id
+                assert step.getStepCount() == step_index
+                # Agent step logging works
+                # assert step.getAgents().size() == 1 # Not supported in Py, getAgents() returns a complex map of custom types
+                agent_log = step.getAgent(AGENT_NAME1);
+                assert 101 == agent_log.getCount()
+                
+                assert 100.0 + step_index + i_id == agent_log.getMaxFloat("float_var")
+                assert 101 + step_index + i_id== agent_log.getMaxInt("int_var")
+                assert 102.0 + step_index + i_id== agent_log.getMaxUInt("uint_var")
+
+                assert 0.0 + step_index + i_id== agent_log.getMinFloat("float_var")
+                assert 1 + step_index + i_id== agent_log.getMinInt("int_var")
+                assert 2.0 + step_index + i_id== agent_log.getMinUInt("uint_var")
+
+                assert 50.0 + step_index + i_id== agent_log.getMean("float_var")
+                assert 51.0 + step_index + i_id== agent_log.getMean("int_var")
+                assert 52.0 + step_index + i_id== agent_log.getMean("uint_var")
+
+                # Test value calculated with excel
+                assert pytest.approx(29.15476, 0.0001) == agent_log.getStandardDev("float_var")
+                assert pytest.approx(29.15476, 0.0001) == agent_log.getStandardDev("int_var")
+                assert pytest.approx(29.15476, 0.0001) == agent_log.getStandardDev("uint_var")
+
+                assert (50.0 + step_index + i_id) * 101 == agent_log.getSumFloat("float_var")
+                assert (51 + step_index + i_id) * 101 == agent_log.getSumInt("int_var")
+                assert (52 + step_index + i_id) * 101 == agent_log.getSumUInt("uint_var")
+
+                # Env step logging works
+                assert step.getEnvironmentPropertyFloat("float_prop") == 1.0 + step_index
+                assert step.getEnvironmentPropertyInt("int_prop") == 1 + step_index
+                assert step.getEnvironmentPropertyUInt("uint_prop") == 1 + step_index
+
+                f_a = step.getEnvironmentPropertyArrayFloat("float_prop_array");
+                assert f_a[0] == 1.0 + step_index
+                assert f_a[1] == 2.0 + step_index
+                i_a = step.getEnvironmentPropertyArrayInt("int_prop_array");
+                assert i_a[0] == 2 + step_index
+                assert i_a[1] == 3 + step_index
+                assert i_a[2] == 4 + step_index
+                u_a = step.getEnvironmentPropertyArrayUInt("uint_prop_array");
+                assert u_a[0] == 3 + step_index
+                assert u_a[1] == 4 + step_index
+                assert u_a[2] == 5 + step_index
+                assert u_a[3] == 6 + step_index
+
+                step_index+=2;
+                
+                
+            ## Check exit log, should match final step log
+            step_index = 10;
+            exit = log.getExitLog();
+            assert exit.getStepCount() == step_index
+            # Agent step logging works
+            # assert exit.getAgents().size() == 1 # Not supported in Py, getAgents() returns a complex map of custom types
+            agent_log = exit.getAgent(AGENT_NAME1);
+            assert 101 == agent_log.getCount()
+
+            assert 100.0 + step_index + i_id == agent_log.getMaxFloat("float_var")
+            assert 101 + step_index + i_id== agent_log.getMaxInt("int_var")
+            assert 102.0 + step_index + i_id== agent_log.getMaxUInt("uint_var")
+
+            assert 0.0 + step_index + i_id== agent_log.getMinFloat("float_var")
+            assert 1 + step_index + i_id== agent_log.getMinInt("int_var")
+            assert 2.0 + step_index + i_id== agent_log.getMinUInt("uint_var")
+
+            assert 50.0 + step_index + i_id== agent_log.getMean("float_var")
+            assert 51.0 + step_index + i_id== agent_log.getMean("int_var")
+            assert 52.0 + step_index + i_id== agent_log.getMean("uint_var")
+
+            # Test value calculated with excel
+            assert pytest.approx(29.15476, 0.0001) == agent_log.getStandardDev("float_var")
+            assert pytest.approx(29.15476, 0.0001) == agent_log.getStandardDev("int_var")
+            assert pytest.approx(29.15476, 0.0001) == agent_log.getStandardDev("uint_var")
+
+            assert (50.0 + step_index + i_id) * 101 == agent_log.getSumFloat("float_var")
+            assert (51 + step_index + i_id) * 101 == agent_log.getSumInt("int_var")
+            assert (52 + step_index + i_id) * 101 == agent_log.getSumUInt("uint_var")
+
+            # Env step logging works
+            assert step.getEnvironmentPropertyFloat("float_prop") == 1.0 + step_index
+            assert step.getEnvironmentPropertyInt("int_prop") == 1 + step_index
+            assert step.getEnvironmentPropertyUInt("uint_prop") == 1 + step_index
+
+            f_a = step.getEnvironmentPropertyArrayFloat("float_prop_array");
+            assert f_a[0] == 1.0 + step_index
+            assert f_a[1] == 2.0 + step_index
+            i_a = step.getEnvironmentPropertyArrayInt("int_prop_array");
+            assert i_a[0] == 2 + step_index
+            assert i_a[1] == 3 + step_index
+            assert i_a[2] == 4 + step_index
+            u_a = step.getEnvironmentPropertyArrayUInt("uint_prop_array");
+            assert u_a[0] == 3 + step_index
+            assert u_a[1] == 4 + step_index
+            assert u_a[2] == 5 + step_index
+            assert u_a[3] == 6 + step_index
+
+            i_id+=1

--- a/tests/swig/python/io/test_logging_exceptions.py
+++ b/tests/swig/python/io/test_logging_exceptions.py
@@ -1,0 +1,240 @@
+import pytest
+from unittest import TestCase
+from pyflamegpu import *
+import os
+
+MODEL_NAME = "Model";
+AGENT_NAME1 = "Agent1";
+AGENT_NAME2 = "Agent2";
+
+class LoggingExceptionTest(TestCase):
+
+    def test_LoggerSupportedFileType(self):
+        # WriterFactory::createLogger() - UnsupportedFileType
+        m = pyflamegpu.ModelDescription(MODEL_NAME);
+        m.newAgent(AGENT_NAME1);
+        sim = pyflamegpu.CUDASimulation(m);
+        # Unsupported file types
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # UnsupportedFileType exception
+            sim.exportLog("test.csv", True, True);
+        assert e.value.type() == "UnsupportedFileType"
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # UnsupportedFileType exception
+            sim.exportLog("test.html", True, True);
+        assert e.value.type() == "UnsupportedFileType"
+        # Does not throw
+        sim.exportLog("test.json", True, True);
+        # Cleanup
+        os.remove("test.json")
+        
+    def test_LoggingConfigExceptions(self):
+        # Define model
+        m = pyflamegpu.ModelDescription(MODEL_NAME);
+        m.newAgent(AGENT_NAME1);
+        m.Environment().newPropertyFloat("float_prop", 1.0);
+
+        lcfg = pyflamegpu.LoggingConfig(m);
+        # Property doesn't exist
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidEnvProperty exception
+            lcfg.logEnvironment("int_prop")
+        assert e.value.type() == "InvalidEnvProperty"
+        # Property does exist
+        lcfg.logEnvironment("float_prop")
+        # Property already marked for logging
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidEnvProperty exception
+            lcfg.logEnvironment("float_prop")
+        assert e.value.type() == "InvalidEnvProperty"
+        # THIS DOES NOT WORK, cfg holds a copy of the ModelDescription, not a reference to it.
+        # Add new property after lcfg made
+        m.Environment().newPropertyInt("int_prop", 1)
+        # Property does not exist
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidEnvProperty exception
+            lcfg.logEnvironment("int_prop")
+        assert e.value.type() == "InvalidEnvProperty"
+
+        # Agent does not exist
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidAgentName exception
+            lcfg.agent(AGENT_NAME2, "state2")
+        assert e.value.type() == "InvalidAgentName"
+        # Agent state does not exist
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidAgentState exception
+            lcfg.agent(AGENT_NAME1, "state2")
+        assert e.value.type() == "InvalidAgentState"
+        # Agent/State does exist
+        lcfg.agent(AGENT_NAME1, "default"); # There isn't currently a py mapping of ModelData::DEFAULT_STATE
+        # THIS DOES NOT WORK, cfg holds a copy of the ModelDescription, not a reference to it.
+        # Add new agent after lcfg
+        a2 = m.newAgent(AGENT_NAME2);
+        a2.newState("state2");
+        # Agent/State does not exist
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidAgentName exception
+            lcfg.agent(AGENT_NAME2, "state2")
+        assert e.value.type() == "InvalidAgentName"
+        
+    def test_AgentLoggingConfigExceptions(self):
+        m = pyflamegpu.ModelDescription(MODEL_NAME);
+        a = m.newAgent(AGENT_NAME1);
+        a.newVariableFloat("float_var");
+        a.newVariableArrayFloat("float_var_array", 2);
+
+        lcfg = pyflamegpu.LoggingConfig(m);
+        alcfg = lcfg.agent(AGENT_NAME1);
+
+        # Log functions all pass to the same common method which contains the checks
+        # Test 1, test them all (mean, standard dev, min, max, sum)
+        # Bad variable name
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidVarType exception
+            alcfg.logMeanInt("int_var")
+        assert e.value.type() == "InvalidAgentVar"
+        # Type does not match variable name
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidAgentName exception
+            alcfg.logMeanInt("float_var")
+        assert e.value.type() == "InvalidVarType"
+        # Array variables are not supported
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidVarType exception
+            alcfg.logMeanFloat("float_var_array")
+        assert e.value.type() == "InvalidVarType"
+        # Variable is correct
+        alcfg.logMeanFloat("float_var")
+        # Variable has already been marked for logging
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidArgument exception
+            alcfg.logMeanFloat("float_var")
+        assert e.value.type() == "InvalidArgument"
+        # THIS DOES NOT WORK, cfg holds a copy of the ModelDescription, not a reference to it.
+        # Add new agent var after log creation
+        a.newVariableInt("int_var");
+        # Variable is not found
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidAgentVar exception
+            alcfg.logMeanInt("int_var")
+        assert e.value.type() == "InvalidAgentVar"
+        
+    def test_LogFrameExceptions(self):
+        # Define model
+        m = pyflamegpu.ModelDescription(MODEL_NAME);
+        m.Environment().newPropertyFloat("float_prop", 1.0);
+        m.Environment().newPropertyInt("int_prop", 1);
+        m.Environment().newPropertyUInt("uint_prop", 1);
+        m.Environment().newPropertyArrayFloat("float_prop_array", 2, [1.0, 2.0]);
+        m.Environment().newPropertyArrayInt("int_prop_array", 3, [2, 3, 4]);
+        m.Environment().newPropertyArrayUInt("uint_prop_array", 4, [3, 4, 5, 6]);
+
+        # Define logging configs
+        lcfg = pyflamegpu.LoggingConfig(m);
+
+        slcfg = pyflamegpu.StepLoggingConfig(lcfg);
+        slcfg.logEnvironment("float_prop");
+        slcfg.logEnvironment("uint_prop_array");
+
+        # Run model
+        sim = pyflamegpu.CUDASimulation(m);
+        sim.SimulationConfig().steps = 1;
+        sim.setStepLog(slcfg);
+
+        sim.step();
+
+        # Fetch log
+        log = sim.getRunLog();
+        steps = log.getStepLog();
+        assert steps.size() == 1
+        slog = steps[0];
+        # Property wasn't logged
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidEnvProperty exception
+            slog.getEnvironmentPropertyFloat("float_prop2")
+        assert e.value.type() == "InvalidEnvProperty"
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidEnvProperty exception
+            slog.getEnvironmentPropertyInt("int_prop")
+        assert e.value.type() == "InvalidEnvProperty"
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidEnvProperty exception
+            slog.getEnvironmentPropertyArrayFloat("float_prop2")
+        assert e.value.type() == "InvalidEnvProperty"
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidEnvProperty exception
+            slog.getEnvironmentPropertyArrayInt("int_prop")
+        assert e.value.type() == "InvalidEnvProperty"
+        # Property wrong type
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidEnvPropertyType exception
+            slog.getEnvironmentPropertyInt("float_prop")
+        assert e.value.type() == "InvalidEnvPropertyType"
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidEnvPropertyType exception
+            slog.getEnvironmentPropertyArrayInt("uint_prop_array")
+        assert e.value.type() == "InvalidEnvPropertyType"
+        # Property wrong length (array length exception not applicable to python)
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidEnvPropertyType exception
+            slog.getEnvironmentPropertyUInt("uint_prop_array")
+        assert e.value.type() == "InvalidEnvPropertyType"        
+        # Correct property settings work
+        slog.getEnvironmentPropertyFloat("float_prop")
+        slog.getEnvironmentPropertyArrayUInt("uint_prop_array")
+        
+    def test_AgentLogFrameExceptions(self):
+        # Define model
+        m = pyflamegpu.ModelDescription(MODEL_NAME);
+        a = m.newAgent(AGENT_NAME1);
+        a.newVariableFloat("float_var");
+        a.newVariableInt("int_var");
+        a.newVariableUInt("uint_var");
+        a.newVariableArrayFloat("float_var_array", 2);
+
+        # Define logging configs
+        lcfg = pyflamegpu.LoggingConfig(m);
+        slcfg = pyflamegpu.StepLoggingConfig(lcfg);
+        alcfg = slcfg.agent(AGENT_NAME1);
+        alcfg.logMeanFloat("float_var");
+        alcfg.logStandardDevFloat("float_var");
+        alcfg.logMinInt("int_var");
+        alcfg.logMaxInt("int_var");
+        alcfg.logSumUInt("uint_var");
+
+        # Run model
+        sim = pyflamegpu.CUDASimulation(m);
+        sim.SimulationConfig().steps = 1;
+        sim.setStepLog(slcfg);
+        sim.step();
+
+        # Fetch log
+        log = sim.getRunLog();
+        steps = log.getStepLog();
+        assert steps.size() == 1
+        slog = steps[0];
+        # Agent/state was not logged
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidAgentState exception
+            slog.getAgent("wrong_agent")
+        assert e.value.type() == "InvalidAgentState"
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidAgentState exception
+            slog.getAgent(AGENT_NAME1, "wrong_state")
+        assert e.value.type() == "InvalidAgentState"
+        alog = slog.getAgent(AGENT_NAME1);
+        # Count was not logged
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidOperation exception
+            alog.getCount()
+        assert e.value.type() == "InvalidOperation"
+        # Variable/Reduction wasn't logged
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidAgentVar exception
+            alog.getMean("int_var")
+        assert e.value.type() == "InvalidAgentVar"
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidAgentVar exception
+            alog.getStandardDev("double_var")
+        assert e.value.type() == "InvalidAgentVar"
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidAgentVar exception
+            alog.getMinFloat("float_var")
+        assert e.value.type() == "InvalidAgentVar"
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidAgentVar exception
+            alog.getMaxFloat("float_var")
+        assert e.value.type() == "InvalidAgentVar"
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidAgentVar exception
+            alog.getSumUInt("uint_prop_array")
+        assert e.value.type() == "InvalidAgentVar"
+        # Property wrong type
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidVarType exception
+            alog.getMinFloat("int_var")
+        assert e.value.type() == "InvalidVarType"
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidVarType exception
+            alog.getMaxFloat("int_var")
+        assert e.value.type() == "InvalidVarType"
+        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidVarType exception
+            alog.getSumInt("uint_var")
+        assert e.value.type() == "InvalidVarType"
+        # Correct property settings work
+        alog.getMean("float_var")
+        alog.getStandardDev("float_var")
+        alog.getMinInt("int_var")
+        alog.getMaxInt("int_var")
+        alog.getSumUInt("uint_var")

--- a/tests/swig/python/model/test_subagent.py
+++ b/tests/swig/python/model/test_subagent.py
@@ -22,17 +22,14 @@ class SubAgentDescriptionTest(TestCase):
         ma.newVariableUInt("b_uint");
         ma.newState("b");
         # Missing exit condition        
+        m.newSubModel("sub", sm);
         with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidSubModel exception
-            m.newSubModel("sub", sm);
+            s = pyflamegpu.CUDASimulation(m)
+        assert e.value.type() == "InvalidSubModel"
         exitcdn = ExitAlways()
         sm.addExitConditionCallback(exitcdn);
-        m.newSubModel("sub", sm);
-        # Submodel name already exists
-        sm2 = pyflamegpu.ModelDescription("sub2");
-        # Define SubModel
-        sm2.newAgent("a");
-        with pytest.raises(pyflamegpu.FGPURuntimeException) as e:  # InvalidSubModelName exception
-            m.newSubModel("sub", sm2);
+        # Does not throw with exit condition
+        s = pyflamegpu.CUDASimulation(m)
 
     def test_InvalidAgentName(self):
         sm = pyflamegpu.ModelDescription("sub");

--- a/tests/test_cases/io/test_logging.cu
+++ b/tests/test_cases/io/test_logging.cu
@@ -1,0 +1,495 @@
+#include "gtest/gtest.h"
+
+#include "flamegpu/flame_api.h"
+
+
+namespace test_logging {
+const char *MODEL_NAME = "Model";
+const char *AGENT_NAME1 = "Agent1";
+const char *FUNCTION_NAME1 = "Func1";
+const char *HOST_FUNCTION_NAME1 = "Func2";
+
+FLAMEGPU_AGENT_FUNCTION(agent_fn1, MsgNone, MsgNone) {
+    // increment all variables
+    FLAMEGPU->setVariable<float>("float_var", FLAMEGPU->getVariable<float>("float_var") + 1.0f);
+    FLAMEGPU->setVariable<int>("int_var", FLAMEGPU->getVariable<int>("int_var") + 1);
+    FLAMEGPU->setVariable<unsigned int>("uint_var", FLAMEGPU->getVariable<unsigned int>("uint_var") + 1);
+    return ALIVE;
+}
+FLAMEGPU_STEP_FUNCTION(step_fn1) {
+    // increment all properties
+    FLAMEGPU->environment.setProperty<float>("float_prop", FLAMEGPU->environment.getProperty<float>("float_prop") + 1.0f);
+    FLAMEGPU->environment.setProperty<int>("int_prop", FLAMEGPU->environment.getProperty<int>("int_prop") + 1);
+    FLAMEGPU->environment.setProperty<unsigned int>("uint_prop", FLAMEGPU->environment.getProperty<unsigned int>("uint_prop") + 1);
+
+    auto a = FLAMEGPU->environment.getProperty<float, 2>("float_prop_array");
+    auto b = FLAMEGPU->environment.getProperty<int, 3>("int_prop_array");
+    auto c = FLAMEGPU->environment.getProperty<unsigned int, 4>("uint_prop_array");
+    FLAMEGPU->environment.setProperty<float, 2>("float_prop_array", {a[0] + 1.0f, a[1] + 1.0f});
+    FLAMEGPU->environment.setProperty<int, 3>("int_prop_array", {b[0] + 1, b[1] + 1, b[2] + 1});
+    FLAMEGPU->environment.setProperty<unsigned int, 4>("uint_prop_array", {c[0] + 1, c[1] + 1, c[2] + 1, c[3] + 1});
+}
+template<typename T>
+void logAllAgent(AgentLoggingConfig &alcfg, const std::string &var_name) {
+    alcfg.logMin<T>(var_name);
+    alcfg.logMax<T>(var_name);
+    alcfg.logMean<T>(var_name);
+    alcfg.logStandardDev<T>(var_name);
+    alcfg.logSum<T>(var_name);
+}
+TEST(LoggingTest, CUDASimulationStep) {
+    /**
+     * Ensure the expected data is logged when CUDASimulation::step() is called
+     * Note: does not check files logged to disk
+     */
+    // Define model
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME1);
+    a.newVariable<float>("float_var");
+    a.newVariable<int>("int_var");
+    a.newVariable<unsigned int>("uint_var");
+    AgentFunctionDescription &f1 = a.newFunction(FUNCTION_NAME1, agent_fn1);
+    m.newLayer().addAgentFunction(f1);
+    m.addStepFunction(step_fn1);
+    m.Environment().newProperty<float>("float_prop", 1.0f);
+    m.Environment().newProperty<int>("int_prop", 1);
+    m.Environment().newProperty<unsigned int>("uint_prop", 1);
+    m.Environment().newProperty<float, 2>("float_prop_array", {1.0f, 2.0f});
+    m.Environment().newProperty<int, 3>("int_prop_array", {2, 3, 4});
+    m.Environment().newProperty<unsigned int, 4>("uint_prop_array", {3, 4, 5, 6});
+
+    // Define logging configs
+    LoggingConfig lcfg(m);
+    AgentLoggingConfig alcfg = lcfg.agent(AGENT_NAME1);
+    alcfg.logCount();
+    logAllAgent<float>(alcfg, "float_var");
+    logAllAgent<int>(alcfg, "int_var");
+    logAllAgent<unsigned int>(alcfg, "uint_var");
+    lcfg.logEnvironment("float_prop");
+    lcfg.logEnvironment("int_prop");
+    lcfg.logEnvironment("uint_prop");
+    lcfg.logEnvironment("float_prop_array");
+    lcfg.logEnvironment("int_prop_array");
+    lcfg.logEnvironment("uint_prop_array");
+
+    StepLoggingConfig slcfg(lcfg);
+    slcfg.setFrequency(2);
+
+    // Create agent population
+    AgentPopulation pop(a, 101);
+    for (int i = 0; i < 101; ++i) {
+        auto instance = pop.getNextInstance();
+        instance.setVariable<float>("float_var", static_cast<float>(i));
+        instance.setVariable<int>("int_var", static_cast<int>(i+1));
+        instance.setVariable<unsigned int>("uint_var", static_cast<unsigned int>(i+2));
+    }
+
+    // Run model
+    CUDASimulation sim(m);
+    sim.SimulationConfig().steps = 10;
+    sim.setStepLog(slcfg);
+    sim.setExitLog(lcfg);
+    sim.setPopulationData(pop);
+
+    // Step log 5 individual times, and check step logs match expectations
+    for (unsigned int i = 1; i <= 10; ++i) {
+        sim.step();
+        const auto &log = sim.getRunLog();
+        const auto &steps = log.getStepLog();
+        EXPECT_EQ(steps.size(), i/2);  // Step log frequency works as intended
+    }
+    {
+        const auto &log = sim.getRunLog();
+        const auto &steps = log.getStepLog();
+        unsigned int step_index = 2;
+        for (const auto &step : steps) {
+            ASSERT_EQ(step.getStepCount(), step_index);
+            // Agent step logging works
+            EXPECT_EQ(step.getAgents().size(), 1u);
+            auto agent_log = step.getAgent(AGENT_NAME1);
+            EXPECT_EQ(101u, agent_log.getCount());
+
+            EXPECT_EQ(100.0f + step_index, agent_log.getMax<float>("float_var"));
+            EXPECT_EQ(static_cast<int>(101 + step_index), agent_log.getMax<int>("int_var"));
+            EXPECT_EQ(102.0 + step_index, agent_log.getMax<unsigned int>("uint_var"));
+
+            EXPECT_EQ(0.0f + step_index, agent_log.getMin<float>("float_var"));
+            EXPECT_EQ(static_cast<int>(1 + step_index), agent_log.getMin<int>("int_var"));
+            EXPECT_EQ(2.0 + step_index, agent_log.getMin<unsigned int>("uint_var"));
+
+            EXPECT_EQ(50.0 + step_index, agent_log.getMean("float_var"));
+            EXPECT_EQ(51.0 + step_index, agent_log.getMean("int_var"));
+            EXPECT_EQ(52.0 + step_index, agent_log.getMean("uint_var"));
+
+            EXPECT_FLOAT_EQ(29.15476f, static_cast<float>(agent_log.getStandardDev("float_var")));  // Test value calculated with excel
+            EXPECT_FLOAT_EQ(29.15476f, static_cast<float>(agent_log.getStandardDev("int_var")));
+            EXPECT_FLOAT_EQ(29.15476f, static_cast<float>(agent_log.getStandardDev("uint_var")));
+
+            EXPECT_EQ((50.0 + step_index) * 101, agent_log.getSum<float>("float_var"));
+            EXPECT_EQ(static_cast<int>(51 + step_index) * 101, agent_log.getSum<int>("int_var"));
+            EXPECT_EQ((52 + step_index) * 101, agent_log.getSum<unsigned int>("uint_var"));
+
+            // Env step logging works
+            ASSERT_EQ(step.getEnvironmentProperty<float>("float_prop"), 1.0f + step_index);
+            ASSERT_EQ(step.getEnvironmentProperty<int>("int_prop"), static_cast<int>(1 + step_index));
+            ASSERT_EQ(step.getEnvironmentProperty<unsigned int>("uint_prop"), 1 + step_index);
+
+            const auto f_a = step.getEnvironmentProperty<float, 2>("float_prop_array");
+            ASSERT_EQ(f_a[0], 1.0f + step_index);
+            ASSERT_EQ(f_a[1], 2.0f + step_index);
+            const auto i_a = step.getEnvironmentProperty<int, 3>("int_prop_array");
+            ASSERT_EQ(i_a[0], static_cast<int>(2 + step_index));
+            ASSERT_EQ(i_a[1], static_cast<int>(3 + step_index));
+            ASSERT_EQ(i_a[2], static_cast<int>(4 + step_index));
+            const auto u_a = step.getEnvironmentProperty<unsigned int, 4>("uint_prop_array");
+            ASSERT_EQ(u_a[0], 3 + step_index);
+            ASSERT_EQ(u_a[1], 4 + step_index);
+            ASSERT_EQ(u_a[2], 5 + step_index);
+            ASSERT_EQ(u_a[3], 6 + step_index);
+
+            step_index+=2;
+        }
+    }
+}
+TEST(LoggingTest, CUDASimulationSimulate) {
+    /**
+     * Ensure the expected data is logged when CUDASimulation::simulate() is called
+     * Note: does not check files logged to disk
+     */
+    // Define model
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME1);
+    a.newVariable<float>("float_var");
+    a.newVariable<int>("int_var");
+    a.newVariable<unsigned int>("uint_var");
+    AgentFunctionDescription &f1 = a.newFunction(FUNCTION_NAME1, agent_fn1);
+    m.newLayer().addAgentFunction(f1);
+    m.addStepFunction(step_fn1);
+    m.Environment().newProperty<float>("float_prop", 1.0f);
+    m.Environment().newProperty<int>("int_prop", 1);
+    m.Environment().newProperty<unsigned int>("uint_prop", 1);
+    m.Environment().newProperty<float, 2>("float_prop_array", {1.0f, 2.0f});
+    m.Environment().newProperty<int, 3>("int_prop_array", {2, 3, 4});
+    m.Environment().newProperty<unsigned int, 4>("uint_prop_array", {3, 4, 5, 6});
+
+    // Define logging configs
+    LoggingConfig lcfg(m);
+    AgentLoggingConfig alcfg = lcfg.agent(AGENT_NAME1);
+    alcfg.logCount();
+    logAllAgent<float>(alcfg, "float_var");
+    logAllAgent<int>(alcfg, "int_var");
+    logAllAgent<unsigned int>(alcfg, "uint_var");
+    lcfg.logEnvironment("float_prop");
+    lcfg.logEnvironment("int_prop");
+    lcfg.logEnvironment("uint_prop");
+    lcfg.logEnvironment("float_prop_array");
+    lcfg.logEnvironment("int_prop_array");
+    lcfg.logEnvironment("uint_prop_array");
+
+    StepLoggingConfig slcfg(lcfg);
+    slcfg.setFrequency(2);
+
+    // Create agent population
+    AgentPopulation pop(a, 101);
+    for (int i = 0; i < 101; ++i) {
+        auto instance = pop.getNextInstance();
+        instance.setVariable<float>("float_var", static_cast<float>(i));
+        instance.setVariable<int>("int_var", static_cast<int>(i+1));
+        instance.setVariable<unsigned int>("uint_var", static_cast<unsigned int>(i+2));
+    }
+
+    // Run model
+    CUDASimulation sim(m);
+    sim.SimulationConfig().steps = 10;
+    // sim.SimulationConfig().common_log_file = "commmon.json";
+    // sim.SimulationConfig().step_log_file = "step.json";
+    // sim.SimulationConfig().exit_log_file = "exit.json";
+    sim.SimulationConfig().steps = 10;
+    sim.setStepLog(slcfg);
+    sim.setExitLog(lcfg);
+    sim.setPopulationData(pop);
+    // Call simulate(), and check step and exit logs match expectations
+    sim.simulate();
+    {  // Check step log
+        const auto &log = sim.getRunLog();
+        const auto &steps = log.getStepLog();
+        EXPECT_EQ(steps.size(), 6);  // init log, + 5 logs from 10 steps
+        unsigned int step_index = 0;
+        for (const auto &step : steps) {
+            ASSERT_EQ(step.getStepCount(), step_index);
+            // Agent step logging works
+            EXPECT_EQ(step.getAgents().size(), 1u);
+            auto agent_log = step.getAgent(AGENT_NAME1);
+
+            EXPECT_EQ(101u, agent_log.getCount());
+            EXPECT_EQ(100.0f + step_index, agent_log.getMax<float>("float_var"));
+            EXPECT_EQ(static_cast<int>(101 + step_index), agent_log.getMax<int>("int_var"));
+            EXPECT_EQ(102.0 + step_index, agent_log.getMax<unsigned int>("uint_var"));
+
+            EXPECT_EQ(0.0f + step_index, agent_log.getMin<float>("float_var"));
+            EXPECT_EQ(static_cast<int>(1 + step_index), agent_log.getMin<int>("int_var"));
+            EXPECT_EQ(2.0 + step_index, agent_log.getMin<unsigned int>("uint_var"));
+
+            EXPECT_EQ(50.0 + step_index, agent_log.getMean("float_var"));
+            EXPECT_EQ(51.0 + step_index, agent_log.getMean("int_var"));
+            EXPECT_EQ(52.0 + step_index, agent_log.getMean("uint_var"));
+
+            EXPECT_FLOAT_EQ(29.15476f, static_cast<float>(agent_log.getStandardDev("float_var")));  // Test value calculated with excel
+            EXPECT_FLOAT_EQ(29.15476f, static_cast<float>(agent_log.getStandardDev("int_var")));
+            EXPECT_FLOAT_EQ(29.15476f, static_cast<float>(agent_log.getStandardDev("uint_var")));
+
+            EXPECT_EQ((50.0 + step_index) * 101, agent_log.getSum<float>("float_var"));
+            EXPECT_EQ(static_cast<int>(51 + step_index) * 101, agent_log.getSum<int>("int_var"));
+            EXPECT_EQ((52 + step_index) * 101, agent_log.getSum<unsigned int>("uint_var"));
+
+            // Env step logging works
+            ASSERT_EQ(step.getEnvironmentProperty<float>("float_prop"), 1.0f + step_index);
+            ASSERT_EQ(step.getEnvironmentProperty<int>("int_prop"), static_cast<int>(1 + step_index));
+            ASSERT_EQ(step.getEnvironmentProperty<unsigned int>("uint_prop"), 1 + step_index);
+
+            const auto f_a = step.getEnvironmentProperty<float, 2>("float_prop_array");
+            ASSERT_EQ(f_a[0], 1.0f + step_index);
+            ASSERT_EQ(f_a[1], 2.0f + step_index);
+            const auto i_a = step.getEnvironmentProperty<int, 3>("int_prop_array");
+            ASSERT_EQ(i_a[0], static_cast<int>(2 + step_index));
+            ASSERT_EQ(i_a[1], static_cast<int>(3 + step_index));
+            ASSERT_EQ(i_a[2], static_cast<int>(4 + step_index));
+            const auto u_a = step.getEnvironmentProperty<unsigned int, 4>("uint_prop_array");
+            ASSERT_EQ(u_a[0], 3 + step_index);
+            ASSERT_EQ(u_a[1], 4 + step_index);
+            ASSERT_EQ(u_a[2], 5 + step_index);
+            ASSERT_EQ(u_a[3], 6 + step_index);
+
+            step_index+=2;
+        }
+    }
+    {  // Check exit log, should match final step log
+        const auto &log = sim.getRunLog();
+        const unsigned int step_index = 10;
+        const auto &exit = log.getExitLog();
+        ASSERT_EQ(exit.getStepCount(), step_index);
+        // Agent step logging works
+        EXPECT_EQ(exit.getAgents().size(), 1u);
+        auto agent_log = exit.getAgent(AGENT_NAME1);
+        EXPECT_EQ(101u, agent_log.getCount());
+
+        EXPECT_EQ(100.0f + step_index, agent_log.getMax<float>("float_var"));
+        EXPECT_EQ(static_cast<int>(101 + step_index), agent_log.getMax<int>("int_var"));
+        EXPECT_EQ(102.0 + step_index, agent_log.getMax<unsigned int>("uint_var"));
+
+        EXPECT_EQ(0.0f + step_index, agent_log.getMin<float>("float_var"));
+        EXPECT_EQ(static_cast<int>(1 + step_index), agent_log.getMin<int>("int_var"));
+        EXPECT_EQ(2.0 + step_index, agent_log.getMin<unsigned int>("uint_var"));
+
+        EXPECT_EQ(50.0 + step_index, agent_log.getMean("float_var"));
+        EXPECT_EQ(51.0 + step_index, agent_log.getMean("int_var"));
+        EXPECT_EQ(52.0 + step_index, agent_log.getMean("uint_var"));
+
+        EXPECT_FLOAT_EQ(29.15476f, static_cast<float>(agent_log.getStandardDev("float_var")));  // Test value calculated with excel
+        EXPECT_FLOAT_EQ(29.15476f, static_cast<float>(agent_log.getStandardDev("int_var")));
+        EXPECT_FLOAT_EQ(29.15476f, static_cast<float>(agent_log.getStandardDev("uint_var")));
+
+        EXPECT_EQ((50.0 + step_index) * 101, agent_log.getSum<float>("float_var"));
+        EXPECT_EQ(static_cast<int>(51 + step_index) * 101, agent_log.getSum<int>("int_var"));
+        EXPECT_EQ((52 + step_index) * 101, agent_log.getSum<unsigned int>("uint_var"));
+
+        // Env step logging works
+        ASSERT_EQ(exit.getEnvironmentProperty<float>("float_prop"), 1.0f + step_index);
+        ASSERT_EQ(exit.getEnvironmentProperty<int>("int_prop"), static_cast<int>(1 + step_index));
+        ASSERT_EQ(exit.getEnvironmentProperty<unsigned int>("uint_prop"), 1 + step_index);
+
+        const auto f_a = exit.getEnvironmentProperty<float, 2>("float_prop_array");
+        ASSERT_EQ(f_a[0], 1.0f + step_index);
+        ASSERT_EQ(f_a[1], 2.0f + step_index);
+        const auto i_a = exit.getEnvironmentProperty<int, 3>("int_prop_array");
+        ASSERT_EQ(i_a[0], static_cast<int>(2 + step_index));
+        ASSERT_EQ(i_a[1], static_cast<int>(3 + step_index));
+        ASSERT_EQ(i_a[2], static_cast<int>(4 + step_index));
+        const auto u_a = exit.getEnvironmentProperty<unsigned int, 4>("uint_prop_array");
+        ASSERT_EQ(u_a[0], 3 + step_index);
+        ASSERT_EQ(u_a[1], 4 + step_index);
+        ASSERT_EQ(u_a[2], 5 + step_index);
+        ASSERT_EQ(u_a[3], 6 + step_index);
+    }
+}
+FLAMEGPU_INIT_FUNCTION(logging_ensemble_init) {
+    const int instance_id  = FLAMEGPU->environment.getProperty<int>("instance_id");
+    for (int i = instance_id; i < instance_id + 101; ++i) {
+        auto instance = FLAMEGPU->newAgent(AGENT_NAME1);
+        instance.setVariable<float>("float_var", static_cast<float>(i));
+        instance.setVariable<int>("int_var", static_cast<int>(i+1));
+        instance.setVariable<unsigned int>("uint_var", static_cast<unsigned int>(i+2));
+    }
+}
+TEST(LoggingTest, CUDAEnsembleSimulate) {
+    /**
+     * Ensure the expected data is logged when CUDAEnsemble::simulate() is called
+     * Note: does not check files logged to disk
+     */
+    // Define model
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME1);
+    a.newVariable<float>("float_var");
+    a.newVariable<int>("int_var");
+    a.newVariable<unsigned int>("uint_var");
+    AgentFunctionDescription &f1 = a.newFunction(FUNCTION_NAME1, agent_fn1);
+    m.addInitFunction(logging_ensemble_init);
+    m.newLayer().addAgentFunction(f1);
+    m.addStepFunction(step_fn1);
+    m.Environment().newProperty<int>("instance_id", 0);  // This will act as the modifier for ensemble instances, only impacting the init fn
+    m.Environment().newProperty<float>("float_prop", 1.0f);
+    m.Environment().newProperty<int>("int_prop", 1);
+    m.Environment().newProperty<unsigned int>("uint_prop", 1);
+    m.Environment().newProperty<float, 2>("float_prop_array", {1.0f, 2.0f});
+    m.Environment().newProperty<int, 3>("int_prop_array", {2, 3, 4});
+    m.Environment().newProperty<unsigned int, 4>("uint_prop_array", {3, 4, 5, 6});
+
+    // Define logging configs
+    LoggingConfig lcfg(m);
+    AgentLoggingConfig alcfg = lcfg.agent(AGENT_NAME1);
+    alcfg.logCount();
+    logAllAgent<float>(alcfg, "float_var");
+    logAllAgent<int>(alcfg, "int_var");
+    logAllAgent<unsigned int>(alcfg, "uint_var");
+    lcfg.logEnvironment("float_prop");
+    lcfg.logEnvironment("instance_id");
+    lcfg.logEnvironment("int_prop");
+    lcfg.logEnvironment("uint_prop");
+    lcfg.logEnvironment("float_prop_array");
+    lcfg.logEnvironment("int_prop_array");
+    lcfg.logEnvironment("uint_prop_array");
+
+    StepLoggingConfig slcfg(lcfg);
+    slcfg.setFrequency(2);
+
+    // Set up the runplan
+    RunPlanVec plan(m, 10);
+    int i_id = 0;
+    for (auto &p : plan) {
+        p.setSteps(10);
+        p.setProperty<int>("instance_id", i_id++);
+        // p.setOutputSubdirectory(i_id%2 == 0 ? "a" : "b");
+    }
+
+    // Run model
+    CUDAEnsemble sim(m);
+    sim.Config().concurrent_runs = 5;
+    sim.Config().silent = true;
+    sim.Config().timing = false;
+    // sim.Config().out_directory = "ensemble_out";
+    // sim.Config().out_format = "json";
+    sim.setStepLog(slcfg);
+    sim.setExitLog(lcfg);
+    // Call simulate(), and check step and exit logs match expectations
+    sim.simulate(plan);
+    {  // Check step log
+        const auto &run_logs = sim.getLogs();
+        i_id = 0;
+        for (auto &log : run_logs) {
+            {  // Check step log
+                auto &steps = log.getStepLog();
+                EXPECT_EQ(steps.size(), 6);  // init log, + 5 logs from 10 steps
+                unsigned int step_index = 0;
+                for (const auto &step : steps) {
+                    // Log corresponds to the correct instance
+                    ASSERT_EQ(step.getEnvironmentProperty<int>("instance_id"), i_id);
+                    ASSERT_EQ(step.getStepCount(), step_index);
+                    // Agent step logging works
+                    EXPECT_EQ(step.getAgents().size(), 1u);
+                    auto agent_log = step.getAgent(AGENT_NAME1);
+
+                    EXPECT_EQ(101u, agent_log.getCount());
+                    EXPECT_EQ(100.0f + step_index + i_id, agent_log.getMax<float>("float_var"));
+                    EXPECT_EQ(static_cast<int>(101 + step_index + i_id), agent_log.getMax<int>("int_var"));
+                    EXPECT_EQ(102.0 + step_index + i_id, agent_log.getMax<unsigned int>("uint_var"));
+
+                    EXPECT_EQ(0.0f + step_index + i_id, agent_log.getMin<float>("float_var"));
+                    EXPECT_EQ(static_cast<int>(1 + step_index + i_id), agent_log.getMin<int>("int_var"));
+                    EXPECT_EQ(2.0 + step_index + i_id, agent_log.getMin<unsigned int>("uint_var"));
+
+                    EXPECT_EQ(50.0 + step_index + i_id, agent_log.getMean("float_var"));
+                    EXPECT_EQ(51.0 + step_index + i_id, agent_log.getMean("int_var"));
+                    EXPECT_EQ(52.0 + step_index + i_id, agent_log.getMean("uint_var"));
+
+                    EXPECT_FLOAT_EQ(29.15476f, static_cast<float>(agent_log.getStandardDev("float_var")));  // Test value calculated with excel
+                    EXPECT_FLOAT_EQ(29.15476f, static_cast<float>(agent_log.getStandardDev("int_var")));
+                    EXPECT_FLOAT_EQ(29.15476f, static_cast<float>(agent_log.getStandardDev("uint_var")));
+
+                    EXPECT_EQ((50.0 + step_index + i_id) * 101, agent_log.getSum<float>("float_var"));
+                    EXPECT_EQ(static_cast<int>(51 + step_index + i_id) * 101, agent_log.getSum<int>("int_var"));
+                    EXPECT_EQ((52 + step_index + i_id) * 101, agent_log.getSum<unsigned int>("uint_var"));
+
+                    // Env step logging works
+                    ASSERT_EQ(step.getEnvironmentProperty<float>("float_prop"), 1.0f + step_index);
+                    ASSERT_EQ(step.getEnvironmentProperty<int>("int_prop"), static_cast<int>(1 + step_index));
+                    ASSERT_EQ(step.getEnvironmentProperty<unsigned int>("uint_prop"), 1 + step_index);
+
+                    const auto f_a = step.getEnvironmentProperty<float, 2>("float_prop_array");
+                    ASSERT_EQ(f_a[0], 1.0f + step_index);
+                    ASSERT_EQ(f_a[1], 2.0f + step_index);
+                    const auto i_a = step.getEnvironmentProperty<int, 3>("int_prop_array");
+                    ASSERT_EQ(i_a[0], static_cast<int>(2 + step_index));
+                    ASSERT_EQ(i_a[1], static_cast<int>(3 + step_index));
+                    ASSERT_EQ(i_a[2], static_cast<int>(4 + step_index));
+                    const auto u_a = step.getEnvironmentProperty<unsigned int, 4>("uint_prop_array");
+                    ASSERT_EQ(u_a[0], 3 + step_index);
+                    ASSERT_EQ(u_a[1], 4 + step_index);
+                    ASSERT_EQ(u_a[2], 5 + step_index);
+                    ASSERT_EQ(u_a[3], 6 + step_index);
+
+                    step_index+=2;
+                }
+            }
+            {  // Check exit log, should match final step log
+                const unsigned int step_index = 10;
+                const auto &exit = log.getExitLog();
+                ASSERT_EQ(exit.getStepCount(), step_index);
+                // Agent step logging works
+                EXPECT_EQ(exit.getAgents().size(), 1u);
+                auto agent_log = exit.getAgent(AGENT_NAME1);
+                EXPECT_EQ(101u, agent_log.getCount());
+
+                EXPECT_EQ(100.0f + step_index + i_id, agent_log.getMax<float>("float_var"));
+                EXPECT_EQ(static_cast<int>(101 + step_index + i_id), agent_log.getMax<int>("int_var"));
+                EXPECT_EQ(102.0 + step_index + i_id, agent_log.getMax<unsigned int>("uint_var"));
+
+                EXPECT_EQ(0.0f + step_index + i_id, agent_log.getMin<float>("float_var"));
+                EXPECT_EQ(static_cast<int>(1 + step_index + i_id), agent_log.getMin<int>("int_var"));
+                EXPECT_EQ(2.0 + step_index + i_id, agent_log.getMin<unsigned int>("uint_var"));
+
+                EXPECT_EQ(50.0 + step_index + i_id, agent_log.getMean("float_var"));
+                EXPECT_EQ(51.0 + step_index + i_id, agent_log.getMean("int_var"));
+                EXPECT_EQ(52.0 + step_index + i_id, agent_log.getMean("uint_var"));
+
+                EXPECT_FLOAT_EQ(29.15476f, static_cast<float>(agent_log.getStandardDev("float_var")));  // Test value calculated with excel
+                EXPECT_FLOAT_EQ(29.15476f, static_cast<float>(agent_log.getStandardDev("int_var")));
+                EXPECT_FLOAT_EQ(29.15476f, static_cast<float>(agent_log.getStandardDev("uint_var")));
+
+                EXPECT_EQ((50.0 + step_index + i_id) * 101, agent_log.getSum<float>("float_var"));
+                EXPECT_EQ(static_cast<int>(51 + step_index + i_id) * 101, agent_log.getSum<int>("int_var"));
+                EXPECT_EQ((52 + step_index + i_id) * 101, agent_log.getSum<unsigned int>("uint_var"));
+
+                // Env step logging works
+                ASSERT_EQ(exit.getEnvironmentProperty<float>("float_prop"), 1.0f + step_index);
+                ASSERT_EQ(exit.getEnvironmentProperty<int>("int_prop"), static_cast<int>(1 + step_index));
+                ASSERT_EQ(exit.getEnvironmentProperty<unsigned int>("uint_prop"), 1 + step_index);
+
+                const auto f_a = exit.getEnvironmentProperty<float, 2>("float_prop_array");
+                ASSERT_EQ(f_a[0], 1.0f + step_index);
+                ASSERT_EQ(f_a[1], 2.0f + step_index);
+                const auto i_a = exit.getEnvironmentProperty<int, 3>("int_prop_array");
+                ASSERT_EQ(i_a[0], static_cast<int>(2 + step_index));
+                ASSERT_EQ(i_a[1], static_cast<int>(3 + step_index));
+                ASSERT_EQ(i_a[2], static_cast<int>(4 + step_index));
+                const auto u_a = exit.getEnvironmentProperty<unsigned int, 4>("uint_prop_array");
+                ASSERT_EQ(u_a[0], 3 + step_index);
+                ASSERT_EQ(u_a[1], 4 + step_index);
+                ASSERT_EQ(u_a[2], 5 + step_index);
+                ASSERT_EQ(u_a[3], 6 + step_index);
+            }
+            ++i_id;
+        }
+    }
+}
+
+}  // namespace test_logging

--- a/tests/test_cases/io/test_logging_exceptions.cu
+++ b/tests/test_cases/io/test_logging_exceptions.cu
@@ -1,0 +1,188 @@
+#include "gtest/gtest.h"
+
+#include "flamegpu/flame_api.h"
+
+// Need to test
+// LogFrame
+// AgentLogFrame
+
+namespace test_logging_exception {
+const char *MODEL_NAME = "Model";
+const char *AGENT_NAME1 = "Agent1";
+const char *AGENT_NAME2 = "Agent2";
+
+TEST(LoggingExceptionTest, LoggerSupportedFileType) {
+    // WriterFactory::createLogger() - UnsupportedFileType
+    ModelDescription m(MODEL_NAME);
+    m.newAgent(AGENT_NAME1);
+    CUDASimulation sim(m);
+    EXPECT_THROW(sim.exportLog("test.csv", true, true), UnsupportedFileType);
+    EXPECT_THROW(sim.exportLog("test.html", true, true), UnsupportedFileType);
+    EXPECT_NO_THROW(sim.exportLog("test.json", true, true));
+    // Cleanup
+    ASSERT_EQ(::remove("test.json"), 0);
+}
+
+TEST(LoggingExceptionTest, LoggingConfigExceptions) {
+    // Define model
+    ModelDescription m(MODEL_NAME);
+    m.newAgent(AGENT_NAME1);
+    m.Environment().newProperty<float>("float_prop", 1.0f);
+
+    LoggingConfig lcfg(m);
+    // Property doesn't exist
+    EXPECT_THROW(lcfg.logEnvironment("int_prop"), InvalidEnvProperty);
+    // Property does exist
+    EXPECT_NO_THROW(lcfg.logEnvironment("float_prop"));
+    // Property already marked for logging
+    EXPECT_THROW(lcfg.logEnvironment("float_prop"), InvalidEnvProperty);
+    // THIS DOES NOT WORK, cfg holds a copy of the ModelDescription, not a reference to it.
+    // Add new property after lcfg made
+    EXPECT_NO_THROW(m.Environment().newProperty<int>("int_prop", 1));
+    // Property does not exist
+    EXPECT_THROW(lcfg.logEnvironment("int_prop"), InvalidEnvProperty);
+
+    // Agent does not exist
+    EXPECT_THROW(lcfg.agent(AGENT_NAME2, "state2"), InvalidAgentName);
+    // Agent state does not exist
+    EXPECT_THROW(lcfg.agent(AGENT_NAME1, "state2"), InvalidAgentState);
+    // Agent/State does exist
+    EXPECT_NO_THROW(lcfg.agent(AGENT_NAME1, ModelData::DEFAULT_STATE));
+    // THIS DOES NOT WORK, cfg holds a copy of the ModelDescription, not a reference to it.
+    // Add new agent after lcfg
+    AgentDescription &a2 = m.newAgent(AGENT_NAME2);
+    a2.newState("state2");
+    // Agent/State does not exist
+    EXPECT_THROW(lcfg.agent(AGENT_NAME2, "state2"), InvalidAgentName);
+}
+TEST(LoggingExceptionTest, AgentLoggingConfigExceptions) {
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME1);
+    a.newVariable<float>("float_var");
+    a.newVariable<float, 2>("float_var_array");
+
+    LoggingConfig lcfg(m);
+    auto alcfg = lcfg.agent(AGENT_NAME1, ModelData::DEFAULT_STATE);
+
+    // Log functions all pass to the same common method which contains the checks
+    // Test 1, test them all (mean, standard dev, min, max, sum)
+    // Bad variable name
+    EXPECT_THROW(alcfg.logMean<int>("int_var"), InvalidAgentVar);
+    // Type does not match variable name
+    EXPECT_THROW(alcfg.logMean<int>("float_var"), InvalidVarType);
+    // Array variables are not supported
+    EXPECT_THROW(alcfg.logMean<float>("float_var_array"), InvalidVarType);
+    // Variable is correct
+    EXPECT_NO_THROW(alcfg.logMean<float>("float_var"));
+    // Variable has already been marked for logging
+    EXPECT_THROW(alcfg.logMean<float>("float_var"), InvalidArgument);
+    // THIS DOES NOT WORK, cfg holds a copy of the ModelDescription, not a reference to it.
+    // Add new agent var after log creation
+    a.newVariable<int>("int_var");
+    // Variable is not found
+    EXPECT_THROW(alcfg.logMean<int>("int_var"), InvalidAgentVar);
+}
+TEST(LoggingExceptionTest, LogFrameExceptions) {
+    // Define model
+    ModelDescription m(MODEL_NAME);
+    m.Environment().newProperty<float>("float_prop", 1.0f);
+    m.Environment().newProperty<int>("int_prop", 1);
+    m.Environment().newProperty<unsigned int>("uint_prop", 1);
+    m.Environment().newProperty<float, 2>("float_prop_array", {1.0f, 2.0f});
+    m.Environment().newProperty<int, 3>("int_prop_array", {2, 3, 4});
+    m.Environment().newProperty<unsigned int, 4>("uint_prop_array", {3, 4, 5, 6});
+
+    // Define logging configs
+    LoggingConfig lcfg(m);
+
+    StepLoggingConfig slcfg(lcfg);
+    slcfg.logEnvironment("float_prop");
+    slcfg.logEnvironment("uint_prop_array");
+
+    // Run model
+    CUDASimulation sim(m);
+    sim.SimulationConfig().steps = 1;
+    sim.setStepLog(slcfg);
+
+    sim.step();
+
+    // Fetch log
+    const auto &log = sim.getRunLog();
+    const auto &steps = log.getStepLog();
+    ASSERT_EQ(steps.size(), 1);
+    auto &slog = *steps.begin();
+    // Property wasn't logged
+    EXPECT_THROW(slog.getEnvironmentProperty<float>("float_prop2"), InvalidEnvProperty);
+    EXPECT_THROW(slog.getEnvironmentProperty<int>("int_prop"), InvalidEnvProperty);
+    auto f1 = &LogFrame::getEnvironmentProperty<float, 2>;  // Hack for 2 arg templates inside macro fn
+    auto f2 = &LogFrame::getEnvironmentProperty<int, 2>;  // Hack for 2 arg templates inside macro fn
+    EXPECT_THROW((slog.*f1)("float_prop2"), InvalidEnvProperty);
+    EXPECT_THROW((slog.*f2)("int_prop"), InvalidEnvProperty);
+    // Property wrong type
+    EXPECT_THROW(slog.getEnvironmentProperty<int>("float_prop"), InvalidEnvPropertyType);
+    auto f3 = &LogFrame::getEnvironmentProperty<int, 4>;  // Hack for 2 arg templates inside macro fn
+    EXPECT_THROW((slog.*f3)("uint_prop_array"), InvalidEnvPropertyType);
+    // Property wrong length
+    EXPECT_THROW(slog.getEnvironmentProperty<unsigned int>("uint_prop_array"), InvalidEnvPropertyType);
+    auto f4 = &LogFrame::getEnvironmentProperty<unsigned int, 2>;  // Hack for 2 arg templates inside macro fn
+    EXPECT_THROW((slog.*f4)("uint_prop_array"), InvalidEnvPropertyType);
+    // Correct property settings work
+    EXPECT_NO_THROW(slog.getEnvironmentProperty<float>("float_prop"));
+    auto f5 = &LogFrame::getEnvironmentProperty<unsigned int, 4>;  // Hack for 2 arg templates inside macro fn
+    EXPECT_NO_THROW((slog.*f5)("uint_prop_array"));
+}
+TEST(LoggingExceptionTest, AgentLogFrameExceptions) {
+    // Define model
+    ModelDescription m(MODEL_NAME);
+    AgentDescription &a = m.newAgent(AGENT_NAME1);
+    a.newVariable<float>("float_var");
+    a.newVariable<int>("int_var");
+    a.newVariable<unsigned int>("uint_var");
+    a.newVariable<float, 2>("float_var_array");
+
+    // Define logging configs
+    LoggingConfig lcfg(m);
+    StepLoggingConfig slcfg(lcfg);
+    AgentLoggingConfig alcfg = slcfg.agent(AGENT_NAME1);
+    alcfg.logMean<float>("float_var");
+    alcfg.logStandardDev<float>("float_var");
+    alcfg.logMin<int>("int_var");
+    alcfg.logMax<int>("int_var");
+    alcfg.logSum<unsigned int>("uint_var");
+
+    // Run model
+    CUDASimulation sim(m);
+    sim.SimulationConfig().steps = 1;
+    sim.setStepLog(slcfg);
+    sim.step();
+
+    // Fetch log
+    const auto &log = sim.getRunLog();
+    const auto &steps = log.getStepLog();
+    ASSERT_EQ(steps.size(), 1);
+    auto &slog = *steps.begin();
+    // Agent/state was not logged
+    EXPECT_THROW(slog.getAgent("wrong_agent"), InvalidAgentState);
+    EXPECT_THROW(slog.getAgent(AGENT_NAME1, "wrong_state"), InvalidAgentState);
+    auto alog = slog.getAgent(AGENT_NAME1);
+    // Count was not logged
+    EXPECT_THROW(alog.getCount(), InvalidOperation);
+    // Variable/Reduction wasn't logged
+    EXPECT_THROW(alog.getMean("int_var"), InvalidAgentVar);
+    EXPECT_THROW(alog.getStandardDev("double_var"), InvalidAgentVar);
+    EXPECT_THROW(alog.getMin<float>("float_var"), InvalidAgentVar);
+    EXPECT_THROW(alog.getMax<float>("float_var"), InvalidAgentVar);
+    EXPECT_THROW(alog.getSum<unsigned int>("uint_prop_array"), InvalidAgentVar);
+    // Property wrong type
+    EXPECT_THROW(alog.getMin<float>("int_var"), InvalidVarType);
+    EXPECT_THROW(alog.getMax<float>("int_var"), InvalidVarType);
+    EXPECT_THROW(alog.getSum<int>("uint_var"), InvalidVarType);
+    // Correct property settings work
+    EXPECT_NO_THROW(alog.getMean("float_var"));
+    EXPECT_NO_THROW(alog.getStandardDev("float_var"));
+    EXPECT_NO_THROW(alog.getMin<int>("int_var"));
+    EXPECT_NO_THROW(alog.getMax<int>("int_var"));
+    EXPECT_NO_THROW(alog.getSum<unsigned int>("uint_var"));
+}
+
+}  // namespace test_logging_exception

--- a/tests/test_cases/model/test_subagent.cu
+++ b/tests/test_cases/model/test_subagent.cu
@@ -21,17 +21,11 @@ TEST(SubAgentDescriptionTest, RequiresExitCondition) {
         ma.newVariable<unsigned int>("b_uint");
         ma.newState("b");
     }
-    // Missing exit condition
-    EXPECT_THROW(m.newSubModel("sub", sm), InvalidSubModel);
-    sm.addExitCondition(ExitAlways);
     m.newSubModel("sub", sm);
-    // Submodel name already exists
-    ModelDescription sm2("sub2");
-    {
-        // Define SubModel
-        sm2.newAgent("a");
-    }
-    EXPECT_THROW(m.newSubModel("sub", sm2), InvalidSubModelName);
+    // Missing exit condition
+    EXPECT_THROW(CUDASimulation s(m), InvalidSubModel);
+    sm.addExitCondition(ExitAlways);
+    EXPECT_NO_THROW(CUDASimulation s(m));
 }
 TEST(SubAgentDescriptionTest, InvalidAgentName) {
     ModelDescription sm("sub");


### PR DESCRIPTION
`CUDAEnsemble` (#245) and associated classes/tests implementation based on the [agreed interface example](https://gist.github.com/Robadob/076ce990e560ba9042009ece65a6af99). This will make use of the multi-thread/device support introduced by #418  (Ensemble 1 strategy (#415) was put on hold due to it being a much larger undertaking).

**ToDo**
- [x] Implement initial `RunPlan` classes
- [x] Implement initial `CUDAEnsemble` class
- [ ] Add methods for import/export `RunPlanVec` to disk, and integrate with `CUDAEnsemble` command line args
- [x] Decide how results will be extracted from `CUDAEnsemble` (can't really test properly without this)
- [x] Test with C
- [x] Test with Python
- [ ] Add the memory space estimating code based on max agent populations

**Changelog**
* Added `CUDAEnsemble` class and `Ensemble` example demonstrating it's usage.
* Added `RunPlan` and `RunPlanVec` classes for generating a collection of configurations to execute with the ensemble
* Added swig support for new classes
* Fixed a deadlock caused by recursive shared locks of a mutex (whilst a 2nd thread asked for unique lock in the middle). This was likely unique to windows, recursive locking is undefined behaviour.
* Added `HostRandom::setSeed()`, `HostRandom::getSeed()`
* Added max steps property to `SubModelData`, this allows a submodel to have 0 exit conditions.


**Known Issues/Concerns**
* Still undecided how default steps and random seed will get to `RunPlanVec`.
* Swig gives warnings related to instances of `RunPlanVec` using `std::vector<RunPlan>` e.g. `operator[]` (Stack overflow suggests this might not prevent the methods being wrapped)
* Undecided on whether the LoggingConfigs should be owned by the `CUDASimulation`/`CUDAEnsemble`, or defined separate like `RunPlanVec`.
* The calculation of standard deviation of agent variable log currently uses a `__constant__`, it has a mutex to ensure it's thread safe. But this is shared between all devices/threads. Could potentially cause slowdown in ensemble scenarios with alot of step logging standard deviation.
* Logging IO classes don't share much with the existing IO classes (I've hated those for a while).
* Ensemble exit logs have no attachment to run index, they just exist in a single file in order of completion.