### PR TITLE
Visualisation: ModelVis::setSimulationStep()

### DIFF
--- a/include/flamegpu/visualiser/ModelVis.h
+++ b/include/flamegpu/visualiser/ModelVis.h
@@ -120,6 +120,13 @@ class ModelVis {
 	 */
     void setStepVisible(const bool& showStep);
     /**
+     * Sets a limit on the rate of simulation
+     * A value of 0 leaves the rate unlimited
+     * This value defaults to 0
+     * @param stepsPerSecond The number of simulation steps to execute per second
+     */
+    void setSimulationSpeed(const unsigned int& stepsPerSecond);
+    /**
      * Adds a static model to the visualisation
      * @param modelPath Path of the model on disk
      * @param texturePath Optional path to a texture fore the model on disk

--- a/src/flamegpu/visualiser/AgentVis.cpp
+++ b/src/flamegpu/visualiser/AgentVis.cpp
@@ -89,8 +89,8 @@ void AgentVis::updateBuffers(std::unique_ptr<FLAMEGPU_Visualisation> &vis) {
         auto &state_map = agent.state_map.at(state);
         vis->updateAgentStateBuffer(agentData.name, state,
             state_map->getSize(),
-            reinterpret_cast<float *>(state_map->getVariablePointer(x_var)),
-            reinterpret_cast<float *>(state_map->getVariablePointer(y_var)),
+            reinterpret_cast<float *>(x_var == "" ? nullptr : state_map->getVariablePointer(x_var)),
+            reinterpret_cast<float *>(y_var == "" ? nullptr : state_map->getVariablePointer(y_var)),
             reinterpret_cast<float *>(z_var == "" ? nullptr : state_map->getVariablePointer(z_var)));
     }
     // TODO Tertiary buffers? (e.g. color, direction[xyz])

--- a/src/flamegpu/visualiser/ModelVis.cpp
+++ b/src/flamegpu/visualiser/ModelVis.cpp
@@ -50,8 +50,8 @@ void ModelVis::activate() {
         visualiser = std::make_unique<FLAMEGPU_Visualisation>(modelCfg);  // Window resolution
         for (auto &agent : agents) {
             // If x and y aren't set, throw exception
-            if (agent.second.x_var.empty() || agent.second.y_var.empty()) {
-                THROW VisualisationException("Agent '%s' has not had x and y variables set, "
+            if (agent.second.x_var.empty() && agent.second.y_var.empty() && agent.second.z_var.empty()) {
+                THROW VisualisationException("Agent '%s' has not had x, y or z variables set, agent requires location to render, "
                     "in ModelVis::activate()\n",
                     agent.second.agentData.name.c_str());
             }
@@ -146,6 +146,10 @@ void ModelVis::setViewClips(const float &nearClip, const float &farClip) {
 
 void ModelVis::setStepVisible(const bool& showStep) {
     modelCfg.stepVisible = showStep;
+}
+
+void ModelVis::setSimulationSpeed(const unsigned int& _stepsPerSecond) {
+    modelCfg.stepsPerSecond = _stepsPerSecond;
 }
 
 StaticModelVis ModelVis::addStaticModel(const std::string &modelPath, const std::string &texturePath) {


### PR DESCRIPTION
Also improved some checks, to allow a user to set only 1 of agent xyz, rather than xy being mandatory.

Closes #442 