### PR TITLE
Tell CMake which python executable to use to fix windows CI

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -70,9 +70,10 @@ jobs:
         }
       shell: powershell
 
+    # Windows GHA fix: specify Python3_ROOT_DIR and _EXECUTABLE to make sure python.exe is found, not python3.exe which does not work with venv
     - name: Configure CMake
       id: configure
-      run: cmake . -B ${{ env.build_dir }} -G "${{ matrix.visual_studio }}" -A x64 -DBUILD_TESTS=${{ env.build_tests }} -DWARNINGS_AS_ERRORS=${{ env.werror }} -DCUDA_ARCH="${{ env.cuda_arch }}" -Werror=dev -DBUILD_SWIG_PYTHON=ON -DBUILD_SWIG_PYTHON_VIRTUALENV=ON 
+      run: cmake . -B ${{ env.build_dir }} -G "${{ matrix.visual_studio }}" -A x64 -DBUILD_TESTS=${{ env.build_tests }} -DWARNINGS_AS_ERRORS=${{ env.werror }} -DCUDA_ARCH="${{ env.cuda_arch }}" -Werror=dev -DBUILD_SWIG_PYTHON=ON -DBUILD_SWIG_PYTHON_VIRTUALENV=ON -DPython3_ROOT_DIR=$(dirname $(which python)) -DPython3_EXECUTABLE=$(which python)
       shell: bash
 
     - name: Build flamegpu2


### PR DESCRIPTION
This should resolve the windows GHA recent failures, by avoiding `python3.exe`.

This feels much cleaner than modifying CMake to try and detect the symlink (which doesn't work propperly) or using the not recommended `--symlinks` option for venv creation.