### PR TITLE
Python3.5 setuptools quickfix + enforce min swig version to the patch

### DIFF
--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -76,6 +76,12 @@ jobs:
         echo "CXX=/usr/bin/g++-${{ matrix.gcc }}" >> $GITHUB_ENV
         echo "CUDAHOSTCXX=/usr/bin/g++-${{ matrix.gcc }}" >> $GITHUB_ENV
 
+    - name: install setuptools with an appropriate version
+      run: | 
+        python3 -m pip install --upgrade wheel
+        python3 -m pip install --upgrade 'setuptools; python_version >= "3.6"' 'setuptools<51.3.0; python_version < "3.6" and python_version >= "3.0"'
+
+
     - name: Install Python Venv
       run: sudo apt-get install python3-venv
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Only documentation can be built without the required dependencies (however Doxyg
   + There may be intermittent compilation errors due to an NVCC+MSVC bug exposed by Thrust/CUB. 
   + Re-running the build appears to work in most cases, Otherwise consider upgrading to CUDA 11.0+ if possible.
 + CMake 3.16 has known issues on some platforms.
++ Python <= 3.5 may encounter issues with dependency installation such as setuptools. If so, please manually install the correct version.
+  + i.e. `python3 -m pip install --upgrade 'setuptools; python_version >= "3.6"' 'setuptools<51.3.0; python_version < "3.6" and python_version >= "3.0"'`
+
 
 ### Building FLAME GPU 2
 

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -21,7 +21,7 @@ message(STATUS "Python found at " ${Python3_EXECUTABLE})
 
 # Define the minimum version of cmake we support.
 # Swig 4.0+ is required for c++14 (and c++11 std::unordered_map). 
-set(SWIG_MINIMUM_SUPPORTED_VERSION 4)
+set(SWIG_MINIMUM_SUPPORTED_VERSION 4.0.2)
 # Define the version of SWIG to be downloaded (to simplify upgrading / output.)
 set(SWIG_DOWNLOAD_VERSION 4.0.2)
 

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -107,6 +107,9 @@ function(search_python_module MODULE_NAME)
 endfunction()
 
 # Look for required python modules to build the python module
+# @todo - Python3.5 is no longer supported by setuptools > 51.3, so need to change the install command to reflect this in cases where pip is too old (i.e. ubuntu 16.04 on CI). It would be better to not install dependencies into non-venvs too.
+# Arguably, we could set up a requirements.txt for building (and exeucting)?
+# https://github.com/pypa/setuptools/issues/2541
 search_python_module(setuptools)
 search_python_module(wheel)
 


### PR DESCRIPTION

+ Enforces swig >= 4.0.2 is available
    + 4.0.1 encounters segfaults with recent additions.
+ Short term fix for Python 3.5 and setuptools version issues.
    + Linux CI installs the correct version of setuptools for the version of python being used
    + Note added to the readme
    + Note added to the CMake file where the setuptools is installed if not available that it needs to be adjusted
        + It should also not install things generically into the users python environment (if a venv is avilable)