### PR TITLE
Reduce RTC memcpys

### DIFF
--- a/include/flamegpu/gpu/CUDAAgent.h
+++ b/include/flamegpu/gpu/CUDAAgent.h
@@ -13,6 +13,7 @@
 #include "flamegpu/gpu/CUDAAgentStateList.h"
 #include "flamegpu/model/AgentFunctionData.h"
 #include "flamegpu/model/SubAgentData.h"
+#include "flamegpu/runtime/cuRVE/curve_rtc.h"
 #include "flamegpu/sim/AgentInterface.h"
 
 class CUDAScatter;
@@ -30,7 +31,8 @@ class CUDAAgent : public AgentInterface {
     /**
      *  map of agent function name to RTC function instance
      */
-    typedef std::map<const std::string, std::unique_ptr<jitify::experimental::KernelInstantiation>> CUDARTCFuncMap;
+     typedef std::map<const std::string, std::unique_ptr<jitify::experimental::KernelInstantiation>> CUDARTCFuncMap;
+     typedef std::map<const std::string, std::unique_ptr<CurveRTCHost>> CUDARTCHeaderMap;
     /**
      * Element type of CUDARTCFuncMap
      */
@@ -203,6 +205,7 @@ class CUDAAgent : public AgentInterface {
      * @param function_name the name of the RTC agent function or the agent function name suffixed with condition (if it is a function condition)
      */
     const jitify::experimental::KernelInstantiation& getRTCInstantiation(const std::string &function_name) const;
+    CurveRTCHost &getRTCHeader(const std::string &function_name) const;
     /**
      * Returns the CUDARTCFuncMap
      */
@@ -268,6 +271,11 @@ class CUDAAgent : public AgentInterface {
      * map between function_name (or function_name_condition) and the jitify instance
      */
     CUDARTCFuncMap rtc_func_map;
+    /**
+     * map between function name (or function_name_condition) and the rtc header
+     * This allows access to the header data cache, for updating curve
+     */
+    CUDARTCHeaderMap rtc_header_map;
     /**
      * Used when allocated new buffers
      */

--- a/include/flamegpu/gpu/CUDASimulation.h
+++ b/include/flamegpu/gpu/CUDASimulation.h
@@ -211,13 +211,6 @@ class CUDASimulation : public Simulation {
      */
     void RTCSafeCudaMemcpyToSymbolAddress(void* ptr, const char* rtc_symbol_name, const void* src, size_t count, size_t offset = 0) const;
 
-    /**
-     * Updates the environment property cache for all RTC agent functions
-     * @param src Source memory address
-     * @param count Length of buffer (Probably EnvironmentManager::MAX_BUFFER_SIZE)
-     */
-    void RTCUpdateEnvironmentVariables(const void* src, size_t count) const;
-
    /**
      * Get the duration of the last time RTC was iniitliased 
      * With a resolution of around 0.5 microseconds (cudaEventElapsedtime)

--- a/include/flamegpu/runtime/utility/EnvironmentManager.cuh
+++ b/include/flamegpu/runtime/utility/EnvironmentManager.cuh
@@ -659,6 +659,11 @@ class EnvironmentManager {
      */
     void buildRTCOffsets(const unsigned int &instance_id, const unsigned int &master_instance_id, const DefragMap &mergeProperties);
     /**
+     * Returns the rtccache ptr for the named instance id
+     * @param instance_id Instance id of the cuda agent model that owns the properties
+     */
+    char* getRTCCache(const unsigned int& instance_id);
+    /**
      * Useful for adding individual variables to RTC cache later on
      */
     void addRTCOffset(const NamePair &name);

--- a/src/flamegpu/runtime/utility/EnvironmentManager.cu
+++ b/src/flamegpu/runtime/utility/EnvironmentManager.cu
@@ -492,6 +492,12 @@ void EnvironmentManager::buildRTCOffsets(const unsigned int &instance_id, const 
         rtc_caches.emplace(instance_id, cache);
     }
 }
+char * EnvironmentManager::getRTCCache(const unsigned int& instance_id) {
+    auto it = rtc_caches.find(instance_id);
+    if (it != rtc_caches.end())
+        return it->second->hc_buffer;
+    THROW UnknownInternalError("Instance with id '%u' not registered in EnvironmentManager for use with RTC in EnvironmentManager::getRTCCache", instance_id);
+}
 void EnvironmentManager::addRTCOffset(const NamePair &name) {
     // Do not lock mutex here, do it in the calling method
     auto mi_it = mapped_properties.find(name);
@@ -645,10 +651,7 @@ void EnvironmentManager::updateDevice(const unsigned int &instance_id) {
         }
     }
     if (rtc_update_required) {
-        // update RTC
-        const CUDASimulation& cuda_agent_model = getCUDASimulation(instance_id);
-        const auto &rtc_cache = rtc_caches.at(instance_id);
-        cuda_agent_model.RTCUpdateEnvironmentVariables(rtc_cache->hc_buffer, rtc_cache->nextFree);
+        // RTC is nolonger updated here, it's always updated before the CurveRTCHost is pushed to device.
         // Update instance's rtc update flag
         rtc_update_required = false;
     }


### PR DESCRIPTION
Updates RTC so a single memcpy is performed per agent function/agent function condition. Can't make it leaner than this, as all agent functions are not linked, so require separate memcpys (unless we want another layer of indirection, so that every rtc func holds a ptr to common storage, but with most models 1 func per layer seems harmless).

Rough changelist:
* `CurveRTCHost` now has a fat buffer, which it stores all env data and curve variable pointers in.
* Data is ordered in the cache; Env data, agent ptrs, msg out ptrs, msg in ptrs, new agent ptrs. (This relies on their order remaining consistent, e.g. no new agent vars added to header after it's initial creation.
* `CUDAAgent` now holds onto `CurveRTCHost` instances when it creates header.
* The various map runtime variables methods now instead call e.g. `CurveRTCHost::getAgentVariableCachePtr()`, to retrieve the pointer to store that variable's data within the RTC header's host cache.
* After the function/condition is full init, `CurveRTCHost::updateDevice()` is called to perform the memcpy.
* Also disabled RTC functions from calling the non-rtc Curve/Env updateDevice methods. (Though I haven't removed the now redundant RTC internals from env).
* Also added a branch to the map runtime variables methods, so RTC doesn't bother updating Curve.