### PR TITLE
Visualisation: Explicitly request texture buffers.

### DIFF
--- a/src/flamegpu/visualiser/AgentVis.cpp
+++ b/src/flamegpu/visualiser/AgentVis.cpp
@@ -75,7 +75,7 @@ void AgentVis::initBindings(std::unique_ptr<FLAMEGPU_Visualisation> &vis) {
         if (states.find(state) != states.end()) {
             vc = states.at(state).config;
         }
-        vis->addAgentState(agentData.name, state, vc);
+        vis->addAgentState(agentData.name, state, vc, !this->x_var.empty(), !this->y_var.empty(), !this->z_var.empty());
     }
 }
 void AgentVis::requestBufferResizes(std::unique_ptr<FLAMEGPU_Visualisation> &vis) {


### PR DESCRIPTION
This is required to improve texture buffer handling in the visualiser.
Helps to close: https://github.com/FLAMEGPU/FLAMEGPU2_visualiser/issues/35