### PR TITLE
Github Actions CMake 3.18.4 + CUDA 11.2

### DIFF
--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -45,6 +45,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    # Install a specific cmake version to avoid gtest issues.
+    - name: Install Specific Cmake version via Pip.
+      run: |
+        python3 -m pip install --user cmake==3.18.4
+        echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
+
     - name: Install CUDA
       env:
         cuda: ${{ matrix.cuda }}

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -16,8 +16,11 @@ jobs:
           # 20.04 supports CUDA 11.0+, once a github hosted runner is available.
           # 18.04 supports CUDA 10.1+ (gcc <=8), 11.0+ (gcc<=9), 11.1+ (gcc<=10)
           - os: ubuntu-18.04
-            cuda: "11.1"
+            cuda: "11.2"
             gcc: 10
+          # - os: ubuntu-18.04
+          #   cuda: "11.1"
+          #   gcc: 10
           # - os: ubuntu-18.04
           #   cuda: "11.0"
           #   gcc: 9

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -15,8 +15,11 @@ jobs:
         include:
           # Windows2019 & VS 2019 supports 10.1+
           - os: windows-2019
-            cuda: "11.1.1"
+            cuda: "11.2.0"
             visual_studio: "Visual Studio 16 2019"
+          # - os: windows-2019
+          #   cuda: "11.1.1"
+          #   visual_studio: "Visual Studio 16 2019"
           # - os: windows-2019
           #   cuda: "11.0.3"
           #   visual_studio: "Visual Studio 16 2019"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -44,6 +44,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    # Install a specific cmake version to avoid gtest issues.
+    # Do not use --user on windows, so no need to alter path.
+    - name: Install Specific Cmake version via Pip.
+      shell: bash
+      run: |
+        python -m pip install cmake==3.18.4
+
     - name: Install CUDA
       env: 
         cuda: ${{ matrix.cuda }}

--- a/scripts/actions/install_cuda_windows.ps1
+++ b/scripts/actions/install_cuda_windows.ps1
@@ -21,13 +21,14 @@ $CUDA_KNOWN_URLS = @{
     "11.0.3" = "http://developer.download.nvidia.com/compute/cuda/11.0.3/network_installers/cuda_11.0.3_win10_network.exe";
     "11.1.0" = "https://developer.download.nvidia.com/compute/cuda/11.1.0/network_installers/cuda_11.1.0_win10_network.exe";
     "11.1.1" = "https://developer.download.nvidia.com/compute/cuda/11.1.1/network_installers/cuda_11.1.1_win10_network.exe";
+    "11.2.0" = "https://developer.download.nvidia.com/compute/cuda/11.2.0/network_installers/cuda_11.2.0_win10_network.exe";
 }
 
 # @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead?
 $VISUAL_STUDIO_MIN_CUDA = @{
     "2019" = "10.1";
     "2017" = "10.0"; # Depends on which version of 2017! 9.0 to 10.0 depending on  version
-    "2015" = "8.0"; # might support older, unsure.
+    "2015" = "8.0"; # might support older, unsure. Depracated as of 11.1, unsupported in 11.2
 }
 
 # cuda_runtime.h is in nvcc <= 10.2, but cudart >= 11.0


### PR DESCRIPTION
Short-term fix for Google Test and CMake 3.19 disagreeing, by pinning Cmake version to be 3.18.4 on CI. 

Also adds CUDA 11.2 CI as the latest verison. 

This is related to #426, but we probably don't want to close the issue until we can un-do the workaround with a gtest update.