### PR TITLE
Update Gtest version to fix cmake 3.19 and therefore CI.

### DIFF
--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -49,10 +49,10 @@ jobs:
     - uses: actions/checkout@v2
 
     # Install a specific cmake version to avoid gtest issues.
-    - name: Install Specific Cmake version via Pip.
-      run: |
-        python3 -m pip install --user cmake==3.18.4
-        echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
+    # - name: Install Specific Cmake version via Pip.
+    #   run: |
+    #     python3 -m pip install --user cmake==3.18.4
+    #     echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
 
     - name: Install CUDA
       env:

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -49,10 +49,10 @@ jobs:
 
     # Install a specific cmake version to avoid gtest issues.
     # Do not use --user on windows, so no need to alter path.
-    - name: Install Specific Cmake version via Pip.
-      shell: bash
-      run: |
-        python -m pip install cmake==3.18.4
+    # - name: Install Specific Cmake version via Pip.
+    #   shell: bash
+    #   run: |
+    #     python -m pip install cmake==3.18.4
 
     - name: Install CUDA
       env: 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,10 +10,12 @@ get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/.. REALPATH)
 # Include common rules.
 include(${FLAMEGPU_ROOT}/cmake/common.cmake)
 
+# 389cb68b87193358358ae87cc56d257fd0d80189 is the first commit to support cmake 3.19+.
+# the next release after release-1.10.0 should include this patch.
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        release-1.10.0
+  GIT_TAG        389cb68b87193358358ae87cc56d257fd0d80189
 )
 
 FetchContent_GetProperties(googletest)


### PR DESCRIPTION
This appears to work locally with 3.19.2, but does output a warning re: CMAKE_MINIMUM_VERSION in rapidjson being deprecated
Closes #426

This may raise it's head again with future cmake releases. 